### PR TITLE
Match the change with odh-manifests tests for consistency

### DIFF
--- a/tests/basictests/dsp-operator.sh
+++ b/tests/basictests/dsp-operator.sh
@@ -19,8 +19,8 @@ function verify_data_science_pipelines_operator_install() {
     os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
 
     os::cmd::expect_success_and_text "oc get deployment -n ${ODHPROJECT} data-science-pipelines-operator-controller-manager" "data-science-pipelines-operator-controller-manager"
-    runningpods=($(oc get pods -n ${ODHPROJECT} --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
-    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "3"
+    runningpods=($(oc get pods -n ${ODHPROJECT} --field-selector="status.phase=Running" | grep data-science-pipelines-operator | wc -l))
+    os::cmd::expect_success_and_text "echo $runningpods" "3"
 }
 
 function create_and_verify_data_science_pipelines_resources() {


### PR DESCRIPTION
Match the change with odh-manifests tests for consistency

## Description

With this PR,
the controller pods are explicitly checked, as in odh-manifests there multiple components installed and it cant be assumed only DSPO is installed on the namespace.
To have consistency we are including the same changes here.
https://github.com/opendatahub-io/odh-manifests/blob/master/tests/basictests/dsp-operator.sh

## How Has This Been Tested?

Already tested in odh-manifests.
```
cd tests
make build
make run
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
