### PR TITLE
Add unit testing.

### DIFF
--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -8,6 +8,7 @@ ARG STATICCHECK_VERSION=v0.3.3
 ARG INEFFASSIGN_VERSION=13ace05
 ARG ERRCHECK_VERSION=v1.6.3
 ARG GHCLI_VERSION=2.23.0
+ARG SETUP_ENVTEST=latest
 
 ENV GOPATH=/build \
   GO111MODULE=on \
@@ -19,6 +20,7 @@ RUN dnf -y install \
     golang \
     git
 
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@${SETUP_ENVTEST}
 RUN go install github.com/mgechev/revive@${REVIVE_VERSION}
 RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}
 RUN go install github.com/gordonklaus/ineffassign@${INEFFASSIGN_VERSION}
@@ -38,7 +40,8 @@ FROM ${CI_BASE}
 ENV SUMMARY="Toolchain for running pre-commit hooks." \
     DESCRIPTION="Toolchain for running pre-commit hooks." \
     PATH=/build/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  GO111MODULE=on
+  GO111MODULE=on \
+  ENVTEST_K8S_VERSION=1.25.0
 
 LABEL summary="$SUMMARY" \
     description="$DESCRIPTION" \
@@ -53,11 +56,13 @@ RUN dnf -y install \
     python3-pip \
     golang \
     git \
-    make \
-    && \
+    make && \
+    /build/bin/setup-envtest use ${ENVTEST_K8S_VERSION} --bin-dir /build/bin -p path && \
     dnf clean all
 
 WORKDIR /build/src
+
+ENV KUBEBUILDER_ASSETS=/build/bin/k8s/${ENVTEST_K8S_VERSION}-linux-amd64
 
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m venv /build

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -12,7 +12,7 @@ jobs:
   precommit:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/opendatahub/pre-commit-go-toolchain:v0.1
