### PR TITLE
Add enable route functionality.

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -71,6 +71,9 @@ type APIServer struct {
 	CollectMetrics bool `json:"collectMetrics"`
 	// +kubebuilder:default:=true
 	// +optional
+	EnableRoute bool `json:"enableOauth"`
+	// +kubebuilder:default:=true
+	// +optional
 	AutoUpdatePipelineDefaultVersion bool                  `json:"autoUpdatePipelineDefaultVersion"`
 	Resources                        *ResourceRequirements `json:"resources,omitempty"`
 }

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -67,6 +67,9 @@ spec:
                   deploy:
                     default: true
                     type: boolean
+                  enableOauth:
+                    default: true
+                    type: boolean
                   image:
                     type: string
                   injectDefaultScript:

--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -18,6 +18,54 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
+        {{ if .APIServer.EnableRoute }}
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-{{.Name}}
+            - --upstream=http://localhost:8888
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-{{.Name}}","namespace":"{{.Namespace}}"}}'
+            - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          ports:
+            - containerPort: 8443
+              name: oauth
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+        {{ end }}
         - env:
             - name: POD_NAMESPACE
               value: "{{.Namespace}}"
@@ -143,3 +191,7 @@ spec:
               {{ end }}
             {{ end }}
       serviceAccountName: ds-pipeline-{{.Name}}
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-proxy-tls-{{.Name}}

--- a/config/internal/apiserver/route.yaml.tmpl
+++ b/config/internal/apiserver/route.yaml.tmpl
@@ -1,0 +1,19 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: ds-pipeline-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-{{.Name}}
+    component: data-science-pipelines
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  to:
+    kind: Service
+    name: ds-pipeline-{{.Name}}
+    weight: 100
+  port:
+    targetPort: oauth
+  tls:
+    termination: Reencrypt

--- a/config/internal/apiserver/sa_ds-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sa_ds-pipeline.yaml.tmpl
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: ds-pipeline-{{.Name}}
   namespace: {{.Namespace}}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"ds-pipeline-{{.Name}}"}}'
   labels:
     app: ds-pipeline-{{.Name}}
     component: data-science-pipelines

--- a/config/internal/apiserver/service.yaml.tmpl
+++ b/config/internal/apiserver/service.yaml.tmpl
@@ -3,11 +3,17 @@ kind: Service
 metadata:
   name: {{.APIServerServiceName}}
   namespace: {{.Namespace}}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: ds-pipelines-proxy-tls-{{.Name}}
   labels:
     app: ds-pipeline-{{.Name}}
     component: data-science-pipelines
 spec:
   ports:
+    - name: oauth
+      port: 8443
+      protocol: TCP
+      targetPort: oauth
     - name: http
       port: 8888
       protocol: TCP

