### PR TITLE
Updates to have auth permission for oauth proxy

### DIFF
--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -29,10 +29,9 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "ds-pipeline-ui-{{.Name}}"}}'
-            - '--openshift-sar={"resource": "route", "resourceName": "ds-pipeline-ui-{{.Name}}", "verb": "get"}'
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-{{.Name}}","namespace":"{{.Namespace}}"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:
             - containerPort: 8443
               name: https

--- a/config/internal/mlpipelines-ui/role.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/role.yaml.tmpl
@@ -59,3 +59,9 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - route.openshift.io
+    verbs:
+      - get
+    resources:
+      - routes

--- a/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
@@ -29,10 +29,9 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "ds-pipeline-ui-testdsp0"}}'
-            - '--openshift-sar={"resource": "route", "resourceName": "ds-pipeline-ui-testdsp0", "verb": "get"}'
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp0","namespace":"default"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:
             - containerPort: 8443
               name: https

--- a/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
@@ -29,10 +29,9 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "ds-pipeline-ui-testdsp2"}}'
-            - '--openshift-sar={"resource": "route", "resourceName": "ds-pipeline-ui-testdsp2", "verb": "get"}'
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp2","namespace":"default"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:
             - containerPort: 8443
               name: https


### PR DESCRIPTION
Updates to have auth permission for OAuth-proxy, which would allow SA to authenticate.

## Description

As most of times, we use the Openshift cluster above 4.9 version, the image update to oauth-proxy is also needed
as TokenReview API change is addressed in newer images.
- This includes new image update
- Providing more specific information on oauth proxy delegation 
- Inclusion of role missing for the SA.

## How Has This Been Tested?
Tested the change by deploying operator using this PR image `quay.io/opendatahub/data-science-pipelines-operator:pr-26`
and send request to the UI routes.

`TOKEN=$(oc create token ds-pipeline-ui-sample -n <namespace>)`
`curl -k -H "Authorization: Bearer $TOKEN"  https://<route-url>/apis/v1beta1/pipelines`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added to the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
