### PR TITLE
Update e2e basictests to use APIServer Route

### DIFF
--- a/config/internal/apiserver/role_ds-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/role_ds-pipeline.yaml.tmpl
@@ -85,3 +85,9 @@ rules:
       - imagestreamtags
     verbs:
       - get
+  - apiGroups:
+      - route.openshift.io
+    verbs:
+      - get
+    resources:
+      - routes

--- a/tests/basictests/dsp-operator.sh
+++ b/tests/basictests/dsp-operator.sh
@@ -38,7 +38,7 @@ function create_and_verify_data_science_pipelines_resources() {
 function check_data_science_pipeline_route() {
     header "Checking Routes of Data Science Pipeline availability"
 
-    os::cmd::try_until_text "oc get pods -n ${DSPAPROJECT}  -l app=ds-pipeline-ui-sample --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "1" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -n ${DSPAPROJECT}  -l app=ds-pipeline-sample --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "1" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function setup_monitoring() {
@@ -59,8 +59,8 @@ function test_metrics() {
 function fetch_runs() {
     header "Fetch the dsp route and verify it works"
 
-    ROUTE=$(oc get route -n ${DSPAPROJECT}  ds-pipeline-ui-sample --template={{.spec.host}})
-    SA_TOKEN=$(oc create token ds-pipeline-ui-sample -n ${DSPAPROJECT})
+    ROUTE=$(oc get route -n ${DSPAPROJECT}  ds-pipeline-sample --template={{.spec.host}})
+    SA_TOKEN=$(oc create token ds-pipeline-sample -n ${DSPAPROJECT})
 
     os::cmd::try_until_text "curl -s -k -H \"Authorization: Bearer ${SA_TOKEN}\" 'https://${ROUTE}/apis/v1beta1/runs'" "{}" $odhdefaulttimeout $odhdefaultinterval
 }


### PR DESCRIPTION
Update e2e CI tests to utilize the API route rather than UI (which will eventually not exist)

## Description
Update urls used in the e2e CI tests to use APIServer route

## How Has This Been Tested?
Testing: Verify CI Passes (it's literally what we're updating ;) )

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
