### PR TITLE
Replace busybox img

### DIFF
--- a/config/configmaps/files/config.yaml
+++ b/config/configmaps/files/config.yaml
@@ -1,9 +1,9 @@
 Images:
-  ApiServer: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
-  Artifact: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
-  PersistentAgent: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
-  ScheduledWorkflow: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
-  ViewerCRD: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
+  ApiServer: quay.io/opendatahub/ds-pipelines-api-server:main
+  Artifact: quay.io/opendatahub/ds-pipelines-artifact-manager:main
+  PersistentAgent: quay.io/opendatahub/ds-pipelines-persistenceagent:main
+  ScheduledWorkflow: quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
+  ViewerCRD: quay.io/opendatahub/ds-pipelines-viewercontroller:main
   Cache: registry.access.redhat.com/ubi8/ubi-minimal
   MoveResultsImage: registry.access.redhat.com/ubi8/ubi-micro
   MlPipelineUI: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui

--- a/config/configmaps/files/config.yaml
+++ b/config/configmaps/files/config.yaml
@@ -5,7 +5,7 @@ Images:
   ScheduledWorkflow: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
   ViewerCRD: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
   Cache: registry.access.redhat.com/ubi8/ubi-minimal
-  MoveResultsImage: busybox
+  MoveResultsImage: registry.access.redhat.com/ubi8/ubi-micro
   MlPipelineUI: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
   MariaDB: registry.redhat.io/rhel8/mariadb-103:1-188
   Minio: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,15 +39,15 @@ spec:
         name: manager
         env:
           - name: IMAGES_APISERVER
-            value: quay.io/modh/odh-ml-pipelines-api-server-container-live:1.22.0-rhods-6564
+            value: quay.io/opendatahub/ds-pipelines-api-server:main
           - name: IMAGES_ARTIFACT
-            value: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.20.0-15
+            value: quay.io/opendatahub/ds-pipelines-artifact-manager:main
           - name: IMAGES_PERSISTENTAGENT
-            value: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.20.0-15
+            value: quay.io/opendatahub/ds-pipelines-persistenceagent:main
           - name: IMAGES_SCHEDULEDWORKFLOW
-            value: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.20.0-15
+            value: quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
           - name: IMAGES_VIEWERCRD
-            value: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.20.0-15
+            value: quay.io/opendatahub/ds-pipelines-viewercontroller:main
           - name: IMAGES_CACHE
             value: registry.access.redhat.com/ubi8/ubi-minimal
           - name: IMAGES_MOVERESULTSIMAGE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,19 +39,19 @@ spec:
         name: manager
         env:
           - name: IMAGES_APISERVER
-            value: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
+            value: quay.io/modh/odh-ml-pipelines-api-server-container-live:1.22.0-rhods-6564
           - name: IMAGES_ARTIFACT
-            value: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
+            value: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.20.0-15
           - name: IMAGES_PERSISTENTAGENT
-            value: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
+            value: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.20.0-15
           - name: IMAGES_SCHEDULEDWORKFLOW
-            value: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
+            value: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.20.0-15
           - name: IMAGES_VIEWERCRD
-            value: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
+            value: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.20.0-15
           - name: IMAGES_CACHE
             value: registry.access.redhat.com/ubi8/ubi-minimal
           - name: IMAGES_MOVERESULTSIMAGE
-            value: busybox
+            value: registry.access.redhat.com/ubi8/ubi-micro
           - name: IMAGES_MLPIPELINEUI
             value: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
           - name: IMAGES_MARIADB

--- a/controllers/testdata/deploy/case_0/config.yaml
+++ b/controllers/testdata/deploy/case_0/config.yaml
@@ -1,11 +1,11 @@
 Images:
-  ApiServer: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
-  Artifact: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
-  PersistentAgent: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
-  ScheduledWorkflow: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
-  ViewerCRD: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
-  Cache: registry.access.redhat.com/ubi8/ubi-minimal
-  MoveResultsImage: busybox
-  MlPipelineUI: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
-  MariaDB: registry.redhat.io/rhel8/mariadb-103:1-188
-  Minio: "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance"
+  ApiServer: api-server:test0
+  Artifact: artifact-manager:test0
+  PersistentAgent: persistenceagent:test0
+  ScheduledWorkflow: scheduledworkflow:test0
+  ViewerCRD: viewercontroller:test0
+  Cache: ubi-minimal:test0
+  MoveResultsImage: busybox:test0
+  MlPipelineUI: frontend:test0
+  MariaDB: mariadb:test0
+  Minio: minio:test0

