### PR TITLE
Use io from io pkg instead of deprecated ioutil.

### DIFF
--- a/controllers/config/templating.go
+++ b/controllers/config/templating.go
@@ -19,7 +19,6 @@ package config
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -48,7 +47,7 @@ func prefixedPath(p string) string {
 
 // A templating manifest source
 func templateSource(r io.Reader, context interface{}) mf.Source {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This fixes the staticheck pre-commit test failure that occurs locally, not sure why it's ignored via the github action, but will follow up a fix on that next.