### PR TITLE
Patch pull request image for e2e tests

### DIFF
--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -46,6 +46,8 @@ pushd ~/kfdef
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, not modifying kfctl_openshift.yaml"
 else
+  IMAGE_TAG=${IMAGE_TAG:-"quay.io/opendatahub/data-science-pipelines-operator:pr-$PULL_NUMBER"}
+  sed -i "s#value: quay.io/opendatahub/data-science-pipelines-operator:latest#value: $IMAGE_TAG" ./kfctl_openshift.yaml
   if [ $REPO_NAME == $ODHREPO ]; then
     echo "Setting manifests in kfctl_openshift to use pull number: $PULL_NUMBER"
     sed -i "s#uri: https://github.com/opendatahub-io/${ODHREPO}/tarball/main#uri: https://api.github.com/repos/opendatahub-io/${ODHREPO}/tarball/pull/${PULL_NUMBER}/head#" ./kfctl_openshift.yaml

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -22,6 +22,9 @@ spec:
       repoRef:
         name: app
         path: config
+      parameters:
+        - name: IMAGES_DSPO
+          value: quay.io/opendatahub/data-science-pipelines-operator:latest
     name: data-science-pipelines-operator
   repos:
   - name: manifests


### PR DESCRIPTION
Patch pull request image for e2e tests

## Description

This would allow e2e tests to patch the image of dspo controller with the image of PR build image.
Depends-On: https://github.com/opendatahub-io/data-science-pipelines-operator/pull/60

## How Has This Been Tested?

This is not tested, as pr tests need to be done on PR itself.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
