### PR TITLE
Add/Enable Customizable Sample Pipeline to APIServer

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -76,6 +76,9 @@ type APIServer struct {
 	EnableRoute bool `json:"enableOauth"`
 	// +kubebuilder:default:=true
 	// +kubebuilder:validation:Optional
+	EnableSamplePipeline bool `json:"enableSamplePipeline"`
+	// +kubebuilder:default:=true
+	// +kubebuilder:validation:Optional
 	AutoUpdatePipelineDefaultVersion bool                  `json:"autoUpdatePipelineDefaultVersion"`
 	Resources                        *ResourceRequirements `json:"resources,omitempty"`
 }

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -72,6 +72,9 @@ spec:
                   enableOauth:
                     default: true
                     type: boolean
+                  enableSamplePipeline:
+                    default: true
+                    type: boolean
                   image:
                     type: string
                   injectDefaultScript:

--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -190,8 +190,22 @@ spec:
               memory: {{.APIServer.Resources.Limits.Memory}}
               {{ end }}
             {{ end }}
+          volumeMounts:
+            - name: sample-config
+              mountPath: /config/sample_config.json
+              subPath: sample_config.json
+            - name: sample-pipeline
+              mountPath: /samples/
       serviceAccountName: ds-pipeline-{{.Name}}
       volumes:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-{{.Name}}
+        # TODO: encap in if-exists block
+        - name: sample-config
+          configMap:
+            name: sample-config-{{.Name}}
+        - name: sample-pipeline
+          configMap:
+            name: sample-pipeline-{{.Name}}
+          

--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -190,22 +190,25 @@ spec:
               memory: {{.APIServer.Resources.Limits.Memory}}
               {{ end }}
             {{ end }}
+          {{ if .APIServer.EnableSamplePipeline }}
           volumeMounts:
             - name: sample-config
               mountPath: /config/sample_config.json
               subPath: sample_config.json
             - name: sample-pipeline
               mountPath: /samples/
+          {{ end }}
       serviceAccountName: ds-pipeline-{{.Name}}
       volumes:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-{{.Name}}
-        # TODO: encap in if-exists block
+        {{ if .APIServer.EnableSamplePipeline }}
         - name: sample-config
           configMap:
             name: sample-config-{{.Name}}
         - name: sample-pipeline
           configMap:
             name: sample-pipeline-{{.Name}}
+        {{ end }}
           

--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -211,4 +211,3 @@ spec:
           configMap:
             name: sample-pipeline-{{.Name}}
         {{ end }}
-          

--- a/config/internal/apiserver/sample-config.yaml.tmpl
+++ b/config/internal/apiserver/sample-config.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: sample-config-{{.Name}}
+    namespace: {{.Namespace}}
+    labels:
+        app: ds-pipeline-{{.Name}}
+        component: data-science-pipelines
+data:
+    sample_config.json: |-
+        [
+          {
+            "name": "[Demo] iris-training",
+            "description": "[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/iris-training) A simple pipeline to demonstrate a basic ML Training workflow",
+            "file": "/samples/iris-pipeline-compiled.yaml"
+          }
+        ]
+

