### PR TITLE
Create DSPA Status Condition fields

### DIFF
--- a/config/samples/dspa_all_fields.yaml
+++ b/config/samples/dspa_all_fields.yaml
@@ -157,11 +157,11 @@ status:
       lastTransitionTime: '2023-02-02T21:00:00Z'
       reason: MinimumReplicasAvailable
       message: 'some message'
-    - type: MLPIpelinesUIReady
+    - type: UserInterfaceReady
       status: "True"
       observedGeneration: 4
       lastTransitionTime: '2023-02-02T21:00:00Z'
-      reason: MinimumReplicasAvailable  # DeploymentDisabled
+      reason: MinimumReplicasAvailable
       message: 'some message'
     - type: PersistenceAgentReady
       status: "True"
@@ -182,11 +182,11 @@ status:
       status: "True"
       observedGeneration: 4
       lastTransitionTime: '2023-02-02T21:00:00Z'
-      reason: DataBaseUnreachable  # DataBaseFailedToDeploy, DataBaseReady
-      message: '500 gateway error received'
+      reason: DataBaseReady
+      message: ''
     - type: ObjectStorageReady
       status: "True"
       observedGeneration: 4
       lastTransitionTime: '2023-02-02T21:00:00Z'
-      reason: ObjectStorageUnreachable  # ObjectStorageFailedToDeploy, ObjectStorageReady
-      message: 'host unreachable'
+      reason: ObjectStorageReady
+      message: ''

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -63,6 +63,19 @@ const (
 	MariaDBImagePath              = "Images.MariaDB"
 )
 
+const (
+	DatabaseReady               = "DatabaseReady"
+	DataBaseFailedToDeploy      = "DataBaseFailedToDeploy"
+	ObjectStorageReady          = "ObjectStorageReady"
+	ObjectStorageFailedToDeploy = "ObjectStorageFailedToDeploy"
+	APIServerReady              = "APIServerReady"
+	PersistenceAgentReady       = "PersistenceAgentReady"
+	ScheduledWorkflowReady      = "ScheduledWorkflowReady"
+	UserInterfaceReady          = "UserInterfaceReady"
+	CrReady                     = "Ready"
+	MinimumReplicasAvailable    = "MinimumReplicasAvailable"
+)
+
 // Any required Configmap paths can be added here,
 // they will be automatically included for required
 // validation check

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -322,6 +322,8 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	for i, condition := range dspa.Status.Conditions {
 		if condition.Status != conditions[i].Status {
 			conditions[i].LastTransitionTime = metav1.Now()
+		} else {
+			conditions[i].LastTransitionTime = condition.LastTransitionTime
 		}
 	}
 	dspa.Status.Conditions = conditions

--- a/tests/basictests/dsp-operator.sh
+++ b/tests/basictests/dsp-operator.sh
@@ -32,7 +32,30 @@ function create_and_verify_data_science_pipelines_resources() {
     os::cmd::try_until_text "oc get crd -n ${DSPAPROJECT} datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io" "datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io" $odhdefaulttimeout $odhdefaultinterval
     os::cmd::try_until_text "oc -n ${DSPAPROJECT} get pods -l app=ds-pipeline-sample -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
     running_pods=$(oc get pods -n ${DSPAPROJECT} -l component=data-science-pipelines --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w)
+    echo "Sleeping for 5 minutes for the DSPO CR settle up "
+    sleep 5m
     os::cmd::expect_success "if [ "$running_pods" -gt "0" ]; then exit 0; else exit 1; fi"
+}
+
+function check_custom_resource_conditions() {
+    header "Testing Data Science Pipelines Application CR conditions"
+
+    # Check if all CR conditions are good
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[6].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+
+    ## Given general condition is good, is expected that other component conditions are good
+    # DataBaseReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[0].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+    # ObjectStorageReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[1].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+    # ApiServerReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[2].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+    # PersistenceAgentReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[3].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+    # ScheduledWorkflowReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[4].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
+    # UserInterfaceReady
+    os::cmd::try_until_text "oc get -n ${DSPAPROJECT} datasciencepipelinesapplication sample -o jsonpath='{.status.conditions[5].status}'" "True" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function check_data_science_pipeline_route() {
@@ -127,6 +150,7 @@ echo "Testing Data Science Pipelines Operator functionality"
 
 verify_data_science_pipelines_operator_install
 create_and_verify_data_science_pipelines_resources
+check_custom_resource_conditions
 check_data_science_pipeline_route
 setup_monitoring
 test_metrics

--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -42,11 +42,18 @@ fi
 
 echo "Saving the dump of the pods logs in the artifacts directory"
 oc get pods -o yaml -n ${ODHPROJECT} > ${ARTIFACT_DIR}/${ODHPROJECT}.pods.yaml
+oc get pods -o yaml -n data-science-pipelines-test > ${ARTIFACT_DIR}/data-science-pipelines-test.pods.yaml
 oc get pods -o yaml -n openshift-operators > ${ARTIFACT_DIR}/openshift-operators.pods.yaml
 echo "Saving the events in the artifacts directory"
 oc get events --sort-by='{.lastTimestamp}' > ${ARTIFACT_DIR}/${ODHPROJECT}.events.txt
+oc get events --sort-by='{.lastTimestamp}' -n data-science-pipelines-test > ${ARTIFACT_DIR}/data-science-pipelines-test.events.txt
 echo "Saving the logs from the opendatahub-operator pod in the artifacts directory"
 oc logs -n openshift-operators $(oc get pods -n openshift-operators -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/opendatahub-operator.log 2> /dev/null || echo "No logs for openshift-operators/opendatahub-operator"
+echo "Saving the logs from the Data Science Pipelines Operator pods in the artifacts directory"
+for pod in $(oc get pods -n opendatahub -l control-plane=controller-manager -o jsonpath="{$.items[*].metadata.name}");
+do
+    oc logs -n opendatahub $pod > ${ARTIFACT_DIR}/$pod.log;
+done
 
 if [ "$success" -ne 1 ]; then
     exit 1


### PR DESCRIPTION
This PR will introduce DataSciencePipelinesApplication CR Status fields.

## Description
Data Science Pipelines is not an operator that deploys DSP stacks in multiple namespaces. In order to get a complete observation of the stack health, conditions must be implemented.

In this implementation, the following conditions were implemented:

* DatabaseReady
* ObjectStorageReady
* ApiServerReady
* PersistenceAgentReady
* ScheduledWorkflowReady
* UserInterfaceReady
* Ready

Each of these conditions check if the `Available` Deployment condition to verify if the component is ready to use. The last condition is a general condition based on the previous conditions and the way the user created the DSP stack (with external resources or without the UI)

## How Has This Been Tested?
Simply follow the instructions in the readme provided to deploy and test this PR. You will have to substitute the kfdef repo to point to this PR, or use the following if you'd like to use my fork:
```
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
   name: data-science-pipelines-operator
   namespace: ${DSPO_NS}
spec:
   applications:
      - kustomizeConfig:
           repoRef:
              name: manifests
              path: data-science-pipelines-operator/
        name: data-science-pipelines-operator
   repos:
      - name: manifests
        uri: "https://github.com/rimolive/odh-manifests/tarball/rmartine"
```
Run the following command to check if conditions were created:
```
$ oc get datasciencepipelinesapplication example -o jsonpath='{.status.conditions}'
```
Check in the output if all `status` fields have the value `True`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