--- a/controllers/testdata/deploy/case_1/config.yaml
+++ b/controllers/testdata/deploy/case_1/config.yaml
@@ -1,11 +1,11 @@
 Images:
-  ApiServer: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
-  Artifact: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
-  PersistentAgent: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
-  ScheduledWorkflow: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
-  ViewerCRD: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
-  Cache: registry.access.redhat.com/ubi8/ubi-minimal
-  MoveResultsImage: busybox
-  MlPipelineUI: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
-  MariaDB: registry.redhat.io/rhel8/mariadb-103:1-188
-  Minio: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+  ApiServer: api-server:test1
+  Artifact: artifact-manager:test1
+  PersistentAgent: persistenceagent:test1
+  ScheduledWorkflow: scheduledworkflow:test1
+  ViewerCRD: viewercontroller:test1
+  Cache: ubi-minimal:test1
+  MoveResultsImage: busybox:test1
+  MlPipelineUI: frontend:test1
+  MariaDB: mariadb:test1
+  Minio: minio:test1

--- a/controllers/testdata/deploy/case_2/config.yaml
+++ b/controllers/testdata/deploy/case_2/config.yaml
@@ -1,11 +1,11 @@
 Images:
-  ApiServer: quay.io/modh/test-api-server-container:test
-  Artifact: quay.io/modh/test-artifact-manager-container:test
-  PersistentAgent: quay.io/modh/test-persistenceagent-container:test
-  ScheduledWorkflow: quay.io/modh/test-scheduledworkflow-container:test
-  ViewerCRD: quay.io/modh/test-viewercontroller-container:test
-  Cache: registry.access.redhat.com/ubi8/test-ubi-minimal
-  MoveResultsImage: testbusybox
-  MlPipelineUI: quay.io/opendatahub/test-frontend-container:beta-ui
-  MariaDB: registry.redhat.io/rhel8/test-mariadb-103:test
-  Minio: quay.io/opendatahub/test-minio:test
+  ApiServer: api-server:test2
+  Artifact: artifact-manager:test2
+  PersistentAgent: persistenceagent:test2
+  ScheduledWorkflow: scheduledworkflow:test2
+  ViewerCRD: viewercontroller:test2
+  Cache: ubi-minimal:test2
+  MoveResultsImage: busybox:test2
+  MlPipelineUI: frontend:test2
+  MariaDB: mariadb:test2
+  Minio: minio:test2

--- a/controllers/testdata/deploy/case_2/cr.yaml
+++ b/controllers/testdata/deploy/case_2/cr.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   apiServer:
     deploy: true
-    image: quay.io/modh/test-api-server-container:test
+    image: api-server:test2
     applyTektonCustomResource: true
     archiveLogs: false
-    artifactImage: quay.io/modh/test-artifact-manager-container:test
-    cacheImage: registry.access.redhat.com/ubi8/test-ubi-minimal
-    moveResultsImage: testbusybox
+    artifactImage: artifact-manager:test2
+    cacheImage: ubi-minimal:test2
+    moveResultsImage: busybox:test2
     injectDefaultScript: true
     stripEOF: true
     terminateStatus: Cancelled
@@ -27,7 +27,7 @@ spec:
         memory: "5Gi"
   persistenceAgent:
     deploy: true
-    image: quay.io/modh/test-persistenceagent-container:test
+    image: persistenceagent:test2
     numWorkers: 5
     resources:
       requests:
@@ -38,7 +38,7 @@ spec:
         memory: "5Gi"
   scheduledWorkflow:
     deploy: true
-    image: quay.io/modh/test-scheduledworkflow-container:test
+    image: scheduledworkflow:test2
     cronScheduleTimezone: EST
     resources:
       requests:
@@ -49,7 +49,7 @@ spec:
         memory: "5Gi"
   viewerCRD:
     deploy: true