--- a/config/internal/common/clusterrolebinding.yaml.tmpl
+++ b/config/internal/common/clusterrolebinding.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ds-pipeline-ui-auth-delegator-{{.Name}}
+  name: ds-pipeline-ui-auth-delegator-{{.Namespace}}-{{.Name}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,3 +10,6 @@ subjects:
   - kind: ServiceAccount
     namespace: {{.Namespace}}
     name: ds-pipeline-ui-{{.Name}}
+  - kind: ServiceAccount
+    namespace: {{.Namespace}}
+    name: ds-pipeline-{{.Name}}

--- a/config/internal/common/policy.yaml.tmpl
+++ b/config/internal/common/policy.yaml.tmpl
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ds-pipelines-{{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app: ds-pipeline-{{.Name}}
+      component: data-science-pipelines
+  policyTypes:
+    - Ingress
+  ingress:
+    # Match all sources for oauth endpoint
+    - ports:
+        - protocol: TCP
+          port: 8443
+    # We only allow DSPA components to communicate
+    # by bypassing oauth proxy, all external
+    # traffic should go through oauth proxy
+    - from:
+        - podSelector:
+            matchLabels:
+              app: mariadb-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: minio-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-ui-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-persistenceagent-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-scheduledworkflow-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-viewer-crd-{{.Name}}
+              component: data-science-pipelines
+      ports:
+        - protocol: TCP
+          port: 8888
+        - protocol: TCP
+          port: 8887

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -155,6 +155,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,0 +1,54 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+)
+
+var commonTemplates = []string{
+	"common/policy.yaml.tmpl",
+}
+
+const commonCusterRolebindingTemplate = "common/clusterrolebinding.yaml.tmpl"
+
+func (r *DSPAReconciler) ReconcileCommon(dsp *dspav1alpha1.DataSciencePipelinesApplication, params *DSPAParams) error {
+	r.Log.Info("Applying Common Resources")
+
+	r.Log.Info("Applying Common Resources")
+	for _, template := range commonTemplates {
+		err := r.Apply(dsp, params, template)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := r.ApplyWithoutOwner(params, commonCusterRolebindingTemplate)
+	if err != nil {
+		return err
+	}
+
+	r.Log.Info("Finished applying Common Resources")
+	return nil
+}
+
+func (r *DSPAReconciler) CleanUpCommon(params *DSPAParams) error {
+	err := r.DeleteResource(params, commonCusterRolebindingTemplate)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/controllers/mlpipeline_ui.go
+++ b/controllers/mlpipeline_ui.go
@@ -31,12 +31,6 @@ var mlPipelineUITemplates = []string{
 	"mlpipelines-ui/service.yaml.tmpl",
 }
 
-var mlPipelineUIClusterScopedTemplates = []string{
-	"mlpipelines-ui/clusterrolebinding.yaml.tmpl",
-}
-
-const uIClusterRolebindingTemplate = "mlpipelines-ui/clusterrolebinding.yaml.tmpl"
-
 func (r *DSPAReconciler) ReconcileUI(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
@@ -53,21 +47,6 @@ func (r *DSPAReconciler) ReconcileUI(dsp *dspav1alpha1.DataSciencePipelinesAppli
 		}
 	}
 
-	err := r.ApplyWithoutOwner(params, uIClusterRolebindingTemplate)
-	if err != nil {
-		return err
-	}
-
 	r.Log.Info("Applying MlPipelineUI Resources")
-	return nil
-}
-
-func (r *DSPAReconciler) CleanUpUI(params *DSPAParams) error {
-	for _, template := range mlPipelineUIClusterScopedTemplates {
-		err := r.DeleteResource(params, template)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/controllers/testdata/deploy/case_2/cr.yaml
+++ b/controllers/testdata/deploy/case_2/cr.yaml
@@ -13,6 +13,7 @@ spec:
     moveResultsImage: testbusybox
     injectDefaultScript: true
     stripEOF: true
+    enableOauth: true
     terminateStatus: Cancelled
     trackArtifacts: true
     dbConfigConMaxLifetimeSec: 125

--- a/controllers/testdata/results/case_0/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_0/apiserver/deployment.yaml
@@ -18,6 +18,53 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-testdsp0
+            - --upstream=http://localhost:8888
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp0","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp0","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          ports:
+            - containerPort: 8443
+              name: oauth
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -132,4 +179,9 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-proxy-tls-testdsp0
+            defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp0

--- a/controllers/testdata/results/case_2/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_2/apiserver/deployment.yaml
@@ -18,6 +18,53 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-testdsp2
+            - --upstream=http://localhost:8888
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp2","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp2","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          ports:
+            - containerPort: 8443
+              name: oauth
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -132,4 +179,9 @@ spec:
             limits:
               cpu: 2522m
               memory: 5Gi
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-proxy-tls-testdsp2
+            defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp2

--- a/controllers/testdata/results/case_3/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_3/apiserver/deployment.yaml
@@ -18,6 +18,53 @@ spec:
         component: data-science-pipelines
     spec:
       containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-testdsp3
+            - --upstream=http://localhost:8888
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp3","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default", "resource": "routes", "resourceName":"ds-pipeline-testdsp3", "verb": "get"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          ports:
+            - containerPort: 8443
+              name: oauth
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -132,4 +179,9 @@ spec:
             limits:
               cpu: 2522m
               memory: 5Gi
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-proxy-tls-testdsp3
+            defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp3


### PR DESCRIPTION
## Description

This change introduces the option for the CR submitter to enable/disable routes for the Apiserver. When the route is enabled, an oauth proxy container is added to the api server and a k8s route is created.

To ensure that all external traffic goes through the route, and all pod-to-pod communications to apiserver go through port 8888 (default), we use a k8s network policy to enforce this behavior.

By allowing pods to communicate to apiserver via port 8888, we can continue provisioning mlpipelines-ui alongside this feature, otherwise the ui would also need to go through oauth proxy.

If the CR submitter switches enableRoute from 'true' to 'false' then the operator will clean up the existing route on the cluster.

## How Has This Been Tested?
Locally and on OCP OSD with: quay.io/hukhan/data-science-pipelines-operator:pull-33
Run unit tests on this pr by cloning the branch and following instructions [here](https://github.com/opendatahub-io/data-science-pipelines-operator#run-tests). 

Deploy on dev cluster with ocp pipelines (logged in as cluster admin): 

```
oc new-project data-science-pipelines-operator
make podman-build podman-push IMG=$YOUR_CONTAINER_REPO
make deploy IMG=$YOUR_CONTAINER_REPO
```

Deploy a sample cr with the updated resource kind: 

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
  namespace: data-science-project
spec: {}
```


By default the field `enableRoute` will be set to `true`.  

Login to the UI,  confirm you can login w/o issues, upload/start a run.

Navigate to the Routes page and fetch the apiserver route, or run: 
```bash
# assuming namespace: data-science-project, and cr name: sample
ROUTE=`https://$(oc get routes -n data-science-project ds-pipeline-sample --template={{.spec.host}})`
```

Curl this route and see if you can by pass the oauth proxy and fetch runs: 

```bash
curl --insecure --location --request GET "${ROUTE}/apis/v1beta1/runs"  --header "Authorization: Bearer $(oc whoami --show-token)"
```

Further testing can include confirming the network policy works. Try curling the service for the api server from another pod that is not deployed by dspo: 

This should fail: 

```
$ oc -n openshift-monitoring rsh alertmanager-main-0
$ curl --location --request GET http://ds-pipeline-sample.data-science-project.svc.cluster.local:8888/apis/v1beta1/runs
```
The above command will succeed if you try it from a dspo component pod, for example the associated persistenceagent pod.

This should succeed: 

```bash
# YOUR_TOKEN == $(oc whoami --show-token)
curl --location --request GET https://ds-pipeline-sample.data-science-project.cluster.local:8443/apis/v1beta1/runs --header 'Authorization: Bearer ${YOUR_TOKEN}' --insecure
```

This also resolves: https://github.com/opendatahub-io/data-science-pipelines-operator/issues/9

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
