### PR TITLE
Allow DSPA metrics to be scrapped by rho…

### DIFF
--- a/config/internal/common/policy.yaml.tmpl
+++ b/config/internal/common/policy.yaml.tmpl
@@ -22,6 +22,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               name: openshift-user-workload-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redhat-ods-monitoring
         - podSelector:
             matchLabels:
               app: mariadb-{{.Name}}


### PR DESCRIPTION
Allow data science pipeline application metrics to be scrapped by rhods-monitoring

## Description
<!--- Describe your changes in detail -->

The promethues scrapping with respect to the RHODS executes in redhat-ods-monitoring
and for prometheus scrape metrics of DSPA, the networkpolicy needs to allow pods from redhat-ods-monitoring
to access DSPA API server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deploy rhods and try to query metrics once including the network policy.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
