### PR TITLE
Add kfdef image parameters.

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: data-science-pipelines-operator
 namePrefix: data-science-pipelines-operator-
 resources:
@@ -6,9 +8,86 @@ resources:
 - ../manager
 - ../prometheus
 - ../configmaps
+
+# Parameterize images via KfDef in ODH
+configMapGenerator:
+  - name: dspo-parameters
+    envs:
+      - params.env
+vars:
+  - name: IMAGES_APISERVER
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_APISERVER
+  - name: IMAGES_ARTIFACT
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_ARTIFACT
+  - name: IMAGES_PERSISTENTAGENT
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_PERSISTENTAGENT
+  - name: IMAGES_SCHEDULEDWORKFLOW
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_SCHEDULEDWORKFLOW
+  - name: IMAGES_VIEWERCRD
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_VIEWERCRD
+  - name: IMAGES_CACHE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_CACHE
+  - name: IMAGES_MOVERESULTSIMAGE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MOVERESULTSIMAGE
+  - name: IMAGES_MLPIPELINEUI
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLPIPELINEUI
+  - name: IMAGES_MARIADB
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MARIADB
+  - name: IMAGES_MINIO
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MINIO
+configurations:
+  - params.yaml
 images:
-- name: controller
-  newName: quay.io/opendatahub/data-science-pipelines-operator
-  newTag: latest
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+  - name: controller
+    newName: quay.io/opendatahub/data-science-pipelines-operator
+    newTag: main

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,0 +1,10 @@
+IMAGES_APISERVER=quay.io/opendatahub/ds-pipelines-api-server:main
+IMAGES_ARTIFACT=quay.io/opendatahub/ds-pipelines-artifact-manager:main
+IMAGES_PERSISTENTAGENT=quay.io/opendatahub/ds-pipelines-persistenceagent:main
+IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
+IMAGES_VIEWERCRD=quay.io/opendatahub/ds-pipelines-viewercontroller:main
+IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
+IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
+IMAGES_MLPIPELINEUI=quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
+IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
+IMAGES_MINIO=quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance

--- a/config/base/params.yaml
+++ b/config/base/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: data
+  kind: ConfigMap
+- path: spec/template/spec/containers[]/env/value
+  kind: Deployment

--- a/config/configmaps/files/config.yaml
+++ b/config/configmaps/files/config.yaml
@@ -1,11 +1,11 @@
 Images:
-  ApiServer: quay.io/opendatahub/ds-pipelines-api-server:main
-  Artifact: quay.io/opendatahub/ds-pipelines-artifact-manager:main
-  PersistentAgent: quay.io/opendatahub/ds-pipelines-persistenceagent:main
-  ScheduledWorkflow: quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
-  ViewerCRD: quay.io/opendatahub/ds-pipelines-viewercontroller:main
-  Cache: registry.access.redhat.com/ubi8/ubi-minimal
-  MoveResultsImage: registry.access.redhat.com/ubi8/ubi-micro
-  MlPipelineUI: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
-  MariaDB: registry.redhat.io/rhel8/mariadb-103:1-188
-  Minio: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+  ApiServer: $(IMAGES_APISERVER)
+  Artifact: $(IMAGES_ARTIFACT)
+  PersistentAgent: $(IMAGES_PERSISTENTAGENT)
+  ScheduledWorkflow: $(IMAGES_SCHEDULEDWORKFLOW)
+  ViewerCRD: $(IMAGES_VIEWERCRD)
+  Cache: $(IMAGES_CACHE)
+  MoveResultsImage: $(IMAGES_MOVERESULTSIMAGE)
+  MlPipelineUI: $(IMAGES_MLPIPELINEUI)
+  MariaDB: $(IMAGES_MARIADB)
+  Minio: $(IMAGES_MINIO)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,26 +38,27 @@ spec:
         image: controller:latest
         name: manager
         env:
+          # Env vars are prioritized over --config
           - name: IMAGES_APISERVER
-            value: quay.io/opendatahub/ds-pipelines-api-server:main
+            value: $(IMAGES_APISERVER)
           - name: IMAGES_ARTIFACT
-            value: quay.io/opendatahub/ds-pipelines-artifact-manager:main
+            value: $(IMAGES_ARTIFACT)
           - name: IMAGES_PERSISTENTAGENT
-            value: quay.io/opendatahub/ds-pipelines-persistenceagent:main
+            value: $(IMAGES_PERSISTENTAGENT)
           - name: IMAGES_SCHEDULEDWORKFLOW
-            value: quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
+            value: $(IMAGES_SCHEDULEDWORKFLOW)
           - name: IMAGES_VIEWERCRD
-            value: quay.io/opendatahub/ds-pipelines-viewercontroller:main
+            value: $(IMAGES_VIEWERCRD)
           - name: IMAGES_CACHE
-            value: registry.access.redhat.com/ubi8/ubi-minimal
+            value: $(IMAGES_CACHE)
           - name: IMAGES_MOVERESULTSIMAGE
-            value: registry.access.redhat.com/ubi8/ubi-micro
+            value: $(IMAGES_MOVERESULTSIMAGE)
           - name: IMAGES_MLPIPELINEUI
-            value: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
+            value: $(IMAGES_MLPIPELINEUI)
           - name: IMAGES_MARIADB
-            value: registry.redhat.io/rhel8/mariadb-103:1-188
+            value: $(IMAGES_MARIADB)
           - name: IMAGES_MINIO
-            value: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+            value: $(IMAGES_MINIO)
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Description
This change will allos a user to deploy dspo via a kfdef and specify image parameters within the kfdef to be used for the DSPA components.



## How Has This Been Tested?
With ODH installed via Olm, deploy this kfdef: 

<details> 

<summary> kfdef.yaml </summary>

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: data-science-pipelines-operator
  namespace: data-science-pipelines-operator
spec:
  applications:
    - kustomizeConfig:
        parameters:
          - name: IMAGES_APISERVER
            value: BLAHBLAH
          - name: IMAGES_ARTIFACT
            value: BLAHBLAH1
          - name: IMAGES_PERSISTENTAGENT
            value: BLAHBLAH2
          - name: IMAGES_SCHEDULEDWORKFLOW
            value: BLAHBLAH3
          - name: IMAGES_VIEWERCRD
            value: BLAHBLAH4
          - name: IMAGES_CACHE
            value: BLAHBLAH5
          - name: IMAGES_MOVERESULTSIMAGE
            value: BLAHBLAH6
          - name: IMAGES_MLPIPELINEUI
            value: BLAHBLAH7
          - name: IMAGES_MARIADB
            value: BLAHBLAH8
          - name: IMAGES_MINIO
            value: BLAHBLAH9
        repoRef:
          name: manifests
          path: config/
      name: data-science-pipelines-operator
  repos:
    - name: manifests
      uri: "https://github.com/HumairAK/data-science-pipelines-operator/tarball/parameterize-kfdef"
```

</details>

Deploy an empty DSPA CR in any namespace, all images should crash because they will have `BLAHBLAH#` (i.e. it consumed the images from the kfdef above). You can cross check the images to see the appropriate images were substituted.

Note that if you update kfdef in-cluster, it will take a while (~3-5 min) for ODH operator to update the deployment, the delay is not due to dspo.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
