### PR TITLE
Adding a ServiceMonitor for Data Science Pipelines Operator

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../prometheus
 
 images:
 - name: controller

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,24 +1,12 @@
-# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: servicemonitor
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
-  name: controller-manager-metrics-monitor
-  namespace: dspipelines-controller
+  name: data-science-pipelines-operator-monitor
+  namespace: data-science-pipelines-operator
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+      port: metrics
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a Service to expose DSP Operator SDK metrics in https://github.com/opendatahub-io/data-science-pipelines-operator/pull/22
Adding a ServiceMonitor for Data Science Pipelines Operator, with labels matching to the above service config.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested out on a local cluster with both the service and the ServiceMonitor configs applied, metrics were found to be scraped by Prometheus:

![image](https://user-images.githubusercontent.com/46318816/220460383-9d5e05d5-4f36-4dca-b387-ee57d6d2448b.png)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
