### PR TITLE
Adding a DSPA ServiceMonitor template

### DIFF
--- a/config/crd/external/monitoring.coreos.com_servicemonitors.yaml
+++ b/config/crd/external/monitoring.coreos.com_servicemonitors.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - endpoints
+                - selector
+              properties:
+                endpoints:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - path
+                      - port
+                    properties:
+                      path:
+                        type: string
+                      port:
+                        type: string
+                  minItems: 1
+                selector:
+                  type: object
+                  properties:
+                    matchLabels:
+                      type: object
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+  scope: Namespaced
+  names:
+    plural: servicemonitors
+    singular: servicemonitor
+    kind: ServiceMonitor

--- a/config/internal/apiserver/monitor.yaml.tmpl
+++ b/config/internal/apiserver/monitor.yaml.tmpl
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: ds-pipeline-{{.Name}}
+    component: data-science-pipelines
+  name: ds-pipeline-{{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+  selector:
+    matchLabels:
+      app: ds-pipeline-{{.Name}}
+      component: data-science-pipelines

--- a/config/internal/common/policy.yaml.tmpl
+++ b/config/internal/common/policy.yaml.tmpl
@@ -19,6 +19,9 @@ spec:
     # by bypassing oauth proxy, all external
     # traffic should go through oauth proxy
     - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-user-workload-monitoring
         - podSelector:
             matchLabels:
               app: mariadb-{{.Name}}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -155,6 +155,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -32,6 +32,7 @@ var apiServerTemplates = []string{
 	"apiserver/sa_pipeline-runner.yaml.tmpl",
 	"apiserver/service.yaml.tmpl",
 	"apiserver/deployment.yaml.tmpl",
+	"apiserver/monitor.yaml.tmpl",
 }
 
 // serverRoute is a resource deployed conditionally

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -139,6 +139,7 @@ func (r *DSPAReconciler) DeleteResourceIfItExists(ctx context.Context, obj clien
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=image.openshift.io,resources=imagestreamtags,verbs=get
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;list
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("namespace", req.Namespace)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a Service Monitor template to procure DSP Application metrics
Also added a CRD for ServiceMonitor because the unit tests run in a fake local K8s cluster which doesn't have the `monitoring.coreos.com/v1` APIVersion.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `make deploy` with these changes
Created a DSP Application in a separate namespace. 
Checked if a ServiceMonitor named `ds-pipelines-samples` came up.
Checked that specifically Data Science Pipelines Application metrics were scraped.
Metrics were found to be scraped by Prometheus: 
![image](https://user-images.githubusercontent.com/46318816/227324491-05262079-d6a7-44a7-960e-6be60e486dda.png)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
