### PR TITLE
Add dynamically generated cookie secrets for oauth

### DIFF
--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -27,7 +27,7 @@ spec:
             - --upstream=http://localhost:8888
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-{{.Name}}","namespace":"{{.Namespace}}"}}'
             - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         {{ end }}
         - env:
             - name: POD_NAMESPACE
@@ -195,3 +197,6 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-{{.Name}}
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-{{.Name}}-cookie-secret

--- a/config/internal/apiserver/secret.yaml.tmpl
+++ b/config/internal/apiserver/secret.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ds-pipelines-{{.Name}}-cookie-secret
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-{{.Name}}
+    component: data-science-pipelines
+data:
+  cookie_secret: {{.APIServerOauthProxyCookieSecret}}

--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
             - --upstream=http://localhost:3000
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-{{.Name}}","namespace":"{{.Namespace}}"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
               value: /etc/config/viewer-pod-template.json
@@ -150,3 +152,6 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-ui-proxy-tls-{{.Name}}
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-ui-{{.Name}}-cookie-secret

--- a/config/internal/mlpipelines-ui/secret.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/secret.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ds-pipelines-ui-{{.Name}}-cookie-secret
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-ui-{{.Name}}
+    component: data-science-pipelines
+data:
+  cookie_secret: {{.MlPipelineUIOauthProxyCookieSecret}}

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -115,6 +115,21 @@ func (r *DSPAReconciler) DeleteResourceIfItExists(ctx context.Context, obj clien
 	return err
 }
 
+func (r *DSPAReconciler) CreateIfDoesNotItExists(ctx context.Context, obj client.Object, nn types.NamespacedName,
+	params *DSPAParams, path string, dsp *dspav1alpha1.DataSciencePipelinesApplication) error {
+	err := r.Get(ctx, nn, obj)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			err := r.Apply(dsp, params, path)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}
+
 //+kubebuilder:rbac:groups=datasciencepipelinesapplications.opendatahub.io,resources=datasciencepipelinesapplications,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=datasciencepipelinesapplications.opendatahub.io,resources=datasciencepipelinesapplications/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=datasciencepipelinesapplications.opendatahub.io,resources=datasciencepipelinesapplications/finalizers,verbs=update
@@ -232,7 +247,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	err = r.ReconcileUI(dspa, params)
+	err = r.ReconcileUI(ctx, dspa, params)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -33,17 +33,19 @@ import (
 )
 
 type DSPAParams struct {
-	Name                 string
-	Namespace            string
-	Owner                mf.Owner
-	APIServer            *dspa.APIServer
-	APIServerServiceName string
-	ScheduledWorkflow    *dspa.ScheduledWorkflow
-	ViewerCRD            *dspa.ViewerCRD
-	PersistenceAgent     *dspa.PersistenceAgent
-	MlPipelineUI         *dspa.MlPipelineUI
-	MariaDB              *dspa.MariaDB
-	Minio                *dspa.Minio
+	Name                               string
+	Namespace                          string
+	Owner                              mf.Owner
+	APIServer                          *dspa.APIServer
+	APIServerServiceName               string
+	APIServerOauthProxyCookieSecret    string
+	ScheduledWorkflow                  *dspa.ScheduledWorkflow
+	ViewerCRD                          *dspa.ViewerCRD
+	PersistenceAgent                   *dspa.PersistenceAgent
+	MlPipelineUI                       *dspa.MlPipelineUI
+	MlPipelineUIOauthProxyCookieSecret string
+	MariaDB                            *dspa.MariaDB
+	Minio                              *dspa.Minio
 	DBConnection
 	ObjectStorageConnection
 }
@@ -367,6 +369,9 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 
 		setResourcesDefault(config.APIServerResourceRequirements, &p.APIServer.Resources)
 
+		generatedPass := passwordGen(32)
+		p.APIServerOauthProxyCookieSecret = base64.StdEncoding.EncodeToString([]byte(generatedPass))
+
 		if p.APIServer.ArtifactScriptConfigMap == nil {
 			p.APIServer.ArtifactScriptConfigMap = &dspa.ArtifactScriptConfigMap{
 				Name: config.ArtifactScriptConfigMapNamePrefix + dsp.Name,
@@ -390,6 +395,9 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 		p.MlPipelineUI.Image = config.GetStringConfigWithDefault(config.MlPipelineUIImagePath, config.DefaultImageValue)
 		setStringDefault(config.MLPipelineUIConfigMapPrefix+dsp.Name, &p.MlPipelineUI.ConfigMapName)
 		setResourcesDefault(config.MlPipelineUIResourceRequirements, &p.MlPipelineUI.Resources)
+
+		generatedPass := passwordGen(32)
+		p.MlPipelineUIOauthProxyCookieSecret = base64.StdEncoding.EncodeToString([]byte(generatedPass))
 	}
 
 	err := p.SetupDBParams(ctx, dsp, client, log)

--- a/controllers/testdata/results/case_0/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_0/apiserver/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - --upstream=http://localhost:8888
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp0","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp0","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -183,5 +185,9 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-testdsp0
+            defaultMode: 420
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-testdsp0-cookie-secret
             defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp0

--- a/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_0/mlpipelines-ui/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - --upstream=http://localhost:3000
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp0","namespace":"default"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
@@ -66,6 +66,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
               value: /etc/config/viewer-pod-template.json
@@ -142,4 +144,8 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-ui-proxy-tls-testdsp0
+            defaultMode: 420
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-ui-testdsp0-cookie-secret
             defaultMode: 420

--- a/controllers/testdata/results/case_2/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_2/apiserver/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - --upstream=http://localhost:8888
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp2","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp2","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -183,5 +185,9 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-testdsp2
+            defaultMode: 420
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-testdsp2-cookie-secret
             defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp2

--- a/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - --upstream=http://localhost:3000
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp2","namespace":"default"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
@@ -66,6 +66,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
               value: /etc/config/viewer-pod-template.json
@@ -142,4 +144,8 @@ spec:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-ui-proxy-tls-testdsp2
+            defaultMode: 420
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-ui-testdsp2-cookie-secret
             defaultMode: 420

--- a/controllers/testdata/results/case_3/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_3/apiserver/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - --upstream=http://localhost:8888
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
-            - --cookie-secret=SECRET
+            - --cookie-secret-file=/etc/oauth/config/cookie_secret
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp3","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default", "resource": "routes", "resourceName":"ds-pipeline-testdsp3", "verb": "get"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
@@ -65,6 +65,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls
+            - mountPath: /etc/oauth/config
+              name: cookie-secret
         - env:
             - name: POD_NAMESPACE
               value: "default"
@@ -184,4 +186,8 @@ spec:
           secret:
             secretName: ds-pipelines-proxy-tls-testdsp3
             defaultMode: 420
-      serviceAccountName: ds-pipeline-testdsp3
+        - name: cookie-secret
+          secret:
+            secretName: ds-pipelines-ui-testdsp3-cookie-secret
+            defaultMode: 420
+      serviceAccountName: ds-pipeline-testdsp2


### PR DESCRIPTION
## Description
Follow up to: https://github.com/opendatahub-io/data-science-pipelines-operator/pull/34#discussion_r1129907202

## How Has This Been Tested?
Tested locally and live on ocp. Simply run `make deploy IMG=$PR_BUILD` and test oauth proxy.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
