### PR TITLE
Address linting and deprecated ioutil pkg.

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,8 @@
+version: "1"
+rules:
+  - base: main
+    upstream: opendatahub-io:main
+    mergeMethod: none  # don't automatically merge
+    mergeUnstable: false
+label: "do-not-merge/hold"
+conflictLabel: "needs-rebase"

--- a/controllers/config/templating.go
+++ b/controllers/config/templating.go
@@ -19,7 +19,6 @@ package config
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -48,7 +47,7 @@ func prefixedPath(p string) string {
 
 // A templating manifest source
 func templateSource(r io.Reader, context interface{}) mf.Source {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This addresses the failure [here](https://github.com/red-hat-data-services/data-science-pipelines-operator/pull/4#issuecomment-1424305639)

Donnu why it wasn't caught in upstream repo, but the error was accurate. We might need to make sure the yaml lint config is being picked up in the github action.

There's also a commit that addresses deprecated package for ioutil. Again not sure why this wasn't picked up upstream. My suspicion is both the yamllint and golanglint configs are not being included in the github action.