### PR TITLE
Adding a service to expose Operator SDK metrics

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - manager.yaml
+- manager-service.yaml

--- a/config/manager/manager-service.yaml
+++ b/config/manager/manager-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-science-pipelines-operator
+  labels:
+    control-plane: controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+  selector:
+    control-plane: controller-manager


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adding a service to expose Operator SDK metrics port

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a test cluster:

- Added this service config
- Port forwarded to the localhost port via the service:
`oc port-forward svc/data-science-pipelines-operator 8080:8080 -n data-science-pipelines-operator`
- Curled to the localhost to retrieve a list of Operator SDK metrics:
`curl -v http://localhost:8080/metrics`

Find a list of metrics returned by the curl command [here.](http://pastebin.test.redhat.com/1092224)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