+      image: quay.io/opendatahub/pre-commit-go-toolchain:v0.2
       env:
         XDG_CACHE_HOME: /cache
         GOCACHE: /cache/go-build

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ cd ${REPO}/config/default
 kustomize build . | oc delete -f -
 oc delete project data-science-pipelines-operator
 ```
+
+
+# Run tests 
+
+Simply clone the directry and execute `make test`.
+
+To run it without `make` you can run the following: 
+```bash
+tmpFolder=$(mktemp -d)
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+export KUBEBUILDER_ASSETS=$(${GOPATH}/bin/setup-envtest use 1.25.0 --bin-dir ${tmpFolder}/bin -p path)
+go test ./... -coverprofile cover.out
+
+# once $KUBEBUILDER_ASSETS you can also run the full test suite successfully by running:
+pre-commit run --all-files
+```

--- a/config/crd/external/route.openshift.io_routes.yaml
+++ b/config/crd/external/route.openshift.io_routes.yaml
@@ -1,0 +1,254 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    listKind: RouteList
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "A route allows developers to expose services through an HTTP(S)
+          aware load balancing and proxy layer via a public DNS entry. The route may
+          further specify TLS options and a certificate, or specify a public CNAME
+          that the router should also accept for HTTP and HTTPS traffic. An administrator
+          typically configures their router to be visible outside the cluster firewall,
+          and may also add additional security, caching, or traffic controls on the
+          service content. Routers usually talk directly to the service endpoints.
+          \n Once a route is created, the `host` field may not be changed. Generally,
+          routers use the oldest route with a given host when resolving conflicts.
+          \n Routers are subject to additional customization and may support additional
+          controls via the annotations field. \n Because administrators may configure
+          multiple routers, the route status field is used to return information to
+          clients about the names and states of the route under each router. If a
+          client chooses a duplicate name, for instance, the route status conditions
+          are used to indicate the route cannot be chosen."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the route
+            properties:
+              alternateBackends:
+                description: alternateBackends allows up to 3 additional backends
+                  to be assigned to the route. Only the Service kind is allowed, and
+                  it will be defaulted to Service. Use the weight field in RouteTargetReference
+                  object to specify relative preference.
+                items:
+                  description: RouteTargetReference specifies the target that resolve
+                    into endpoints. Only the 'Service' kind is allowed. Use 'weight'
+                    field to emphasize one over others.
+                  properties:
+                    kind:
+                      description: The kind of target that the route is referring
+                        to. Currently, only 'Service' is allowed
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred
+                        to. e.g. name of the service
+                      type: string
+                    weight:
+                      description: weight as an integer between 0 and 256, default
+                        1, that specifies the target's relative weight against other
+                        target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      type: integer
+                  required:
+                  - kind
+                  - name
+                  - weight
+                  type: object
+                type: array
+              host:
+                description: host is an alias/DNS that points to the service. Optional.
+                  If not specified a route name will typically be automatically chosen.
+                  Must follow DNS952 subdomain conventions.
+                type: string
+              path:
+                description: Path that the router watches for, to route traffic for
+                  to the service. Optional
+                type: string
+              port:
+                description: If specified, the port to be used by the router. Most
+                  routers will use all endpoints exposed by the service by default
+                  - set this value to instruct routers which port to use.
+                properties:
+                  targetPort:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: The target port on pods selected by the service this
+                      route points to. If this is a string, it will be looked up as
+                      a named port in the target endpoints port list. Required
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetPort
+                type: object
+              tls:
+                description: The tls field provides the ability to configure certificates
+                  and termination for the route.
+                properties:
+                  caCertificate:
+                    description: caCertificate provides the cert authority certificate
+                      contents
+                    type: string
+                  certificate:
+                    description: certificate provides certificate contents
+                    type: string
+                  destinationCACertificate:
+                    description: destinationCACertificate provides the contents of
+                      the ca certificate of the final destination.  When using reencrypt
+                      termination this file should be provided in order to have routers
+                      use it for health checks on the secure connection. If this field
+                      is not specified, the router may provide its own destination
+                      CA and perform hostname validation using the short service name
+                      (service.namespace.svc), which allows infrastructure generated
+                      certificates to automatically verify.
+                    type: string
+                  insecureEdgeTerminationPolicy:
+                    description: "insecureEdgeTerminationPolicy indicates the desired
+                      behavior for insecure connections to a route. While each router
+                      may make its own decisions on which ports to expose, this is
+                      normally port 80. \n * Allow - traffic is sent to the server
+                      on the insecure port (default) * Disable - no traffic is allowed
+                      on the insecure port. * Redirect - clients are redirected to
+                      the secure port."
+                    type: string
+                  key:
+                    description: key provides key file contents
+                    type: string
+                  termination:
+                    description: termination indicates termination type.
+                    type: string
+                required:
+                - termination
+                type: object
+              to:
+                description: to is an object the route should use as the primary backend.
+                  Only the Service kind is allowed, and it will be defaulted to Service.
+                  If the weight field (0-256 default 1) is set to zero, no traffic
+                  will be sent to this backend.
+                properties:
+                  kind:
+                    description: The kind of target that the route is referring to.
+                      Currently, only 'Service' is allowed
+                    type: string
+                  name:
+                    description: name of the service/target that is being referred
+                      to. e.g. name of the service
+                    type: string
+                  weight:
+                    description: weight as an integer between 0 and 256, default 1,
+                      that specifies the target's relative weight against other target
+                      reference objects. 0 suppresses requests to this backend.
+                    format: int32
+                    type: integer
+                required:
+                - kind
+                - name
+                - weight
+                type: object
+              wildcardPolicy:
+                description: Wildcard policy if any for the route. Currently only
+                  'Subdomain' or 'None' is allowed.
+                type: string
+            required:
+            - to
+            type: object
+          status:
+            description: status is the current state of the route
+            properties:
+              ingress:
+                description: ingress describes the places where the route may be exposed.
+                  The list of ingress points may contain duplicate Host or RouterName
+                  values. Routes are considered live once they are `Ready`
+                items:
+                  description: RouteIngress holds information about the places where
+                    a route is exposed.
+                  properties:
+                    conditions:
+                      description: Conditions is the state of the route, may be empty.
+                      items:
+                        description: RouteIngressCondition contains details for the
+                          current condition of this route on a particular router.
+                        properties:
+                          lastTransitionTime:
+                            description: RFC 3339 date and time when this condition
+                              last transitioned
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: (brief) reason for the condition's last transition,
+                              and is usually a machine and human readable constant
+                            type: string
+                          status:
+                            description: Status is the status of the condition. Can
+                              be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition. Currently
+                              only Ready.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    host:
+                      description: Host is the host string under which the route is
+                        exposed; this value is required
+                      type: string
+                    routerCanonicalHostname:
+                      description: CanonicalHostname is the external host name for
+                        the router that can be used as a CNAME for the host requested
+                        for this route. This value is optional and may not be set
+                        in all cases.
+                      type: string
+                    routerName:
+                      description: Name is a name chosen by the router to identify
+                        itself; this value is required
+                      type: string
+                    wildcardPolicy:
+                      description: Wildcard policy is the wildcard policy that was
+                        allowed where this route is exposed.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - ingress
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/internal/apiserver/service.yaml.tmpl
+++ b/config/internal/apiserver/service.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{.ApiServerServiceName}}
+  name: {{.APIServerServiceName}}
   namespace: {{.Namespace}}
   labels:
     app: ds-pipeline-{{.Name}}

--- a/config/internal/mlpipelines-ui/route.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/route.yaml.tmpl
@@ -12,6 +12,7 @@ spec:
   to:
     kind: Service
     name: ds-pipeline-ui-{{.Name}}
+    weight: 100
   port:
     targetPort: 8443
   tls:

--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -25,19 +25,19 @@ import (
 )
 
 var apiServerTemplates = []string{
-	"config/internal/apiserver/artifact_script.yaml.tmpl",
-	"config/internal/apiserver/role_ds-pipeline.yaml.tmpl",
-	"config/internal/apiserver/role_pipeline-runner.yaml.tmpl",
-	"config/internal/apiserver/rolebinding_ds-pipeline.yaml.tmpl",
-	"config/internal/apiserver/rolebinding_pipeline-runner.yaml.tmpl",
-	"config/internal/apiserver/sa_ds-pipeline.yaml.tmpl",
-	"config/internal/apiserver/sa_pipeline-runner.yaml.tmpl",
-	"config/internal/apiserver/service.yaml.tmpl",
-	"config/internal/apiserver/deployment.yaml.tmpl",
+	"apiserver/artifact_script.yaml.tmpl",
+	"apiserver/role_ds-pipeline.yaml.tmpl",
+	"apiserver/role_pipeline-runner.yaml.tmpl",
+	"apiserver/rolebinding_ds-pipeline.yaml.tmpl",
+	"apiserver/rolebinding_pipeline-runner.yaml.tmpl",
+	"apiserver/sa_ds-pipeline.yaml.tmpl",
+	"apiserver/sa_pipeline-runner.yaml.tmpl",
+	"apiserver/service.yaml.tmpl",
+	"apiserver/deployment.yaml.tmpl",
 }
 
 // This is hardcoded in kfp-tekton, apiserver will always use this hardcoded secret for tekton resources
-const minioArtifactSecret = "config/internal/apiserver/mlpipeline-minio-artifact.yaml.tmpl"
+const minioArtifactSecret = "apiserver/mlpipeline-minio-artifact.yaml.tmpl"
 const minioArtifactSecretName = "mlpipeline-minio-artifact"
 
 func (r *DSPipelineReconciler) ReconcileAPIServer(ctx context.Context, dsp *dspipelinesiov1alpha1.DSPipeline, req ctrl.Request, params *DSPipelineParams) error {

--- a/controllers/database.go
+++ b/controllers/database.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	DBDeploymentTemplate     = "config/internal/mariadb/deployment.yaml.tmpl"
-	DBPvcTemplate            = "config/internal/mariadb/pvc.yaml.tmpl"
-	DBServiceAccountTemplate = "config/internal/mariadb/sa.yaml.tmpl"
-	DBSecretTemplate         = "config/internal/mariadb/secret.yaml.tmpl"
-	DBServiceTemplate        = "config/internal/mariadb/service.yaml.tmpl"
+	DBDeploymentTemplate     = "mariadb/deployment.yaml.tmpl"
+	DBPvcTemplate            = "mariadb/pvc.yaml.tmpl"
+	DBServiceAccountTemplate = "mariadb/sa.yaml.tmpl"
+	DBSecretTemplate         = "mariadb/secret.yaml.tmpl"
+	DBServiceTemplate        = "mariadb/service.yaml.tmpl"
 )
 
 func (r *DSPipelineReconciler) ReconcileDatabase(ctx context.Context, dsp *dspipelinesiov1alpha1.DSPipeline,

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -143,6 +143,7 @@ func (r *DSPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// FixMe: Hack for stubbing gvk during tests as these are not populated by test suite
+	// https://github.com/opendatahub-io/data-science-pipelines-operator/pull/7#discussion_r1102887037
 	// In production we expect these to be populated
 	if dspipeline.Kind == "" {
 		dspipeline = dspipeline.DeepCopy()

--- a/controllers/dspipeline_controller_test.go
+++ b/controllers/dspipeline_controller_test.go
@@ -1,0 +1,99 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	mfc "github.com/manifestival/controller-runtime-client"
+	mf "github.com/manifestival/manifestival"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	dspipelinesiov1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	dspcrcase1                  = "./testdata/deploy/case_1.yaml"
+	apiserverDeployment         = "./testdata/results/case_1/apiserver/deployment.yaml"
+	mariadbDeployment           = "./testdata/results/case_1/mariadb/deployment.yaml"
+	minioDeployment             = "./testdata/results/case_1/minio/deployment.yaml"
+	mlpipelinesUIDeployment     = "./testdata/results/case_1/mlpipelines-ui/deployment.yaml"
+	persistenceAgentDeployment  = "./testdata/results/case_1/persistence-agent/deployment.yaml"
+	scheduledWorkflowDeployment = "./testdata/results/case_1/scheduled-workflow/deployment.yaml"
+	viewerCrdDeployment         = "./testdata/results/case_1/viewer-crd/deployment.yaml"
+)
+
+func deployDSP(ctx context.Context, path string, opts mf.Option) {
+	dsp := &dspipelinesiov1alpha1.DSPipeline{}
+	err := convertToStructuredResource(path, dsp, opts)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(ctx, dsp)).Should(Succeed())
+}
+
+func compareDeployments(path string, opts mf.Option) {
+	expectedDeployment := &appsv1.Deployment{}
+	Expect(convertToStructuredResource(path, expectedDeployment, opts)).NotTo(HaveOccurred())
+
+	actualDeployment := &appsv1.Deployment{}
+	Eventually(func() error {
+		namespacedNamed := types.NamespacedName{Name: expectedDeployment.Name, Namespace: WorkingNamespace}
+		return k8sClient.Get(ctx, namespacedNamed, actualDeployment)
+	}, timeout, interval).ShouldNot(HaveOccurred())
+
+	Expect(testutil.DeploymentsAreEqual(*expectedDeployment, *actualDeployment)).Should(BeTrue())
+
+}
+
+var _ = Describe("The DS Pipeline Controller", func() {
+	client := mfc.NewClient(k8sClient)
+	opts := mf.UseClient(client)
+	ctx := context.Background()
+	Context("In a namespace, when a DSP CR is deployed", func() {
+
+		It("Should create an api server deployment", func() {
+			deployDSP(ctx, dspcrcase1, opts)
+			compareDeployments(apiserverDeployment, opts)
+		})
+
+		It("Should create a MLpipeline UI", func() {
+			By("Creating MLPipeline UI resources")
+			compareDeployments(mlpipelinesUIDeployment, opts)
+		})
+
+		It("Should create a MariaDB deployment", func() {
+			compareDeployments(mariadbDeployment, opts)
+		})
+
+		It("Should create a Minio storage deployment", func() {
+			compareDeployments(minioDeployment, opts)
+		})
+
+		It("Should create a Persistence Agent deployment", func() {
+			compareDeployments(persistenceAgentDeployment, opts)
+		})
+
+		It("Should create a Scheduled Workflow deployment", func() {
+			compareDeployments(scheduledWorkflowDeployment, opts)
+		})
+
+		It("Should create a Viewer CRD deployment", func() {
+			compareDeployments(viewerCrdDeployment, opts)
+		})
+	})
+
+})

--- a/controllers/mlpipeline_ui.go
+++ b/controllers/mlpipeline_ui.go
@@ -21,21 +21,21 @@ import (
 )
 
 var mlPipelineUITemplates = []string{
-	"config/internal/mlpipelines-ui/configmap.yaml.tmpl",
-	"config/internal/mlpipelines-ui/deployment.yaml.tmpl",
-	"config/internal/mlpipelines-ui/role.yaml.tmpl",
-	"config/internal/mlpipelines-ui/rolebinding.yaml.tmpl",
-	"config/internal/mlpipelines-ui/route.yaml.tmpl",
-	"config/internal/mlpipelines-ui/sa-ds-pipeline-ui.yaml.tmpl",
-	"config/internal/mlpipelines-ui/sa_ds-pipelines-viewer.yaml.tmpl",
-	"config/internal/mlpipelines-ui/service.yaml.tmpl",
+	"mlpipelines-ui/configmap.yaml.tmpl",
+	"mlpipelines-ui/deployment.yaml.tmpl",
+	"mlpipelines-ui/role.yaml.tmpl",
+	"mlpipelines-ui/rolebinding.yaml.tmpl",
+	"mlpipelines-ui/route.yaml.tmpl",
+	"mlpipelines-ui/sa-ds-pipeline-ui.yaml.tmpl",
+	"mlpipelines-ui/sa_ds-pipelines-viewer.yaml.tmpl",
+	"mlpipelines-ui/service.yaml.tmpl",
 }
 
 var mlPipelineUIClusterScopedTemplates = []string{
-	"config/internal/mlpipelines-ui/clusterrolebinding.yaml.tmpl",
+	"mlpipelines-ui/clusterrolebinding.yaml.tmpl",
 }
 
-const uIClusterRolebindingTemplate = "config/internal/mlpipelines-ui/clusterrolebinding.yaml.tmpl"
+const uIClusterRolebindingTemplate = "mlpipelines-ui/clusterrolebinding.yaml.tmpl"
 
 func (r *DSPipelineReconciler) ReconcileUI(dsp *dspipelinesiov1alpha1.DSPipeline,
 	params *DSPipelineParams) error {

--- a/controllers/persistence_agent.go
+++ b/controllers/persistence_agent.go
@@ -21,10 +21,10 @@ import (
 )
 
 var persistenceAgentTemplates = []string{
-	"config/internal/persistence-agent/deployment.yaml.tmpl",
-	"config/internal/persistence-agent/sa.yaml.tmpl",
-	"config/internal/persistence-agent/role.yaml.tmpl",
-	"config/internal/persistence-agent/rolebinding.yaml.tmpl",
+	"persistence-agent/deployment.yaml.tmpl",
+	"persistence-agent/sa.yaml.tmpl",
+	"persistence-agent/role.yaml.tmpl",
+	"persistence-agent/rolebinding.yaml.tmpl",
 }
 
 func (r *DSPipelineReconciler) ReconcilePersistenceAgent(dsp *dspipelinesiov1alpha1.DSPipeline,

--- a/controllers/scheduled_workflow.go
+++ b/controllers/scheduled_workflow.go
@@ -21,12 +21,12 @@ import (
 )
 
 var scheduledWorkflowTemplates = []string{
-	"config/internal/scheduled-workflow/deployment.yaml.tmpl",
-	"config/internal/scheduled-workflow/role.yaml.tmpl",
-	"config/internal/scheduled-workflow/rolebinding.yaml.tmpl",
-	"config/internal/scheduled-workflow/sa.yaml.tmpl",
-	"config/internal/scheduled-workflow/role.yaml.tmpl",
-	"config/internal/scheduled-workflow/rolebinding.yaml.tmpl",
+	"scheduled-workflow/deployment.yaml.tmpl",
+	"scheduled-workflow/role.yaml.tmpl",
+	"scheduled-workflow/rolebinding.yaml.tmpl",
+	"scheduled-workflow/sa.yaml.tmpl",
+	"scheduled-workflow/role.yaml.tmpl",
+	"scheduled-workflow/rolebinding.yaml.tmpl",
 }
 
 func (r *DSPipelineReconciler) ReconcileScheduledWorkflow(dsp *dspipelinesiov1alpha1.DSPipeline,

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	storageDeploymentTemplate     = "config/internal/minio/deployment.yaml.tmpl"
-	storagePvcTemplate            = "config/internal/minio/pvc.yaml.tmpl"
-	storageServiceAccountTemplate = "config/internal/minio/service.yaml.tmpl"
-	storageSecretTemplate         = "config/internal/minio/secret.yaml.tmpl"
+	storageDeploymentTemplate     = "minio/deployment.yaml.tmpl"
+	storagePvcTemplate            = "minio/pvc.yaml.tmpl"
+	storageServiceAccountTemplate = "minio/service.yaml.tmpl"
+	storageSecretTemplate         = "minio/secret.yaml.tmpl"
 )
 
 func (r *DSPipelineReconciler) ReconcileStorage(ctx context.Context, dsp *dspipelinesiov1alpha1.DSPipeline,

--- a/controllers/testdata/deploy/case_1.yaml
+++ b/controllers/testdata/deploy/case_1.yaml
@@ -1,0 +1,37 @@
+apiVersion: dspipelines.opendatahub.io/v1alpha1
+kind: DSPipeline
+metadata:
+  name: testdsp
+spec:
+  apiServer:
+    artifactScriptConfigMap:
+      name: ds-pipeline-artifact-script-testdsp
+      key: "artifact_script"
+    apiServerImage: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
+    artifactImage: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
+  persistentAgent:
+    image: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
+    pipelineAPIServerName: apiserver
+  scheduledWorkflow:
+    image: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
+  viewerCRD:
+    image: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
+  mlpipelineUI:
+    image: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
+    configMap: ds-pipeline-ui-configmap
+  database:
+    mariaDB:
+      image: registry.redhat.io/rhel8/mariadb-103:1-188
+      username: mlpipeline
+      pipelineDBName: randomDBName
+      passwordSecret:
+        name: ds-pipelines-db-testdsp
+        key: password
+  storage:
+    minio:
+      image: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+      bucket: mlpipeline
+      s3CredentialsSecret:
+        secretName: somesecret-testdsp
+        accessKey: accesskey
+        secretKey: secretkey

--- a/controllers/testdata/results/case_1/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_1/apiserver/deployment.yaml
@@ -1,94 +1,96 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ds-pipeline-{{.Name}}
-  namespace: {{.Namespace}}
+  name: ds-pipeline-testdsp
+  namespace: default
   labels:
-    app: ds-pipeline-{{.Name}}
+    app: ds-pipeline-testdsp
     component: data-science-pipelines
 spec:
   selector:
     matchLabels:
-      app: ds-pipeline-{{.Name}}
+      app: ds-pipeline-testdsp
       component: data-science-pipelines
   template:
     metadata:
       labels:
-        app: ds-pipeline-{{.Name}}
+        app: ds-pipeline-testdsp
         component: data-science-pipelines
     spec:
       containers:
         - env:
             - name: POD_NAMESPACE
-              value: "{{.Namespace}}"
+              value: "default"
             - name: DBCONFIG_USER
-              value: "{{.DBUser}}"
+              value: "mlpipeline"
             - name: DBCONFIG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: "{{.DBPasswordSecretKey}}"
-                  name: "{{.DBPasswordSecret}}"
+                  key: "password"
+                  name: "ds-pipelines-db-testdsp"
             - name: DBCONFIG_DBNAME
-              value: "{{.DBName}}"
+              value: "randomDBName"
             - name: DBCONFIG_HOST
-              value: "{{.DBHost}}"
+              value: "mariadb-testdsp.default.svc.cluster.local"
             - name: DBCONFIG_PORT
-              value: "{{.DBPort}}"
+              value: "3306"
             - name: PIPELINE_RUNTIME
-              value: "{{.PipelineRuntime}}"
+              value: "tekton"
             - name: ARTIFACT_BUCKET
-              value: "{{.ArtifactBucket}}"
+              value: "mlpipeline"
             - name: ARTIFACT_ENDPOINT
-              value: "{{.ArtifactEndpoint}}"
+              value: "minio-testdsp:9000"
             - name: ARTIFACT_SCRIPT
               valueFrom:
                 configMapKeyRef:
-                  key: "{{ .ArtifactScriptConfigMapKey }}"
-                  name: "{{ .ArtifactScriptConfigMapName }}"
+                  key: "artifact_script"
+                  name: "ds-pipeline-artifact-script-testdsp"
             - name: ARTIFACT_IMAGE
-              value: "{{.ArtifactImage}}"
+              value: "quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8"
             - name: INJECT_DEFAULT_SCRIPT
-              value: "{{.InjectDefaultScript}}"
+              value: "true"
             - name: APPLY_TEKTON_CUSTOM_RESOURCE
-              value: "{{.ApplyTektonCustomResource}}"
+              value: "true"
             - name: TERMINATE_STATUS
-              value: "{{.TerminateStatus}}"
+              value: "Cancelled"
             - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
-              value: "{{.AutoUpdatePipelineDefaultVersion}}"
+              value: "true"
             - name: DBCONFIG_CONMAXLIFETIMESEC
-              value: "{{.DBConfigCONMAXLifetimeSec}}"
+              value: "120"
             - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
               value: "ds-pipeline-visualizationserver"
             - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
               value: "8888"
             - name: OBJECTSTORECONFIG_BUCKETNAME
-              value: "{{.ObjectStoreConfigBucketName}}"
+              value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  key: "{{.AccessKeySecretKey}}"
-                  name: "{{.S3CredentialsSecretName}}"
+                  key: "accesskey"
+                  name: "somesecret-testdsp"
             - name: OBJECTSTORECONFIG_SECRETACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  key: "{{.SecretKey}}"
-                  name: "{{.S3CredentialsSecretName}}"
+                  key: "secretkey"
+                  name: "somesecret-testdsp"
             - name: OBJECTSTORECONFIG_SECURE
-              value: "{{.ObjectStoreConfigSecure}}"
+              value: "false"
             - name: MINIO_SERVICE_SERVICE_HOST
-              value: "{{.MinioServiceServiceHost}}"
+              value: "minio-testdsp.default.svc.cluster.local"
             - name: MINIO_SERVICE_SERVICE_PORT
-              value: "{{.MinioServiceServicePort}}"
+              value: "9000"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
-              value: "pipeline-runner-{{.Name}}"
-          image: {{.APIServerImage}}
+              value: "pipeline-runner-testdsp"
+          image: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
           imagePullPolicy: Always
           name: ds-pipeline-api-server
           ports:
             - containerPort: 8888
               name: http
+              protocol: TCP
             - containerPort: 8887
               name: grpc
+              protocol: TCP
           livenessProbe:
             exec:
               command:
@@ -103,7 +105,7 @@ spec:
             timeoutSeconds: 2
           readinessProbe:
             exec:
-              command: # wget -q -S -O - http://localhost:8888/apis/v1beta1/healthz
+              command:
                 - wget
                 - -q
                 - -S
@@ -120,4 +122,4 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
-      serviceAccountName: ds-pipeline-{{.Name}}
+      serviceAccountName: ds-pipeline-testdsp

--- a/controllers/testdata/results/case_1/mariadb/deployment.yaml
+++ b/controllers/testdata/results/case_1/mariadb/deployment.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb-testdsp
+  namespace: default
+  labels:
+    app: mariadb-testdsp
+    component: data-science-pipelines
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # Need this since backing PVC is ReadWriteOnce, which creates resource lock condition in default Rolling strategy
+  selector:
+    matchLabels:
+      app: mariadb-testdsp
+      component: data-science-pipelines
+  template:
+    metadata:
+      labels:
+        app: mariadb-testdsp
+        component: data-science-pipelines
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-i"
+                - "-c"
+                - >-
+                  MYSQL_PWD=$MYSQL_PASSWORD mysql -h 127.0.0.1 -u $MYSQL_USER -D
+                  $MYSQL_DATABASE -e 'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3306
+            timeoutSeconds: 1
+          env:
+            - name: MYSQL_USER
+              value: "mlpipeline"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipelines-db-testdsp"
+            - name: MYSQL_DATABASE
+              value: "randomDBName"
+            - name: MYSQL_ALLOW_EMPTY_PASSWORD
+              value: "true"
+          resources:
+            requests:
+              cpu: 300m
+              memory: 800Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: mariadb-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-testdsp

--- a/controllers/testdata/results/case_1/minio/deployment.yaml
+++ b/controllers/testdata/results/case_1/minio/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-testdsp
+  namespace: default
+  labels:
+    app: minio-testdsp
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: minio-testdsp
+      component: data-science-pipelines
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-testdsp
+        component: data-science-pipelines
+    spec:
+      containers:
+        - args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "somesecret-testdsp"
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "somesecret-testdsp"
+          image: "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance"
+          name: minio
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 20m
+              memory: 100Mi
+            limits:
+              cpu: 250m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /data
+              name: data
+              subPath: minio
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-testdsp

--- a/controllers/testdata/results/case_1/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_1/mlpipelines-ui/deployment.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-ui-testdsp
+  namespace: default
+  labels:
+    app: ds-pipeline-ui-testdsp
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-ui-testdsp
+      component: data-science-pipelines
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ds-pipeline-ui-testdsp
+        component: data-science-pipelines
+    spec:
+      containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-ui-testdsp
+            - --upstream=http://localhost:3000
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "ds-pipeline-ui-testdsp"}}'
+            - '--openshift-sar={"resource": "route", "resourceName": "ds-pipeline-ui-testdsp", "verb": "get"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+        - env:
+            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+              value: /etc/config/viewer-pod-template.json
+            - name: MINIO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "somesecret-testdsp"
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "somesecret-testdsp"
+            - name: ALLOW_CUSTOM_VISUALIZATIONS
+              value: "true"
+            - name: ARGO_ARCHIVE_LOGS
+              value: "true"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp
+            - name: ML_PIPELINE_SERVICE_PORT
+              value: '8888'
+          image: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          name: ds-pipeline-ui
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 70Mi
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-volume
+              readOnly: true
+      serviceAccountName: ds-pipeline-ui-testdsp
+      volumes:
+        - configMap:
+            name: ds-pipeline-ui-configmap-testdsp
+            defaultMode: 420
+          name: config-volume
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-ui-proxy-tls-testdsp
+            defaultMode: 420

--- a/controllers/testdata/results/case_1/persistence-agent/deployment.yaml
+++ b/controllers/testdata/results/case_1/persistence-agent/deployment.yaml
@@ -1,29 +1,29 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ds-pipeline-persistenceagent-{{.Name}}
-  namespace: {{.Namespace}}
+  name: ds-pipeline-persistenceagent-testdsp
+  namespace: default
   labels:
-    app: ds-pipeline-persistenceagent-{{.Name}}
+    app: ds-pipeline-persistenceagent-testdsp
     component: data-science-pipelines
 spec:
   selector:
     matchLabels:
-      app: ds-pipeline-persistenceagent-{{.Name}}
+      app: ds-pipeline-persistenceagent-testdsp
       component: data-science-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
-        app: ds-pipeline-persistenceagent-{{.Name}}
+        app: ds-pipeline-persistenceagent-testdsp
         component: data-science-pipelines
     spec:
       containers:
         - env:
             - name: NAMESPACE
-              value: "{{.Namespace}}"
-          image: "{{.PersistenceAgentImage}}"
+              value: "default"
+          image: "quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8"
           imagePullPolicy: IfNotPresent
           name: ds-pipeline-persistenceagent
           command:
@@ -31,8 +31,8 @@ spec:
             - "--logtostderr=true"
             - "--ttlSecondsAfterWorkflowFinish=86400"
             - "--numWorker=2"
-            - "--mlPipelineAPIServerName={{.APIServerServiceName}}"
-            - "--namespace={{.Namespace}}"
+            - "--mlPipelineAPIServerName=ds-pipeline-testdsp"
+            - "--namespace=default"
             - "--mlPipelineServiceHttpPort=8888"
             - "--mlPipelineServiceGRPCPort=8887"
           livenessProbe:
@@ -60,4 +60,4 @@ spec:
             limits:
               cpu: 250m
               memory: 1Gi
-      serviceAccountName: ds-pipeline-persistenceagent-{{.Name}}
+      serviceAccountName: ds-pipeline-persistenceagent-testdsp

--- a/controllers/testdata/results/case_1/scheduled-workflow/deployment.yaml
+++ b/controllers/testdata/results/case_1/scheduled-workflow/deployment.yaml
@@ -1,46 +1,41 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ds-pipeline-persistenceagent-{{.Name}}
-  namespace: {{.Namespace}}
+  name: ds-pipeline-scheduledworkflow-testdsp
+  namespace: default
   labels:
-    app: ds-pipeline-persistenceagent-{{.Name}}
+    app: ds-pipeline-scheduledworkflow-testdsp
     component: data-science-pipelines
 spec:
   selector:
     matchLabels:
-      app: ds-pipeline-persistenceagent-{{.Name}}
+      app: ds-pipeline-scheduledworkflow-testdsp
       component: data-science-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
-        app: ds-pipeline-persistenceagent-{{.Name}}
+        app: ds-pipeline-scheduledworkflow-testdsp
         component: data-science-pipelines
     spec:
       containers:
         - env:
-            - name: NAMESPACE
-              value: "{{.Namespace}}"
-          image: "{{.PersistenceAgentImage}}"
+            - name: CRON_SCHEDULE_TIMEZONE
+              value: "UTC"
+          image: "quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8"
           imagePullPolicy: IfNotPresent
-          name: ds-pipeline-persistenceagent
+          name: ds-pipeline-scheduledworkflow
           command:
-            - persistence_agent
+            - controller
             - "--logtostderr=true"
-            - "--ttlSecondsAfterWorkflowFinish=86400"
-            - "--numWorker=2"
-            - "--mlPipelineAPIServerName={{.APIServerServiceName}}"
-            - "--namespace={{.Namespace}}"
-            - "--mlPipelineServiceHttpPort=8888"
-            - "--mlPipelineServiceGRPCPort=8887"
+            - "--namespace=default"
           livenessProbe:
             exec:
               command:
                 - test
                 - -x
-                - persistence_agent
+                - controller
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 2
@@ -49,15 +44,15 @@ spec:
               command:
                 - test
                 - -x
-                - persistence_agent
+                - controller
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
           resources:
             requests:
               cpu: 120m
-              memory: 500Mi
+              memory: 100Mi
             limits:
               cpu: 250m
-              memory: 1Gi
-      serviceAccountName: ds-pipeline-persistenceagent-{{.Name}}
+              memory: 250Mi
+      serviceAccountName: ds-pipeline-scheduledworkflow-testdsp

--- a/controllers/testdata/results/case_1/viewer-crd/deployment.yaml
+++ b/controllers/testdata/results/case_1/viewer-crd/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-viewer-crd-testdsp
+  namespace: default
+  labels:
+    app: ds-pipeline-viewer-crd-testdsp
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-viewer-crd-testdsp
+      component: data-science-pipelines
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ds-pipeline-viewer-crd-testdsp
+        component: data-science-pipelines
+    spec:
+      containers:
+        - image: "quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8"
+          imagePullPolicy: Always
+          name: ds-pipeline-viewer-crd
+          command:
+            - controller
+            - "-logtostderr=true"
+            - "-max_num_viewers=50"
+            - "--namespace=default"
+          livenessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - controller
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - controller
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 120m
+              memory: 100Mi
+            limits:
+              cpu: 250m
+              memory: 500Mi
+      serviceAccountName: ds-pipeline-viewer-crd-testdsp

--- a/controllers/testutil/util.go
+++ b/controllers/testutil/util.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	"reflect"
+)
+
+func notEqualMsg(value string) {
+	print(fmt.Sprintf("%s are not equal.", value))
+}
+
+func DeploymentsAreEqual(dp1 appsv1.Deployment, dp2 appsv1.Deployment) bool {
+
+	if !reflect.DeepEqual(dp1.ObjectMeta.Labels, dp2.ObjectMeta.Labels) {
+		notEqualMsg("labels")
+		return false
+	}
+
+	if !reflect.DeepEqual(dp1.Spec.Selector, dp2.Spec.Selector) {
+		notEqualMsg("selector")
+		return false
+	}
+
+	if !reflect.DeepEqual(dp1.Spec.Template.ObjectMeta, dp2.Spec.Template.ObjectMeta) {
+		notEqualMsg("selector")
+		return false
+	}
+
+	if !reflect.DeepEqual(dp1.Spec.Template.Spec.Volumes, dp2.Spec.Template.Spec.Volumes) {
+		notEqualMsg("Volumes")
+		return false
+	}
+
+	if len(dp1.Spec.Template.Spec.Containers) != len(dp2.Spec.Template.Spec.Containers) {
+		notEqualMsg("Containers")
+		return false
+	}
+	for i := range dp1.Spec.Template.Spec.Containers {
+		c1 := dp1.Spec.Template.Spec.Containers[i]
+		c2 := dp2.Spec.Template.Spec.Containers[i]
+		if !reflect.DeepEqual(c1.Env, c2.Env) {
+			notEqualMsg("Container Env")
+			return false
+		}
+		if !reflect.DeepEqual(c1.Ports, c2.Ports) {
+			notEqualMsg("Container Ports")
+			return false
+		}
+		if !reflect.DeepEqual(c1.Resources, c2.Resources) {
+			notEqualMsg("Container Resources")
+			return false
+		}
+		if !reflect.DeepEqual(c1.VolumeMounts, c2.VolumeMounts) {
+			notEqualMsg("Container VolumeMounts")
+			return false
+		}
+		if !reflect.DeepEqual(c1.Args, c2.Args) {
+			notEqualMsg("Container Args")
+			return false
+		}
+		if c1.Name != c2.Name {
+			notEqualMsg("Container Name")
+			return false
+		}
+		if c1.Image != c2.Image {
+			notEqualMsg("Container Image")
+			return false
+		}
+	}
+
+	return true
+}

--- a/controllers/viewer_crd.go
+++ b/controllers/viewer_crd.go
@@ -21,10 +21,10 @@ import (
 )
 
 var viewerCRDTemplates = []string{
-	"config/internal/viewer-crd/deployment.yaml.tmpl",
-	"config/internal/viewer-crd/role.yaml.tmpl",
-	"config/internal/viewer-crd/rolebinding.yaml.tmpl",
-	"config/internal/viewer-crd/sa.yaml.tmpl",
+	"viewer-crd/deployment.yaml.tmpl",
+	"viewer-crd/role.yaml.tmpl",
+	"viewer-crd/rolebinding.yaml.tmpl",
+	"viewer-crd/sa.yaml.tmpl",
 }
 
 func (r *DSPipelineReconciler) ReconcileViewerCRD(dsp *dspipelinesiov1alpha1.DSPipeline,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/manifestival/controller-runtime-client v0.4.0
 	github.com/manifestival/manifestival v0.7.2
-	github.com/onsi/ginkgo/v2 v2.1.4
+	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v3.9.0+incompatible
 	go.uber.org/zap v1.21.0
@@ -53,6 +53,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -72,6 +73,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -447,6 +448,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -456,8 +458,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
-github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -770,6 +772,7 @@ golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -874,6 +877,7 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=

--- a/main.go
+++ b/main.go
@@ -84,9 +84,10 @@ func main() {
 	}
 
 	if err = (&controllers.DSPipelineReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log,
+		TemplatesPath: "config/internal/",
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DSPipelineParams")
 		os.Exit(1)


### PR DESCRIPTION
## Description
Add unit tests for dsp operator. Adds about ~75% coverage, tests currently only compare deployments but can be extended to other resources. Code was updated to accommodate unit testing, like allowing the ability to specify template manifests.

## How Has This Been Tested?
See tests running in my example in my fork [here](https://github.com/HumairAK/data-science-pipelines-operator/actions/runs/4139249101/jobs/7156610600).

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
