### PR TITLE
Rename the component to respect name-prefix

### DIFF
--- a/config/manager/manager-service.yaml
+++ b/config/manager/manager-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: data-science-pipelines-operator
+  name: service
   labels:
     control-plane: controller-manager
 spec:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: data-science-pipelines-operator-monitor
+  name: service-monitor
   namespace: data-science-pipelines-operator
 spec:
   endpoints:


### PR DESCRIPTION
Rename the component to respect name-prefix

## Description

The nameprefix, is added to each component list in kustomize
https://github.com/opendatahub-io/data-science-pipelines-operator/blob/79745047878305b07648066c78696ac9878f89d0/config/base/kustomization.yaml#L4

the name of service and servicemonitor, were showing repetition.
ex: `data-science-pipelines-operator-data-science-pipelines-operator-monitor`

## How Has This Been Tested?
`kustomize build config/base`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
