### PR TITLE
Include metrics testing in E2E tests

### DIFF
--- a/tests/basictests/dsp-operator.sh
+++ b/tests/basictests/dsp-operator.sh
@@ -32,12 +32,30 @@ function create_and_verify_data_science_pipelines_resources() {
     os::cmd::expect_success "if [ "$running_pods" -gt "0" ]; then exit 0; else exit 1; fi"
 }
 
+function check_data_science_pipeline_route() {
+    header "Checking Routes of Data Science Pipeline availability"
+    os::cmd::try_until_text "oc get pods -l app=ds-pipeline-ui-sample --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "1" $odhdefaulttimeout $odhdefaultinterval
+}
+
+function setup_monitoring() {
+    header "Enabling User Workload Monitoring on the cluster"
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/enable-uwm.yaml"
+}
+
+function test_metrics() {
+    header "Checking metrics for total number of runs, should be 1 since we have spun up 1 run"
+
+    cluster_version=$(oc get -o json clusterversion | jq '.items[0].status.desired.version')
+    monitoring_token=$(oc create token thanos-querier -n openshift-monitoring)
+    monitoring_route=$(oc get route thanos-querier -n openshift-monitoring --template={{.spec.host}})
+    os::cmd::try_until_text "oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H \"Authorization: Bearer $monitoring_token\" 'https://thanos-querier.openshift-monitoring:9091/api/v1/query' -d 'query=controller_runtime_max_concurrent_reconciles{namespace=\"opendatahub\"}' | jq '.data.result[0].value[1]'" "1" $odhdefaulttimeout $odhdefaultinterval
+}
+
 function create_pipeline() {
     header "Creating a pipeline from data science pipelines stack"
 
     ROUTE=$(oc get route ds-pipeline-ui-sample --template={{.spec.host}})
-    SA_TOKEN=$(oc whoami --show-token)
-
+    SA_TOKEN=$(oc create token ds-pipeline-ui-sample)
     PIPELINE_ID=$(curl -s -k -H "Authorization: Bearer ${SA_TOKEN}" -F "uploadfile=@${RESOURCEDIR}/test-pipeline-run.yaml" https://${ROUTE}/apis/v1beta1/pipelines/upload | jq -r .id)
     os::cmd::try_until_not_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/pipelines/${PIPELINE_ID} | jq" "null" $odhdefaulttimeout $odhdefaultinterval
 }
@@ -49,7 +67,20 @@ function verify_pipeline_availabilty() {
 
 function create_run() {
     header "Creating the run from uploaded pipeline"
-    RUN_ID=$(curl -s -k -H "Authorization: Bearer ${SA_TOKEN}" -H "Content-Type: application/json"  -d "{\"name\":\"test-pipeline-run_run\", \"pipeline_spec\":{\"pipeline_id\":\"${PIPELINE_ID}\"}}" https://${ROUTE}/apis/v1beta1/runs | jq -r .run.id)
+
+    RUN_ID=$(( curl -k -H "Authorization: Bearer ${SA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -X POST "https://${ROUTE}/apis/v1beta1/runs" \
+        -d @- << EOF
+        {
+            "name":"test-pipeline-run",
+            "pipeline_spec":{
+                "pipeline_id":"${PIPELINE_ID}"
+            }
+        }
+EOF
+        ) | jq -r .run.id)
+
     os::cmd::try_until_not_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID} | jq '" "null" $odhdefaulttimeout $odhdefaultinterval
 }
 
@@ -78,6 +109,9 @@ function delete_pipeline() {
 echo "Testing Data Science Pipelines Operator functionality"
 verify_data_science_pipelines_operator_install
 create_and_verify_data_science_pipelines_resources
+check_data_science_pipeline_route
+setup_monitoring
+test_metrics
 create_pipeline
 verify_pipeline_availabilty
 create_run

--- a/tests/resources/dsp-operator/test-dspo-cr.yaml
+++ b/tests/resources/dsp-operator/test-dspo-cr.yaml
@@ -19,36 +19,12 @@ spec:
     image: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
   mlpipelineUI:
     image: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
-    configMap: ds-pipeline-ui-configmap
   database:
     mariaDB:   # mutually exclusive with custom
       image: registry.redhat.io/rhel8/mariadb-103:1-188
       username: mlpipeline
       pipelineDBName: randomDBName
-      passwordSecret:
-        name: ds-pipelines-db-sample
-        key: password
-    # customDB:
-    #   host: mysql:3306
-    #   port: "8888"
-    #   username: root
-    #   pipelineDBName: randomDBName
-    #   passwordSecret:
-    #     name: somesecret
-    #     key: somekey
-  storage:
+  objectStorage:
     minio:  # mutually exclusive with custom
       image: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
       bucket: mlpipeline
-      s3CredentialsSecret:
-        secretName: somesecret-sample
-        accessKey: accesskey
-        secretKey: secretkey
-#    customStorage:
-#      host: minio.com
-#      port: "9092"
-#      bucket: mlpipeline
-#      s3CredentialsSecret:
-#        secretName: somesecret-db-sample
-#        accessKey: somekey
-#        secretKey: somekey


### PR DESCRIPTION
Include metrics testing in E2E tests

## Description

Included metrics testing check as a part of E2E tests, as mentioned in Note here:https://github.com/opendatahub-io/data-science-pipelines-operator/pull/23#issue-1593637302
- Adjusted Token creation for SA as per cluster rules.


## How Has This Been Tested?
with the help of makefile and openshift cluster, try the following:
```
cd tests
make build
make run
```
Tested on openshift cluster with version: 4.12.2

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