-    image: quay.io/modh/test-viewercontroller-container:test
+    image: viewercontroller:test2
     maxNumViewer: 25
     resources:
       requests:
@@ -60,7 +60,7 @@ spec:
         memory: "5Gi"
   mlpipelineUI:
     deploy: true
-    image: quay.io/opendatahub/test-frontend-container:beta-ui
+    image: frontend:test2
     configMap: some-test-configmap
     resources:
       requests:
@@ -72,7 +72,7 @@ spec:
   database:
     mariaDB:
       deploy: true
-      image: registry.redhat.io/rhel8/test-mariadb-103:test
+      image: mariadb:test2
       username: testuser
       pipelineDBName: randomDBName
       pvcSize: 32Gi
@@ -86,7 +86,7 @@ spec:
   objectStorage:
     minio:
       deploy: true
-      image: quay.io/opendatahub/test-minio:test
+      image: minio:test2
       bucket: mlpipeline
       pvcSize: 40Gi
       resources:

--- a/controllers/testdata/deploy/case_3/config.yaml
+++ b/controllers/testdata/deploy/case_3/config.yaml
@@ -1,11 +1,11 @@
 Images:
-  ApiServer: quay.io/modh/test-api-server-container:test1
-  Artifact: quay.io/modh/test-artifact-manager-container:test1
-  PersistentAgent: quay.io/modh/test-persistenceagent-container:test1
-  ScheduledWorkflow: quay.io/modh/test-scheduledworkflow-container:test1
-  ViewerCRD: quay.io/modh/test-viewercontroller-container:test1
-  Cache: registry.access.redhat.com/ubi8/test-ubi-minimal
-  MoveResultsImage: testbusybox
-  MlPipelineUI: quay.io/opendatahub/test-frontend-container:beta-ui
-  MariaDB: registry.redhat.io/rhel8/test-mariadb-103:test1
-  Minio: quay.io/opendatahub/test-minio:test1
+  ApiServer: api-server:test3
+  Artifact: artifact-manager:test3
+  PersistentAgent: persistenceagent:test3
+  ScheduledWorkflow: scheduledworkflow:test3
+  ViewerCRD: viewercontroller:test3
+  Cache: ubi-minimal:test3
+  MoveResultsImage: busybox:test3
+  MlPipelineUI: frontend:test3
+  MariaDB: mariadb:test3
+  Minio: minio:test3

--- a/controllers/testdata/deploy/case_3/cr.yaml
+++ b/controllers/testdata/deploy/case_3/cr.yaml
@@ -8,12 +8,12 @@ spec:
       name: doesnotexist
       key: "somekey"
     deploy: true
-    image: quay.io/modh/test-api-server-container:test
+    image: api-server:test3
     applyTektonCustomResource: true
     archiveLogs: false
-    artifactImage: quay.io/modh/test-artifact-manager-container:test
-    cacheImage: registry.access.redhat.com/ubi8/test-ubi-minimal
-    moveResultsImage: testbusybox
+    artifactImage: artifact-manager:test3
+    cacheImage: ubi-minimal:test3
+    moveResultsImage: busybox:test3
     injectDefaultScript: true
     stripEOF: true
     terminateStatus: Cancelled
@@ -30,7 +30,7 @@ spec:
         memory: "5Gi"
   persistenceAgent:
     deploy: true
-    image: quay.io/modh/test-persistenceagent-container:test
+    image: persistenceagent:test3
     numWorkers: 5
     resources:
       requests:
@@ -41,7 +41,7 @@ spec:
         memory: "5Gi"
   scheduledWorkflow:
     deploy: true
-    image: quay.io/modh/test-scheduledworkflow-container:test
+    image: scheduledworkflow:test3
     cronScheduleTimezone: EST
     resources:
       requests:
@@ -52,7 +52,7 @@ spec:
         memory: "5Gi"
   viewerCRD:
     deploy: true
-    image: quay.io/modh/test-viewercontroller-container:test
+    image: viewercontroller:test3
     maxNumViewer: 25
     resources:
       requests:
@@ -63,7 +63,7 @@ spec:
         memory: "5Gi"
   mlpipelineUI:
     deploy: true
-    image: quay.io/opendatahub/test-frontend-container:beta-ui
+    image: frontend:test3
     configMap: some-test-configmap
     resources:
       requests:
