### PR TITLE
Add a data-science-pipelines-operator label for DSPO manifests

### DIFF
--- a/config/manager/manager-service.yaml
+++ b/config/manager/manager-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: service
   labels:
     control-plane: controller-manager
+    app.kubernetes.io/created-by: data-science-pipelines-operator
 spec:
   ports:
     - name: metrics

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/created-by: data-science-pipelines-operator
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If we do an `oc get pods -l app.kubernetes.io/created-by=data-science-pipelines-operator` after deploying DSP Operator, it won't return any pods, because only the DSPO deployment contains this label, the pods don't. Adding this label to the pods as well, so they could be filtered using the component name, that is, Data Science Pipelines Operator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Deploy a DSP Operator instance.
- Try out  `oc get pods -l app.kubernetes.io/created-by=data-science-pipelines-operator` in the same namespace where the operator is deployed. Make sure it displays DSPO pods.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
