### PR TITLE
Correct secret generation for external secrets.

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -144,11 +144,12 @@ type MariaDB struct {
 }
 
 type ExternalDB struct {
-	Host           string          `json:"host,omitempty"`
-	Port           string          `json:"port,omitempty"`
-	Username       string          `json:"username,omitempty"`
-	DBName         string          `json:"pipelineDBName,omitempty"`
-	PasswordSecret *SecretKeyValue `json:"passwordSecret,omitempty"`
+	// +kubebuilder:validation:Required
+	Host           string          `json:"host"`
+	Port           string          `json:"port"`
+	Username       string          `json:"username"`
+	DBName         string          `json:"pipelineDBName"`
+	PasswordSecret *SecretKeyValue `json:"passwordSecret"`
 }
 
 type ObjectStorage struct {
@@ -186,22 +187,24 @@ type Resources struct {
 type ExternalStorage struct {
 	// +kubebuilder:validation:Required
 	Host                string `json:"host"`
-	Port                string `json:"port"`
 	Bucket              string `json:"bucket"`
 	Scheme              string `json:"scheme"`
+	Port                string `json:"port"`
 	*S3CredentialSecret `json:"s3CredentialsSecret"`
 }
 
 type S3CredentialSecret struct {
-	SecretName string `json:"secretName,omitempty"`
+	// +kubebuilder:validation:Required
+	SecretName string `json:"secretName"`
 	// The "Keys" in the k8sSecret key/value pairs. Not to be confused with the values.
-	AccessKey string `json:"accessKey,omitempty"`
-	SecretKey string `json:"secretKey,omitempty"`
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
 }
 
 type SecretKeyValue struct {
-	Name string `json:"name,omitempty"`
-	Key  string `json:"key,omitempty"`
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+	Key  string `json:"key"`
 }
 
 type DSPAStatus struct {

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -125,6 +125,9 @@ spec:
                             type: string
                           name:
                             type: string
+                        required:
+                        - key
+                        - name
                         type: object
                       pipelineDBName:
                         type: string
@@ -132,6 +135,12 @@ spec:
                         type: string
                       username:
                         type: string
+                    required:
+                    - host
+                    - passwordSecret
+                    - pipelineDBName
+                    - port
+                    - username
                     type: object
                   mariaDB:
                     properties:
@@ -146,6 +155,9 @@ spec:
                             type: string
                           name:
                             type: string
+                        required:
+                        - key
+                        - name
                         type: object
                       pipelineDBName:
                         default: mlpipeline
@@ -233,6 +245,10 @@ spec:
                             type: string
                           secretName:
                             type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
                         type: object
                       scheme:
                         type: string
@@ -288,6 +304,10 @@ spec:
                             type: string
                           secretName:
                             type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
                         type: object
                     required:
                     - image

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -29,13 +29,14 @@ const (
 	ArtifactScriptConfigMapKey        = "artifact_script"
 	DSPServicePrefix                  = "ds-pipeline"
 
-	MariaDBName             = "mlpipeline"
-	MariaDBHostPrefix       = "mariadb"
-	MariaDBHostPort         = "3306"
-	MariaDBUser             = "mlpipeline"
-	MariaDBSecretNamePrefix = "mariadb-"
-	MariaDBSecretKey        = "password"
-	MariaDBNamePVCSize      = "10Gi"
+	DBSecretNamePrefix = "ds-pipeline-db-"
+	DBSecretKey        = "password"
+
+	MariaDBName        = "mlpipeline"
+	MariaDBHostPrefix  = "mariadb"
+	MariaDBHostPort    = "3306"
+	MariaDBUser        = "mlpipeline"
+	MariaDBNamePVCSize = "10Gi"
 
 	MinioHostPrefix    = "minio"
 	MinioPort          = "9000"

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -197,22 +197,14 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	usingCustomDB := params.UsingExternalDB(dspa)
-
-	if !usingCustomDB {
-		err = r.ReconcileDatabase(ctx, dspa, params)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+	err = r.ReconcileDatabase(ctx, dspa, params)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	usingCustomStorage := params.UsingExternalStorage(dspa)
-
-	if !usingCustomStorage {
-		err := r.ReconcileStorage(ctx, dspa, params)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+	err = r.ReconcileStorage(ctx, dspa, params)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	err = r.ReconcileCommon(dspa, params)

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -106,8 +106,8 @@ func (p *DSPAParams) SetupDBParams(ctx context.Context, dsp *dspa.DataSciencePip
 
 	// Even if a secret is specified DSPO will deploy its own secret owned by DSPO
 	p.DBConnection.CredentialsSecret = &dspa.SecretKeyValue{
-		Name: config.MariaDBSecretNamePrefix + p.Name,
-		Key:  config.MariaDBSecretKey,
+		Name: config.DBSecretNamePrefix + p.Name,
+		Key:  config.DBSecretKey,
 	}
 
 	if usingExternalDB {
@@ -118,7 +118,6 @@ func (p *DSPAParams) SetupDBParams(ctx context.Context, dsp *dspa.DataSciencePip
 		p.DBConnection.DBName = dsp.Spec.Database.ExternalDB.DBName
 		customCreds = dsp.Spec.Database.ExternalDB.PasswordSecret
 	} else {
-
 		// If no externalDB or mariaDB is specified, DSPO assumes
 		// MariaDB deployment with defaults.
 		if p.MariaDB == nil {
@@ -261,12 +260,14 @@ func (p *DSPAParams) SetupObjectParams(ctx context.Context, dsp *dspa.DataScienc
 		}
 	}
 
-	p.ObjectStorageConnection.Endpoint = fmt.Sprintf(
+	endpoint := fmt.Sprintf(
 		"%s://%s:%s",
 		p.ObjectStorageConnection.Scheme,
 		p.ObjectStorageConnection.Host,
 		p.ObjectStorageConnection.Port,
 	)
+
+	p.ObjectStorageConnection.Endpoint = endpoint
 
 	// Secret where DB credentials reside on cluster
 	var credsSecretName string

--- a/controllers/testdata/deploy/case_3/cr.yaml
+++ b/controllers/testdata/deploy/case_3/cr.yaml
@@ -4,98 +4,30 @@ metadata:
   name: testdsp3
 spec:
   apiServer:
+    enableOauth: true
     artifactScriptConfigMap:
       name: doesnotexist
       key: "somekey"
     deploy: true
-    image: api-server:test3
-    applyTektonCustomResource: true
-    archiveLogs: false
-    artifactImage: artifact-manager:test3
-    cacheImage: ubi-minimal:test3
-    moveResultsImage: busybox:test3
-    injectDefaultScript: true
-    stripEOF: true
-    terminateStatus: Cancelled
-    trackArtifacts: true
-    dbConfigConMaxLifetimeSec: 125
-    collectMetrics: true
-    autoUpdatePipelineDefaultVersion: true
-    resources:
-      requests:
-        cpu: "1231m"
-        memory: "1Gi"
-      limits:
-        cpu: "2522m"
-        memory: "5Gi"
-  persistenceAgent:
-    deploy: true
-    image: persistenceagent:test3
-    numWorkers: 5
-    resources:
-      requests:
-        cpu: "1233m"
-        memory: "1Gi"
-      limits:
-        cpu: "2524m"
-        memory: "5Gi"
-  scheduledWorkflow:
-    deploy: true
-    image: scheduledworkflow:test3
-    cronScheduleTimezone: EST
-    resources:
-      requests:
-        cpu: "1235m"
-        memory: "1Gi"
-      limits:
-        cpu: "2526m"
-        memory: "5Gi"
-  viewerCRD:
-    deploy: true
-    image: viewercontroller:test3
-    maxNumViewer: 25
-    resources:
-      requests:
-        cpu: "1237m"
-        memory: "1Gi"
-      limits:
-        cpu: "2528m"
-        memory: "5Gi"
-  mlpipelineUI:
-    deploy: true
-    image: frontend:test3
-    configMap: some-test-configmap
-    resources:
-      requests:
-        cpu: "1239m"
-        memory: "1Gi"
-      limits:
-        cpu: "2530m"
-        memory: "5Gi"
+  persistenceAgent: {}
+  scheduledWorkflow: {}
+  viewerCRD: {}
   database:
-    mariaDB:
-      deploy: true
-      image: mariadb:test3
-      username: testuser
-      pipelineDBName: randomDBName
-      pvcSize: 32Gi
-      resources:
-        requests:
-          cpu: "1212m"
-          memory: "1Gi"
-        limits:
-          cpu: "2554m"
-          memory: "5Gi"
+    externalDB:
+      host: testdbhost3
+      passwordSecret:
+        key: testpswkey3
+        name: testdbpswsecretname3
+      pipelineDBName: testdbname3
+      port: test3
+      username: testuser3
   objectStorage:
-    minio:
-      deploy: true
-      image: minio:test3
-      bucket: mlpipeline
-      pvcSize: 40Gi
-      resources:
-        requests:
-          cpu: "1334m"
-          memory: "1Gi"
-        limits:
-          cpu: "2535m"
-          memory: "5Gi"
+    externalStorage:
+      port: '80'
+      bucket: testbucket3
+      host: teststoragehost3
+      s3CredentialsSecret:
+        accessKey: testaccesskey3
+        secretKey: testsecretkey3
+        secretName: teststoragesecretname3
+      scheme: https

--- a/controllers/testdata/deploy/case_3/secret1.yaml
+++ b/controllers/testdata/deploy/case_3/secret1.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: testdbpswsecretname3
+stringData:
+  testpswkey3: testdbsecretpswvalue3
+type: Opaque

--- a/controllers/testdata/deploy/case_3/secret2.yaml
+++ b/controllers/testdata/deploy/case_3/secret2.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: teststoragesecretname3
+stringData:
+  testaccesskey3: testaccesskeyvalue3
+  testsecretkey3: testsecretkeyvalue3
+type: Opaque

--- a/controllers/testdata/results/case_0/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_0/apiserver/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: "password"
-                  name: "mariadb-testdsp0"
+                  name: "ds-pipeline-db-testdsp0"
             - name: DBCONFIG_DBNAME
               value: "mlpipeline"
             - name: DBCONFIG_HOST

--- a/controllers/testdata/results/case_0/mariadb/deployment.yaml
+++ b/controllers/testdata/results/case_0/mariadb/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: "password"
-                  name: "mariadb-testdsp0"
+                  name: "ds-pipeline-db-testdsp0"
             - name: MYSQL_DATABASE
               value: "mlpipeline"
             - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/controllers/testdata/results/case_2/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_2/apiserver/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: "password"
-                  name: "mariadb-testdsp2"
+                  name: "ds-pipeline-db-testdsp2"
             - name: DBCONFIG_DBNAME
               value: "randomDBName"
             - name: DBCONFIG_HOST

--- a/controllers/testdata/results/case_2/mariadb/deployment.yaml
+++ b/controllers/testdata/results/case_2/mariadb/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: "password"
-                  name: "mariadb-testdsp2"
+                  name: "ds-pipeline-db-testdsp2"
             - name: MYSQL_DATABASE
               value: "randomDBName"
             - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/controllers/testdata/results/case_3/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_3/apiserver/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp3","namespace":"default"}}'
-            - '--openshift-sar={"namespace":"default", "resource": "routes", "resourceName":"ds-pipeline-testdsp3", "verb": "get"}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp3","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:
@@ -69,55 +69,55 @@ spec:
             - name: POD_NAMESPACE
               value: "default"
             - name: DBCONFIG_USER
-              value: "testuser"
+              value: "testuser3"
             - name: DBCONFIG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: "password"
-                  name: "mariadb-testdsp3"
+                  name: "ds-pipeline-db-testdsp3"
             - name: DBCONFIG_DBNAME
-              value: "randomDBName"
+              value: "testdbname3"
             - name: DBCONFIG_HOST
-              value: "mariadb-testdsp3.default.svc.cluster.local"
+              value: "testdbhost3"
             - name: DBCONFIG_PORT
-              value: "3306"
+              value: "test3"
             - name: ARTIFACT_BUCKET
-              value: "mlpipeline"
+              value: "testbucket3"
             - name: ARTIFACT_ENDPOINT
-              value: "http://minio-testdsp3.default.svc.cluster.local:9000"
+              value: "https://teststoragehost3:80"
             - name: ARTIFACT_SCRIPT
               valueFrom:
                 configMapKeyRef:
-                  key: "artifact_script"
-                  name: "ds-pipeline-artifact-script-testdsp3"
+                  key: "somekey"
+                  name: "doesnotexist"
             - name: ARTIFACT_IMAGE
               value: artifact-manager:test3
             - name: ARCHIVE_LOGS
               value: "false"
             - name: TRACK_ARTIFACTS
-              value: "true"
+              value: "false"
             - name: STRIP_EOF
-              value: "true"
+              value: "false"
             - name: PIPELINE_RUNTIME
               value: "tekton"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp3"
             - name: INJECT_DEFAULT_SCRIPT
-              value: "true"
+              value: "false"
             - name: APPLY_TEKTON_CUSTOM_RESOURCE
-              value: "true"
+              value: "false"
             - name: TERMINATE_STATUS
               value: "Cancelled"
             - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
-              value: "true"
+              value: "false"
             - name: DBCONFIG_CONMAXLIFETIMESEC
-              value: "125"
+              value: "120"
             - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
               value: "ds-pipeline-visualizationserver"
             - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
               value: "8888"
             - name: OBJECTSTORECONFIG_BUCKETNAME
-              value: "mlpipeline"
+              value: "testbucket3"
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
                 secretKeyRef:
@@ -131,9 +131,9 @@ spec:
             - name: OBJECTSTORECONFIG_SECURE
               value: "false"
             - name: MINIO_SERVICE_SERVICE_HOST
-              value: "minio-testdsp3.default.svc.cluster.local"
+              value: "teststoragehost3"
             - name: MINIO_SERVICE_SERVICE_PORT
-              value: "9000"
+              value: "80"
             - name: CACHE_IMAGE
               value: ubi-minimal:test3
             - name: MOVERESULTS_IMAGE
@@ -174,11 +174,11 @@ spec:
             timeoutSeconds: 2
           resources:
             requests:
-              cpu: 1231m
-              memory: 1Gi
+              cpu: 250m
+              memory: 500Mi
             limits:
-              cpu: 2522m
-              memory: 5Gi
+              cpu: 500m
+              memory: 1Gi
       volumes:
         - name: proxy-tls
           secret:

--- a/controllers/testdata/results/case_3/database/secret.yaml
+++ b/controllers/testdata/results/case_3/database/secret.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ds-pipeline-db-testdsp3
+  namespace: default
+  labels:
+    app: mariadb-extrenal-storage
+    component: data-science-pipelines
+data:
+  password: dGVzdGRic2VjcmV0cHN3dmFsdWUz
+type: Opaque

--- a/controllers/testdata/results/case_3/storage/secret.yaml
+++ b/controllers/testdata/results/case_3/storage/secret.yaml
@@ -1,0 +1,15 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mlpipeline-minio-artifact
+  namespace: default
+  labels:
+    app: minio-extrenal-storage
+    component: data-science-pipelines
+data:
+  accesskey: dGVzdGFjY2Vzc2tleXZhbHVlMw==
+  host: dGVzdHN0b3JhZ2Vob3N0Mw==
+  port: ODA=
+  secretkey: dGVzdHNlY3JldGtleXZhbHVlMw==
+  secure: ZmFsc2U=
+type: Opaque

--- a/controllers/testutil/util.go
+++ b/controllers/testutil/util.go
@@ -40,6 +40,19 @@ func ConfigMapsAreEqual(expected v1.ConfigMap, actual v1.ConfigMap) bool {
 	return true
 }
 
+func SecretsAreEqual(expected v1.Secret, actual v1.Secret) bool {
+	if expected.Name != actual.Name {
+		notEqualMsg("Secret Names are not equal.")
+		return false
+	}
+
+	if !reflect.DeepEqual(expected.Data, actual.Data) {
+		notEqualMsg("Secret's Data values")
+		return false
+	}
+	return true
+}
+
 func DeploymentsAreEqual(expectedDep appsv1.Deployment, actualDep appsv1.Deployment) bool {
 
 	if !reflect.DeepEqual(expectedDep.ObjectMeta.Labels, actualDep.ObjectMeta.Labels) {


### PR DESCRIPTION
## Description

This change will fix external secret configuration, such that when a secret is provided for external db/storage, the appropriate internal DSPO managed secrets are created.

Summary of changes: 
* Made externaldb fields required 
* made db secret non mariadb specific (to account for externaldb)
* allow deployment of storage/db secrets for external options 
* disable minio deployment by default 
* add tests 

## How Has This Been Tested?

Deploy dspo from this image: quay.io/opendatahub/data-science-pipelines-operator:pr-51

`make install && make deploy IMG=quay.io/opendatahub/data-science-pipelines-operator:pr-51` on this branch.


Tested with external mariadb/minio on ocp live.

Create your external mariadb/minio db deployments using this tool: https://github.com/HumairAK/dspo-external-connection-devenv 

Follow readme, it will spit out a DSPA cr + mariadb/minio creds to connect externally to test out that this works.


## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