--- a/config/internal/apiserver/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline.yaml.tmpl
@@ -1,0 +1,554 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: sample-pipeline-{{.Name}}
+    namespace: {{.Namespace}}
+    labels:
+        app: ds-pipeline-{{.Name}}
+        component: data-science-pipelines
+data:
+    iris-pipeline-compiled.yaml: |-
+        apiVersion: tekton.dev/v1beta1
+        kind: PipelineRun
+        metadata:
+          name: iris-pipeline
+          annotations:
+            tekton.dev/output_artifacts: '{"data-prep": [{"key": "artifacts/$PIPELINERUN/data-prep/X_test.tgz",
+              "name": "data-prep-X_test", "path": "/tmp/outputs/X_test/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/X_train.tgz",
+              "name": "data-prep-X_train", "path": "/tmp/outputs/X_train/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/y_test.tgz",
+              "name": "data-prep-y_test", "path": "/tmp/outputs/y_test/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/y_train.tgz",
+              "name": "data-prep-y_train", "path": "/tmp/outputs/y_train/data"}], "evaluate-model":
+              [{"key": "artifacts/$PIPELINERUN/evaluate-model/mlpipeline-metrics.tgz", "name":
+              "mlpipeline-metrics", "path": "/tmp/outputs/mlpipeline_metrics/data"}], "train-model":
+              [{"key": "artifacts/$PIPELINERUN/train-model/model.tgz", "name": "train-model-model",
+              "path": "/tmp/outputs/model/data"}]}'
+            tekton.dev/input_artifacts: '{"evaluate-model": [{"name": "data-prep-X_test",
+              "parent_task": "data-prep"}, {"name": "data-prep-y_test", "parent_task": "data-prep"},
+              {"name": "train-model-model", "parent_task": "train-model"}], "train-model":
+              [{"name": "data-prep-X_train", "parent_task": "data-prep"}, {"name": "data-prep-y_train",
+              "parent_task": "data-prep"}], "validate-model": [{"name": "train-model-model",
+              "parent_task": "train-model"}]}'
+            tekton.dev/artifact_bucket: mlpipeline
+            tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+            tekton.dev/artifact_endpoint_scheme: http://
+            tekton.dev/artifact_items: '{"data-prep": [["X_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test"],
+              ["X_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train"],
+              ["y_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test"],
+              ["y_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train"]],
+              "evaluate-model": [["mlpipeline-metrics", "/tmp/outputs/mlpipeline_metrics/data"]],
+              "train-model": [["model", "$(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model"]],
+              "validate-model": []}'
+            sidecar.istio.io/inject: "false"
+            tekton.dev/template: ''
+            pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+            pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "iris-model", "name":
+              "model_obc", "optional": true, "type": "String"}], "name": "Iris Pipeline"}'
+          labels:
+            pipelines.kubeflow.org/pipelinename: ''
+            pipelines.kubeflow.org/generation: ''
+        spec:
+          params:
+          - name: model_obc
+            value: iris-model
+          pipelineSpec:
+            params:
+            - name: model_obc
+              default: iris-model
+            tasks:
+            - name: data-prep
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --X-train
+                  - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train
+                  - --X-test
+                  - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test
+                  - --y-train
+                  - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train
+                  - --y-test
+                  - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test
+                  command:
+                  - sh
+                  - -c
+                  - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+                    'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+                    pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+                    --user) && "$0" "$@"
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def _make_parent_dirs_and_return_path(file_path: str):
+                        import os
+                        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                        return file_path
+
+                    def data_prep(
+                        X_train_file,
+                        X_test_file,
+                        y_train_file,
+                        y_test_file,
+                    ):
+                        import pickle
+
+                        import pandas as pd
+
+                        from sklearn import datasets
+                        from sklearn.model_selection import train_test_split
+
+                        def get_iris_data():
+                            iris = datasets.load_iris()
+                            data = pd.DataFrame(
+                                {
+                                    "sepalLength": iris.data[:, 0],
+                                    "sepalWidth": iris.data[:, 1],
+                                    "petalLength": iris.data[:, 2],
+                                    "petalWidth": iris.data[:, 3],
+                                    "species": iris.target,
+                                }
+                            )
+
+                            print("Initial Dataset:")
+                            print(data.head())
+
+                            return data
+
+                        def create_training_set(dataset, test_size = 0.3):
+                            # Features
+                            X = dataset[["sepalLength", "sepalWidth", "petalLength", "petalWidth"]]
+                            # Labels
+                            y = dataset["species"]
+
+                            # Split dataset into training set and test set
+                            X_train, X_test, y_train, y_test = train_test_split(
+                                X, y, test_size=test_size, random_state=11
+                            )
+
+                            return X_train, X_test, y_train, y_test
+
+                        def save_pickle(object_file, target_object):
+                            with open(object_file, "wb") as f:
+                                pickle.dump(target_object, f)
+
+                        dataset = get_iris_data()
+                        X_train, X_test, y_train, y_test = create_training_set(dataset)
+
+                        save_pickle(X_train_file, X_train)
+                        save_pickle(X_test_file, X_test)
+                        save_pickle(y_train_file, y_train)
+                        save_pickle(y_test_file, y_test)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Data prep', description='')
+                    _parser.add_argument("--X-train", dest="X_train_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--X-test", dest="X_test_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--y-train", dest="y_train_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--y-test", dest="y_test_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = data_prep(**_parsed_args)
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/python:latest
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                - image: busybox
+                  name: output-taskrun-name
+                  command:
+                  - sh
+                  - -ec
+                  - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
+                - image: busybox
+                  name: copy-results-artifacts
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    set -exo pipefail
+                    TOTAL_SIZE=0
+                    copy_artifact() {
+                    if [ -d "$1" ]; then
+                      tar -czvf "$1".tar.gz "$1"
+                      SUFFIX=".tar.gz"
+                    fi
+                    ARTIFACT_SIZE=`wc -c "$1"${SUFFIX} | awk '{print $1}'`
+                    TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+                    touch "$2"
+                    if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                      if [ -d "$1" ]; then
+                        tar -tzf "$1".tar.gz > "$2"
+                      elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" "$1"; then
+                        cp "$1" "$2"
+                      fi
+                    fi
+                    }
+                    copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train $(results.X-train.path)
+                    copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test $(results.X-test.path)
+                    copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train $(results.y-train.path)
+                    copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test $(results.y-test.path)
+                  onError: continue
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                results:
+                - name: X-test
+                  description: /tmp/outputs/X_test/data
+                - name: X-train
+                  description: /tmp/outputs/X_train/data
+                - name: taskrun-name
+                - name: y-test
+                  description: /tmp/outputs/y_test/data
+                - name: y-train
+                  description: /tmp/outputs/y_train/data
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Data prep", "outputs":
+                      [{"name": "X_train"}, {"name": "X_test"}, {"name": "y_train"}, {"name":
+                      "y_test"}], "version": "Data prep@sha256=5aeb512900f57983c9f643ec30ddb4ccc66490a443269b51ce0a67d57cb373b0"}'
+                workspaces:
+                - name: data-prep
+              workspaces:
+              - name: data-prep
+                workspace: iris-pipeline
+            - name: train-model
+              params:
+              - name: data-prep-trname
+                value: $(tasks.data-prep.results.taskrun-name)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --X-train
+                  - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/X_train
+                  - --y-train
+                  - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/y_train
+                  - --model
+                  - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model
+                  command:
+                  - sh
+                  - -c
+                  - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+                    'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+                    pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+                    --user) && "$0" "$@"
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def _make_parent_dirs_and_return_path(file_path: str):
+                        import os
+                        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                        return file_path
+
+                    def train_model(
+                        X_train_file,
+                        y_train_file,
+                        model_file,
+                    ):
+                        import pickle
+
+                        from sklearn.ensemble import RandomForestClassifier
+
+                        def load_pickle(object_file):
+                            with open(object_file, "rb") as f:
+                                target_object = pickle.load(f)
+
+                            return target_object
+
+                        def save_pickle(object_file, target_object):
+                            with open(object_file, "wb") as f:
+                                pickle.dump(target_object, f)
+
+                        def train_iris(X_train, y_train):
+                            model = RandomForestClassifier(n_estimators=100)
+                            model.fit(X_train, y_train)
+
+                            return model
+
+                        X_train = load_pickle(X_train_file)
+                        y_train = load_pickle(y_train_file)
+
+                        model = train_iris(X_train, y_train)
+
+                        save_pickle(model_file, model)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Train model', description='')
+                    _parser.add_argument("--X-train", dest="X_train_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--y-train", dest="y_train_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--model", dest="model_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = train_model(**_parsed_args)
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/python:latest
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                - image: registry.access.redhat.com/ubi8/ubi-minimal
+                  name: output-taskrun-name
+                  command:
+                  - sh
+                  - -ec
+                  - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
+                - image: registry.access.redhat.com/ubi8/ubi-minimal
+                  name: copy-results-artifacts
+                  command:
+                  - sh
+                  - -ec
+                  - |
+                    set -exo pipefail
+                    TOTAL_SIZE=0
+                    copy_artifact() {
+                    if [ -d "$1" ]; then
+                      tar -czvf "$1".tar.gz "$1"
+                      SUFFIX=".tar.gz"
+                    fi
+                    ARTIFACT_SIZE=`wc -c "$1"${SUFFIX} | awk '{print $1}'`
+                    TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+                    touch "$2"
+                    if [[ $TOTAL_SIZE -lt 3072 ]]; then
+                      if [ -d "$1" ]; then
+                        tar -tzf "$1".tar.gz > "$2"
+                      elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" "$1"; then
+                        cp "$1" "$2"
+                      fi
+                    fi
+                    }
+                    copy_artifact $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model $(results.model.path)
+                  onError: continue
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                params:
+                - name: data-prep-trname
+                results:
+                - name: model
+                  description: /tmp/outputs/model/data
+                - name: taskrun-name
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Train model",
+                      "outputs": [{"name": "model"}], "version": "Train model@sha256=cb1fbd399ee5849dcdfaafced23a0496cae1d5861795062b22512b766ec418ce"}'
+                workspaces:
+                - name: train-model
+              workspaces:
+              - name: train-model
+                workspace: iris-pipeline
+              runAfter:
+              - data-prep
+              - data-prep
+            - name: evaluate-model
+              params:
+              - name: data-prep-trname
+                value: $(tasks.data-prep.results.taskrun-name)
+              - name: train-model-trname
+                value: $(tasks.train-model.results.taskrun-name)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --X-test
+                  - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/X_test
+                  - --y-test
+                  - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/y_test
+                  - --model
+                  - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.train-model-trname)/model
+                  - --mlpipeline-metrics
+                  - /tmp/outputs/mlpipeline_metrics/data
+                  command:
+                  - sh
+                  - -c
+                  - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+                    'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+                    pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+                    --user) && "$0" "$@"
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def _make_parent_dirs_and_return_path(file_path: str):
+                        import os
+                        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                        return file_path
+
+                    def evaluate_model(
+                        X_test_file,
+                        y_test_file,
+                        model_file,
+                        mlpipeline_metrics_file,
+                    ):
+                        import json
+                        import pickle
+
+                        from sklearn.metrics import accuracy_score
+
+                        def load_pickle(object_file):
+                            with open(object_file, "rb") as f:
+                                target_object = pickle.load(f)
+
+                            return target_object
+
+                        X_test = load_pickle(X_test_file)
+                        y_test = load_pickle(y_test_file)
+                        model = load_pickle(model_file)
+
+                        y_pred = model.predict(X_test)
+
+                        accuracy_score_metric = accuracy_score(y_test, y_pred)
+                        print(f"Accuracy: {accuracy_score_metric}")
+
+                        metrics = {
+                            "metrics": [
+                                {
+                                    "name": "accuracy-score",
+                                    "numberValue": accuracy_score_metric,
+                                    "format": "PERCENTAGE",
+                                },
+                            ]
+                        }
+
+                        with open(mlpipeline_metrics_file, "w") as f:
+                            json.dump(metrics, f)
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Evaluate model', description='')
+                    _parser.add_argument("--X-test", dest="X_test_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--y-test", dest="y_test_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--model", dest="model_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parser.add_argument("--mlpipeline-metrics", dest="mlpipeline_metrics_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = evaluate_model(**_parsed_args)
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/python:latest
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                params:
+                - name: data-prep-trname
+                - name: train-model-trname
+                stepTemplate:
+                  volumeMounts:
+                  - name: mlpipeline-metrics
+                    mountPath: /tmp/outputs/mlpipeline_metrics
+                volumes:
+                - name: mlpipeline-metrics
+                  emptyDir: {}
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Evaluate model",
+                      "outputs": [{"name": "mlpipeline_metrics", "type": "Metrics"}], "version":
+                      "Evaluate model@sha256=f398e65faecc6f5a4ba11a2c78d8a2274e3ede205a0e199c8bb615531a3abd4a"}'
+                workspaces:
+                - name: evaluate-model
+              workspaces:
+              - name: evaluate-model
+                workspace: iris-pipeline
+              runAfter:
+              - data-prep
+              - data-prep
+              - train-model
+            - name: validate-model
+              params:
+              - name: train-model-trname
+                value: $(tasks.train-model.results.taskrun-name)
+              taskSpec:
+                steps:
+                - name: main
+                  args:
+                  - --model
+                  - $(workspaces.validate-model.path)/artifacts/$ORIG_PR_NAME/$(params.train-model-trname)/model
+                  command:
+                  - sh
+                  - -c
+                  - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+                    'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+                    pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+                    --user) && "$0" "$@"
+                  - sh
+                  - -ec
+                  - |
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                  - |
+                    def validate_model(model_file):
+                        import pickle
+
+                        def load_pickle(object_file):
+                            with open(object_file, "rb") as f:
+                                target_object = pickle.load(f)
+
+                            return target_object
+
+                        model = load_pickle(model_file)
+
+                        input_values = [[5, 3, 1.6, 0.2]]
+
+                        print(f"Performing test prediction on {input_values}")
+                        result = model.predict(input_values)
+
+                        print(f"Response: {result}")
+
+                    import argparse
+                    _parser = argparse.ArgumentParser(prog='Validate model', description='')
+                    _parser.add_argument("--model", dest="model_file", type=str, required=True, default=argparse.SUPPRESS)
+                    _parsed_args = vars(_parser.parse_args())
+
+                    _outputs = validate_model(**_parsed_args)
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/python:latest
+                  env:
+                  - name: ORIG_PR_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+                params:
+                - name: train-model-trname
+                metadata:
+                  labels:
+                    pipelines.kubeflow.org/cache_enabled: "true"
+                  annotations:
+                    pipelines.kubeflow.org/component_spec_digest: '{"name": "Validate model",
+                      "outputs": [], "version": "Validate model@sha256=53d18ff94fc8f164e7d8455f2c87fa7fdac17e7502502aaa52012e4247d089ee"}'
+                workspaces:
+                - name: validate-model
+              workspaces:
+              - name: validate-model
+                workspace: iris-pipeline
+              runAfter:
+              - train-model
+            workspaces:
+            - name: iris-pipeline
+          workspaces:
+          - name: iris-pipeline
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi

