### PR TITLE
add shortName for datasciencepipelinesapplications

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -204,6 +204,7 @@ type DSPAStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=dspa
 
 type DataSciencePipelinesApplication struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -12,6 +12,8 @@ spec:
     kind: DataSciencePipelinesApplication
     listKind: DataSciencePipelinesApplicationList
     plural: datasciencepipelinesapplications
+    shortNames:
+    - dspa
     singular: datasciencepipelinesapplication
   scope: Namespaced
   versions:


### PR DESCRIPTION
## Description

the new CRD name `datasciencepipelinesapplications` is a bit long. Add a shortName `dspa`.

## How Has This Been Tested?
ran `make test`, deployed it to a cluster and ran `k get dspa`

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
