### PR TITLE
Add target ns to make deploy/undeploy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IMG ?= quay.io/opendatahub/data-science-pipelines-operator:main
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 # Namespace to deploy the operator
-OPERATOR_NS ?= data-science-pipelines-operator
+OPERATOR_NS ?= odh-applications
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,11 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/opendatahub/data-science-pipelines-operator:latest
+IMG ?= quay.io/opendatahub/data-science-pipelines-operator:main
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
+# Namespace to deploy the operator
+OPERATOR_NS ?= data-science-pipelines-operator
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -139,11 +141,12 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/base && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/base && $(KUSTOMIZE) edit set image controller=${IMG} &&  $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
 	$(KUSTOMIZE) build config/base | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	cd config/base && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
 	$(KUSTOMIZE) build config/base | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Now we will navigate to the DSPO manifests then build and deploy them to this na
 
 ```bash
 cd ${WORKING_DIR}
-make deploy
+make deploy OPERATOR_NS=${DSPO_NS}
 ```
 
 Confirm the pods are successfully deployed and reach running state:
@@ -313,7 +313,7 @@ To clean up standalone DSPO deployment:
 ```bash
 # WORKING_DIR must be the root of this repository's clone
 cd ${WORKING_DIR}
-make undeploy
+make undeploy OPERATOR_NS=${DSPO_NS}
 oc delete project ${DSPO_NS}
 ```
 

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: data-science-pipelines-operator
+namespace: odh-applications
 namePrefix: data-science-pipelines-operator-
 resources:
 - ../crd


### PR DESCRIPTION
## Description
We do not want to enforce a single namespace for dspo make deploy/undeploy command, user should be free to target whichever namespace with ease. Default ns remains the same.

The change also updates image latest to `main` since we do not have this tag currently and latest changes are going to `main` branch. To keep it `latest` we'll need to consult with our ci expert  @harshad16  and make the necessary changes, for now this will get it working again.

## How Has This Been Tested?
simply run make deploy / make undeploy

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
