### PR TITLE
add kubebuilder validation markers for DSPA

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -59,6 +59,7 @@ type APIServer struct {
 	// +kubebuilder:default:=true
 	// +optional
 	StripEOF bool `json:"stripEOF"`
+	// +kubebuilder:validation:Enum=Cancelled;StoppedRunFinally;CancelledRunFinally
 	// +kubebuilder:default:=Cancelled
 	TerminateStatus string `json:"terminateStatus,omitempty"`
 	// +kubebuilder:default:=true

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -105,6 +105,10 @@ spec:
                     type: boolean
                   terminateStatus:
                     default: Cancelled
+                    enum:
+                    - Cancelled
+                    - StoppedRunFinally
+                    - CancelledRunFinally
                     type: string
                   trackArtifacts:
                     default: true


### PR DESCRIPTION
## Description
add kubebuilder validation markers for DSPA. There's currently only one field that's validate-able via simple markers.

## How Has This Been Tested?
Deploy to a cluster and try to set something not in the enum, and it works as expected

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
