### PR TITLE
Fix commented-out command in Makefile deploy func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/overlays/make-deploy \
 		&& $(KUSTOMIZE) edit set image controller=${IMG} \
 		&& $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/overlays/make-deploy # | kubectl apply -f -
+	$(KUSTOMIZE) build config/overlays/make-deploy | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
## Description
fixing kubectl apply command that appears to be accidentally commented-out

## How Has This Been Tested?
run `make deploy OPERATOR_NS=odh-applications` and verify operator is actually deployed via `oc get po -n odh-applications`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
