### PR TITLE
Use empty cr for e2e tests.

### DIFF
--- a/tests/resources/dsp-operator/test-dspo-cr.yaml
+++ b/tests/resources/dsp-operator/test-dspo-cr.yaml
@@ -2,29 +2,4 @@ apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
 kind: DataSciencePipelinesApplication
 metadata:
   name: sample
-spec:
-  apiServer:
-    # optional (default is: ds-pipeline-artifact-script-${metadata.name} / artifact_script)
-    artifactScriptConfigMap:
-      name: ds-pipeline-artifact-script-sample
-      key: "artifact_script"
-    apiServerImage: quay.io/modh/odh-ml-pipelines-api-server-container:v1.18.0-8
-    artifactImage: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
-  persistentAgent:
-    image: quay.io/modh/odh-ml-pipelines-persistenceagent-container:v1.18.0-8
-    pipelineAPIServerName: apiserver
-  scheduledWorkflow:
-    image: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container:v1.18.0-8
-  viewerCRD:
-    image: quay.io/modh/odh-ml-pipelines-viewercontroller-container:v1.18.0-8
-  mlpipelineUI:
-    image: quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui
-  database:
-    mariaDB:   # mutually exclusive with custom
-      image: registry.redhat.io/rhel8/mariadb-103:1-188
-      username: mlpipeline
-      pipelineDBName: randomDBName
-  objectStorage:
-    minio:  # mutually exclusive with custom
-      image: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
-      bucket: mlpipeline
+spec: {}


### PR DESCRIPTION
## Description
This way we don't need to keep making sure the e2e test cr is upto date with spec. 


## How Has This Been Tested?
It has not, we need it to go into ci here to test: https://github.com/openshift/release/pull/37079

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
