### PR TITLE
Rename test pipeline.

### DIFF
--- a/tests/resources/dsp-operator/test-pipeline-run.yaml
+++ b/tests/resources/dsp-operator/test-pipeline-run.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: conditional-execution-pipeline
+  name: conditional-execution-pipeline-test
   annotations:
     tekton.dev/output_artifacts: '{"flip-coin": [{"key": "artifacts/$PIPELINERUN/flip-coin/Output.tgz",
       "name": "flip-coin-Output", "path": "/tmp/outputs/Output/data"}], "random-num":


### PR DESCRIPTION
The current upstream image has a pipeline named the same, so we cannot use this for ci testing, we will get null.