### PR TITLE
remove outdated comment about distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ COPY controllers/ controllers/
 USER root
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the kubebuilder scaffolding uses gcr.io/distroless/static:nonroot but we switched to UBI in 15c7376. So removing old comment.