@@ -75,7 +75,7 @@ spec:
   database:
     mariaDB:
       deploy: true
-      image: registry.redhat.io/rhel8/test-mariadb-103:test
+      image: mariadb:test3
       username: testuser
       pipelineDBName: randomDBName
       pvcSize: 32Gi
@@ -89,7 +89,7 @@ spec:
   objectStorage:
     minio:
       deploy: true
-      image: quay.io/opendatahub/test-minio:test
+      image: minio:test3
       bucket: mlpipeline
       pvcSize: 40Gi
       resources:

--- a/controllers/testdata/results/case_0/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_0/apiserver/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                   key: "artifact_script"
                   name: "ds-pipeline-artifact-script-testdsp0"
             - name: ARTIFACT_IMAGE
-              value: "quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8"
+              value: "artifact-manager:test0"
             - name: ARCHIVE_LOGS
               value: "false"
             - name: TRACK_ARTIFACTS
@@ -88,10 +88,10 @@ spec:
             - name: MINIO_SERVICE_SERVICE_PORT
               value: "9000"
             - name: CACHE_IMAGE
-              value: "registry.access.redhat.com/ubi8/ubi-minimal"
+              value: "ubi-minimal:test0"
             - name: MOVERESULTS_IMAGE
-              value: "busybox"
-          image: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
+              value: "busybox:test0"
+          image: api-server:test0
           imagePullPolicy: Always
           name: ds-pipeline-api-server
           ports:

--- a/controllers/testdata/results/case_0/mariadb/deployment.yaml
+++ b/controllers/testdata/results/case_0/mariadb/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: mariadb
-          image: registry.redhat.io/rhel8/mariadb-103:1-188
+          image: mariadb:test0
           ports:
             - containerPort: 3306
               protocol: TCP

--- a/controllers/testdata/results/case_0/minio/deployment.yaml
+++ b/controllers/testdata/results/case_0/minio/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 secretKeyRef:
                   key: "secretkey"
                   name: "mlpipeline-minio-artifact"
-          image: "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance"
+          image: minio:test0
           name: minio
           ports:
             - containerPort: 9000

--- a/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               value: ds-pipeline-testdsp0
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
-          image: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
+          image: frontend:test0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/controllers/testdata/results/case_0/persistence-agent/deployment.yaml
+++ b/controllers/testdata/results/case_0/persistence-agent/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - env:
             - name: NAMESPACE
               value: "default"
-          image: "quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8"
+          image: persistenceagent:test0
           imagePullPolicy: IfNotPresent
           name: ds-pipeline-persistenceagent
           command:

--- a/controllers/testdata/results/case_0/scheduled-workflow/deployment.yaml
+++ b/controllers/testdata/results/case_0/scheduled-workflow/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - env:
             - name: CRON_SCHEDULE_TIMEZONE
               value: "UTC"
-          image: "quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8"
+          image: scheduledworkflow:test0
           imagePullPolicy: IfNotPresent
           name: ds-pipeline-scheduledworkflow
           command:

--- a/controllers/testdata/results/case_0/viewer-crd/deployment.yaml
+++ b/controllers/testdata/results/case_0/viewer-crd/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
-        - image: "quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8"
+        - image: viewercontroller:test0
           imagePullPolicy: Always
           name: ds-pipeline-viewer-crd
           command:

--- a/controllers/testdata/results/case_2/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_2/apiserver/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                   key: "artifact_script"
                   name: "ds-pipeline-artifact-script-testdsp2"
             - name: ARTIFACT_IMAGE
-              value: "quay.io/modh/test-artifact-manager-container:test"
+              value: "artifact-manager:test2"
             - name: ARCHIVE_LOGS
               value: "false"
             - name: TRACK_ARTIFACTS
@@ -88,10 +88,10 @@ spec:
             - name: MINIO_SERVICE_SERVICE_PORT
               value: "9000"
             - name: CACHE_IMAGE
-              value: "registry.access.redhat.com/ubi8/test-ubi-minimal"
+              value: "ubi-minimal:test2"
             - name: MOVERESULTS_IMAGE
