### PR TITLE
Add ability to parmaterize dspo image via kfdef.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,13 +141,15 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/base && $(KUSTOMIZE) edit set image controller=${IMG} &&  $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/base | kubectl apply -f -
+	cd config/overlays/make-deploy \
+		&& $(KUSTOMIZE) edit set image controller=${IMG} \
+		&& $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
+	$(KUSTOMIZE) build config/overlays/make-deploy # | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	cd config/base && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/base | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	cd config/overlays/make-deploy && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
+	$(KUSTOMIZE) build config/overlays/make-deploy | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -71,9 +71,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.IMAGES_MARIADB
+  - name: IMAGES_DSPO
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_DSPO
 configurations:
   - params.yaml
-images:
-  - name: controller
-    newName: quay.io/opendatahub/data-science-pipelines-operator
-    newTag: main

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -6,3 +6,4 @@ IMAGES_VIEWERCRD=quay.io/opendatahub/ds-pipelines-viewercontroller:main
 IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
 IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
+IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:main

--- a/config/base/params.yaml
+++ b/config/base/params.yaml
@@ -3,3 +3,5 @@ varReference:
   kind: ConfigMap
 - path: spec/template/spec/containers[]/env/value
   kind: Deployment
+- path: spec/template/spec/containers[]/image
+  kind: Deployment

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         - --leader-elect
         - --config
         - /home/config
-        image: controller:latest
+        image: $(IMAGES_DSPO)
         name: manager
         env:
           # Env vars are prioritized over --config

--- a/config/overlays/make-deploy/img_patch.yaml
+++ b/config/overlays/make-deploy/img_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-science-pipelines-operator-controller-manager
+  namespace: odh-applications
+spec:
+  template:
+    spec:
+      containers:
+        - image: controller
+          name: manager

--- a/config/overlays/make-deploy/kustomization.yaml
+++ b/config/overlays/make-deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: odh-applications
+resources:
+- ../../base
+patchesStrategicMerge:
+- img_patch.yaml
+images:
+- name: controller
+  newName: quay.io/opendatahub/data-science-pipelines-operator
+  newTag: main


### PR DESCRIPTION
## Description
This will allow us to sub in PR images during ci testing into kfdefs.

## How Has This Been Tested?
Build the following kfdef: 
```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: ds-pipelines-operator
  namespace: odh-applications
spec:
  applications:
  - kustomizeConfig:
      parameters:
        - name: IMAGES_DSPO
          value: quay.io/opendatahub/data-science-pipelines-operator:blah
      repoRef:
        name: manifests
        path: config/
    name: data-science-pipelines-operator
  repos:
  - name: manifests
    uri: https://github.com/HumairAK/data-science-pipelines-operator/tarball/parameterize-image
  version: master
```

`kfctl build -f above_file.yaml` then do a `kustomize build...` on the resulting `kustomize` folder.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
