### PR TITLE
change log output to have human readable times

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,9 +18,12 @@ package main
 
 import (
 	"flag"
+	"os"
+	"time"
+
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
-	"os"
+	"go.uber.org/zap/zapcore"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -64,6 +67,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
change log output to have human readable times (RFC3339 instead of epoch)

## How Has This Been Tested?
build image, ran it in my dev cluster:
```
2023-02-13T21:15:20Z	DEBUG	events	data-science-pipelines-operator-controller-manager-84d5d4bcwhp7_7b84c00b-fa2a-4001-80ae-6f059785ebd8 became leader	<snip>
```

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

/assign @HumairAK 