-              value: "testbusybox"
-          image: quay.io/modh/test-api-server-container:test
+              value: "busybox:test2"
+          image: api-server:test2
           imagePullPolicy: Always
           name: ds-pipeline-api-server
           ports:

--- a/controllers/testdata/results/case_2/mariadb/deployment.yaml
+++ b/controllers/testdata/results/case_2/mariadb/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: mariadb
-          image: registry.redhat.io/rhel8/test-mariadb-103:test
+          image: mariadb:test2
           ports:
             - containerPort: 3306
               protocol: TCP

--- a/controllers/testdata/results/case_2/minio/deployment.yaml
+++ b/controllers/testdata/results/case_2/minio/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 secretKeyRef:
                   key: "secretkey"
                   name: "mlpipeline-minio-artifact"
-          image: "quay.io/opendatahub/test-minio:test"
+          image: minio:test2
           name: minio
           ports:
             - containerPort: 9000

--- a/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               value: ds-pipeline-testdsp2
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
-          image: quay.io/opendatahub/test-frontend-container:beta-ui
+          image: frontend:test2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/controllers/testdata/results/case_2/persistence-agent/deployment.yaml
+++ b/controllers/testdata/results/case_2/persistence-agent/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - env:
             - name: NAMESPACE
               value: "default"
-          image: "quay.io/modh/test-persistenceagent-container:test"
+          image: persistenceagent:test2
           imagePullPolicy: IfNotPresent
           name: ds-pipeline-persistenceagent
           command:

--- a/controllers/testdata/results/case_2/scheduled-workflow/deployment.yaml
+++ b/controllers/testdata/results/case_2/scheduled-workflow/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - env:
             - name: CRON_SCHEDULE_TIMEZONE
               value: "EST"
-          image: "quay.io/modh/test-scheduledworkflow-container:test"
+          image: scheduledworkflow:test2
           imagePullPolicy: IfNotPresent
           name: ds-pipeline-scheduledworkflow
           command:

--- a/controllers/testdata/results/case_2/viewer-crd/deployment.yaml
+++ b/controllers/testdata/results/case_2/viewer-crd/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
-        - image: "quay.io/modh/test-viewercontroller-container:test"
+        - image: viewercontroller:test2
           imagePullPolicy: Always
           name: ds-pipeline-viewer-crd
           command:

--- a/controllers/testdata/results/case_3/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_3/apiserver/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                   key: "artifact_script"
                   name: "ds-pipeline-artifact-script-testdsp3"
             - name: ARTIFACT_IMAGE
-              value: "quay.io/modh/test-artifact-manager-container:test"
+              value: artifact-manager:test3
             - name: ARCHIVE_LOGS
               value: "false"
             - name: TRACK_ARTIFACTS
@@ -88,10 +88,10 @@ spec:
             - name: MINIO_SERVICE_SERVICE_PORT
               value: "9000"
             - name: CACHE_IMAGE
-              value: "registry.access.redhat.com/ubi8/test-ubi-minimal"
+              value: ubi-minimal:test3
             - name: MOVERESULTS_IMAGE
-              value: "testbusybox"
-          image: quay.io/modh/test-api-server-container:test
+              value: busybox:test3
+          image: api-server:test3
           imagePullPolicy: Always
           name: ds-pipeline-api-server
           ports:


### PR DESCRIPTION
## Description
Also update apiserver image to latest version that allows one to set the
move-results-image. Unfortunately the other components do not have an
image cut for v1.22 so the closest we can get is 1.20, they will be
brought in sync in a follow up change.

## How Has This Been Tested?
Locally and on OCP OSD with: quay.io/hukhan/data-science-pipelines-operator:v0.0.9
Run unit tests on this pr by cloning the branch and following instructions [here](https://github.com/opendatahub-io/data-science-pipelines-operator#run-tests). 

Deploy on dev cluster with ocp pipelines (logged in as cluster admin): 

```
oc new-project data-science-pipelines-operator
make podman-build podman-push IMG=$YOUR_CONTAINER_REPO
make deploy IMG=$YOUR_CONTAINER_REPO
```

Deploy a sample cr with the updated resource kind: 

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
  namespace: data-science-project
spec: {}
```

Run the standard flip coin example and check the move results step in the first pod in the pipeline, confirm it uses the ubi-micro image and finishes successfully.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
