### PR TITLE
remove nonroot user 65532

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY config/internal config/internal
-USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Description
specifying `USER 65532:65532` is a distroless image thing and not required for UBI, which we switched to in 15c7376.

## How Has This Been Tested?
I built the image with this change and deployed it to my test cluster. Everything still works fine.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