--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -33,6 +33,8 @@ var apiServerTemplates = []string{
 	"apiserver/service.yaml.tmpl",
 	"apiserver/deployment.yaml.tmpl",
 	"apiserver/monitor.yaml.tmpl",
+	"apiserver/sample-config.yaml.tmpl",
+	"apiserver/sample-pipeline.yaml.tmpl",
 }
 
 // serverRoute is a resource deployed conditionally

--- a/controllers/dspipeline_controller_test.go
+++ b/controllers/dspipeline_controller_test.go
@@ -55,7 +55,7 @@ var cases = map[string]TestCase{
 		Path:        "./testdata/deploy/case_2/cr.yaml",
 	},
 	"case_3": {
-		Description: "custom Artifact configmap is provided, custom images override defaults",
+		Description: "custom Artifact configmap is provided, custom images override defaults, no sample pipeline",
 		Path:        "./testdata/deploy/case_3/cr.yaml",
 		AdditionalResources: map[string][]string{
 			SecretKind: {
@@ -110,7 +110,9 @@ var secretsCreated = CaseComponentResources{
 
 var configMapsNotCreated = CaseComponentResources{
 	"case_3": {
-		"apiserver": "./testdata/results/case_3/apiserver/configmap_artifact_script.yaml",
+		"apiserver":                "./testdata/results/case_3/apiserver/configmap_artifact_script.yaml",
+		"apiserver-sampleconfig":   "./testdata/results/case_3/apiserver/sample-config.yaml",
+		"apiserver-samplepipeline": "./testdata/results/case_3/apiserver/sample-pipeline.yaml",
 	},
 }
 

--- a/controllers/testdata/deploy/case_2/cr.yaml
+++ b/controllers/testdata/deploy/case_2/cr.yaml
@@ -14,6 +14,7 @@ spec:
     injectDefaultScript: true
     stripEOF: true
     enableOauth: true
+    enableSamplePipeline: true
     terminateStatus: Cancelled
     trackArtifacts: true
     dbConfigConMaxLifetimeSec: 125

--- a/controllers/testdata/deploy/case_3/cr.yaml
+++ b/controllers/testdata/deploy/case_3/cr.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   apiServer:
     enableOauth: true
+    enableSamplePipeline: false
     artifactScriptConfigMap:
       name: doesnotexist
       key: "somekey"

--- a/controllers/testdata/results/case_0/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_0/apiserver/deployment.yaml
@@ -179,9 +179,24 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
+          volumeMounts:
+            - mountPath: /config/sample_config.json
+              name: sample-config
+              subPath: sample_config.json
+            - mountPath: /samples/
+              name: sample-pipeline
       volumes:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-testdsp0
             defaultMode: 420
+        - configMap:
+            defaultMode: 420
+            name: sample-config-testdsp0
+          name: sample-config
+        - configMap:
+            defaultMode: 420
+            name: sample-pipeline-testdsp0
+          name: sample-pipeline
+
       serviceAccountName: ds-pipeline-testdsp0

--- a/controllers/testdata/results/case_2/apiserver/deployment.yaml
+++ b/controllers/testdata/results/case_2/apiserver/deployment.yaml
@@ -179,9 +179,23 @@ spec:
             limits:
               cpu: 2522m
               memory: 5Gi
+          volumeMounts:
+            - mountPath: /config/sample_config.json
+              name: sample-config
+              subPath: sample_config.json
+            - mountPath: /samples/
+              name: sample-pipeline
       volumes:
         - name: proxy-tls
           secret:
             secretName: ds-pipelines-proxy-tls-testdsp2
             defaultMode: 420
+        - configMap:
+            defaultMode: 420
+            name: sample-config-testdsp2
+          name: sample-config
+        - configMap:
+            defaultMode: 420
+            name: sample-pipeline-testdsp2
+          name: sample-pipeline
       serviceAccountName: ds-pipeline-testdsp2

--- a/controllers/testdata/results/case_3/apiserver/sample-config.yaml
+++ b/controllers/testdata/results/case_3/apiserver/sample-config.yaml
@@ -1,17 +1,16 @@
 apiVersion: v1
-kind: ConfigMap
-metadata:
-    name: sample-config-{{.Name}}
-    namespace: {{.Namespace}}
-    labels:
-        app: ds-pipeline-{{.Name}}
-        component: data-science-pipelines
 data:
-    sample_config.json: |-
+  sample_config.json: |-
         [
           {
             "name": "[Demo] iris-training",
             "description": "[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/iris-training) A simple pipeline to demonstrate a basic ML Training workflow",
             "file": "/samples/iris-pipeline-compiled.yaml"
+            "file": "/samples/iris-pipeline-compiled.yaml"
           }
         ]
+
+kind: ConfigMap
+metadata:
+  name: sample-config-testdsp3
+  namespace: default

--- a/controllers/testdata/results/case_3/apiserver/sample-pipeline.yaml
+++ b/controllers/testdata/results/case_3/apiserver/sample-pipeline.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-pipeline-testdsp3
+  namespace: default
+data:
+  sample-pipeline.yaml: |-
+    pipeline: placeholder
+    reason: |-
+      we're not actually checking the contents here,
+      just verifying the CM itself doesn't exist in this test


### PR DESCRIPTION
Allows us to override the default pipeline, in this case with a more data-science applicable example

## Description
Introduce the sample-config and sample-pipeline ConfigMaps, which are mounted as volumes on the APIServer pod.  these contain overrides for `sampel_config.json` and a compiled  Tekton pipeline showing a simple Iris training run example.  This shouldn't be merged before the matching (DSP PR)[https://github.com/opendatahub-io/data-science-pipelines/pull/80] which provides the py source code to the pipeline (else there will be a dead link in the sample pipeline description


## How Has This Been Tested?
Built a dev image of the DSPO, which can be used to override the image defined in the controller-manager Deployment in odh-applications.  From there, create a new DSPA using the dspa_simple.yaml definition and verify flip-coin example has been replaced with an iris-training example.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
