### PR TITLE
Make sure user has same access via cli and UI

### DIFF
--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -30,6 +30,7 @@ spec:
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-{{.Name}}","namespace":"{{.Namespace}}"}}'
+            - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-ui-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:

--- a/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
+++ b/controllers/testdata/results/case_2/mlpipelines-ui/deployment.yaml
@@ -30,6 +30,7 @@ spec:
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp2","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-ui-testdsp2","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
           ports:


### PR DESCRIPTION
Make sure user has same access via cli and UI

## Description

Without the openshift-SAR, a user with access to the cluster can access the Routes
with the openshift-sar check in place, user needs to have access of the route in an rbac, to access the routes.

## How Has This Been Tested?

Deploy the PR on the cluster.
Trying access with user with zero permission , the UI and via the curl command,
both would have same behaviour


## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
