### PR TITLE
Fix the sed termination for patch of images

### DIFF
--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -47,7 +47,7 @@ if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, not modifying kfctl_openshift.yaml"
 else
   IMAGE_TAG=${IMAGE_TAG:-"quay.io/opendatahub/data-science-pipelines-operator:pr-$PULL_NUMBER"}
-  sed -i "s#value: quay.io/opendatahub/data-science-pipelines-operator:latest#value: $IMAGE_TAG" ./kfctl_openshift.yaml
+  sed -i "s#value: quay.io/opendatahub/data-science-pipelines-operator:latest#value: $IMAGE_TAG#" ./kfctl_openshift.yaml
   if [ $REPO_NAME == $ODHREPO ]; then
     echo "Setting manifests in kfctl_openshift to use pull number: $PULL_NUMBER"
     sed -i "s#uri: https://github.com/opendatahub-io/${ODHREPO}/tarball/main#uri: https://api.github.com/repos/opendatahub-io/${ODHREPO}/tarball/pull/${PULL_NUMBER}/head#" ./kfctl_openshift.yaml


### PR DESCRIPTION
Fix the sed termination for a patch of images

## Description

The sed termination is required for a proper patch of the image.
Related-to: #61 

## How Has This Been Tested?

Ran sed operation on the kfdef
`sed -i "s#value: quay.io/opendatahub/data-science-pipelines-operator:latest#value: $IMAGE_TAG#" tests/setup/kfctl_openshift.yaml`


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
