### PR TITLE
Add namespace and DSPA name in Reconciler logs

### DIFF
--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	v1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,13 +49,14 @@ var samplePipelineTemplates = map[string]string{
 }
 
 func (r *DSPAReconciler) ReconcileAPIServer(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication, params *DSPAParams) error {
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 
 	if !dsp.Spec.APIServer.Deploy {
 		r.Log.Info("Skipping Application of APIServer Resources")
 		return nil
 	}
 
-	r.Log.Info("Applying APIServer Resources")
+	log.Info("Applying APIServer Resources")
 
 	for _, template := range apiServerTemplates {
 		err := r.Apply(dsp, params, template)
@@ -93,6 +95,6 @@ func (r *DSPAReconciler) ReconcileAPIServer(ctx context.Context, dsp *dspav1alph
 		}
 	}
 
-	r.Log.Info("Finished applying APIServer Resources")
+	log.Info("Finished applying APIServer Resources")
 	return nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -26,9 +26,9 @@ var commonTemplates = []string{
 const commonCusterRolebindingTemplate = "common/clusterrolebinding.yaml.tmpl"
 
 func (r *DSPAReconciler) ReconcileCommon(dsp *dspav1alpha1.DataSciencePipelinesApplication, params *DSPAParams) error {
-	r.Log.Info("Applying Common Resources")
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 
-	r.Log.Info("Applying Common Resources")
+	log.Info("Applying Common Resources")
 	for _, template := range commonTemplates {
 		err := r.Apply(dsp, params, template)
 		if err != nil {
@@ -41,7 +41,7 @@ func (r *DSPAReconciler) ReconcileCommon(dsp *dspav1alpha1.DataSciencePipelinesA
 		return err
 	}
 
-	r.Log.Info("Finished applying Common Resources")
+	log.Info("Finished applying Common Resources")
 	return nil
 }
 

--- a/controllers/database.go
+++ b/controllers/database.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 )
 
@@ -33,6 +34,8 @@ var dbTemplates = []string{
 func (r *DSPAReconciler) ReconcileDatabase(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	databaseSpecified := dsp.Spec.Database != nil
 	// DB field can be specified as an empty obj, confirm that subfields are also specified
 	// By default if Database is empty, we deploy mariadb
@@ -42,7 +45,7 @@ func (r *DSPAReconciler) ReconcileDatabase(ctx context.Context, dsp *dspav1alpha
 
 	// If external db is specified, it takes precedence
 	if externalDBSpecified {
-		r.Log.Info("Deploying external db secret.")
+		log.Info("Deploying external db secret.")
 		// If using external DB, we just need to create the secret
 		// for apiserver
 		err := r.Apply(dsp, params, dbSecret)
@@ -50,7 +53,7 @@ func (r *DSPAReconciler) ReconcileDatabase(ctx context.Context, dsp *dspav1alpha
 			return err
 		}
 	} else if deployMariaDB {
-		r.Log.Info("Applying mariaDB resources.")
+		log.Info("Applying mariaDB resources.")
 		for _, template := range dbTemplates {
 			err := r.Apply(dsp, params, template)
 			if err != nil {
@@ -69,11 +72,11 @@ func (r *DSPAReconciler) ReconcileDatabase(ctx context.Context, dsp *dspav1alpha
 			}
 		}
 	} else {
-		r.Log.Info("No externalDB detected, and mariaDB disabled. " +
+		log.Info("No externalDB detected, and mariaDB disabled. " +
 			"skipping Application of DB Resources")
 		return nil
 	}
-	r.Log.Info("Finished applying Database Resources")
+	log.Info("Finished applying Database Resources")
 
 	return nil
 }

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -163,7 +163,7 @@ func (r *DSPAReconciler) isDeploymentAvailable(ctx context.Context, dspa *dspav1
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("namespace", req.Namespace)
+	log := r.Log.WithValues("namespace", req.Namespace).WithValues("dspa_name", req.Name)
 
 	log.V(1).Info("DataSciencePipelinesApplication Reconciler called.")
 

--- a/controllers/mlpipeline_ui.go
+++ b/controllers/mlpipeline_ui.go
@@ -34,12 +34,14 @@ var mlPipelineUITemplates = []string{
 func (r *DSPAReconciler) ReconcileUI(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	if dsp.Spec.MlPipelineUI == nil || !dsp.Spec.MlPipelineUI.Deploy {
-		r.Log.Info("Skipping Application of MlPipelineUI Resources")
+		log.Info("Skipping Application of MlPipelineUI Resources")
 		return nil
 	}
 
-	r.Log.Info("Applying MlPipelineUI Resources")
+	log.Info("Applying MlPipelineUI Resources")
 	for _, template := range mlPipelineUITemplates {
 		err := r.Apply(dsp, params, template)
 		if err != nil {
@@ -47,6 +49,6 @@ func (r *DSPAReconciler) ReconcileUI(dsp *dspav1alpha1.DataSciencePipelinesAppli
 		}
 	}
 
-	r.Log.Info("Applying MlPipelineUI Resources")
+	log.Info("Applying MlPipelineUI Resources")
 	return nil
 }

--- a/controllers/persistence_agent.go
+++ b/controllers/persistence_agent.go
@@ -30,12 +30,14 @@ var persistenceAgentTemplates = []string{
 func (r *DSPAReconciler) ReconcilePersistenceAgent(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	if !dsp.Spec.PersistenceAgent.Deploy {
-		r.Log.Info("Skipping Application of PersistenceAgent Resources")
+		log.Info("Skipping Application of PersistenceAgent Resources")
 		return nil
 	}
 
-	r.Log.Info("Applying PersistenceAgent Resources")
+	log.Info("Applying PersistenceAgent Resources")
 
 	for _, template := range persistenceAgentTemplates {
 		err := r.Apply(dsp, params, template)
@@ -44,6 +46,6 @@ func (r *DSPAReconciler) ReconcilePersistenceAgent(dsp *dspav1alpha1.DataScience
 		}
 	}
 
-	r.Log.Info("Finished applying PersistenceAgent Resources")
+	log.Info("Finished applying PersistenceAgent Resources")
 	return nil
 }

--- a/controllers/scheduled_workflow.go
+++ b/controllers/scheduled_workflow.go
@@ -32,12 +32,14 @@ var scheduledWorkflowTemplates = []string{
 func (r *DSPAReconciler) ReconcileScheduledWorkflow(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	if !dsp.Spec.ScheduledWorkflow.Deploy {
-		r.Log.Info("Skipping Application of ScheduledWorkflow Resources")
+		log.Info("Skipping Application of ScheduledWorkflow Resources")
 		return nil
 	}
 
-	r.Log.Info("Applying ScheduledWorkflow Resources")
+	log.Info("Applying ScheduledWorkflow Resources")
 
 	for _, template := range scheduledWorkflowTemplates {
 		err := r.Apply(dsp, params, template)
@@ -46,6 +48,6 @@ func (r *DSPAReconciler) ReconcileScheduledWorkflow(dsp *dspav1alpha1.DataScienc
 		}
 	}
 
-	r.Log.Info("Finished applying ScheduledWorkflow Resources")
+	log.Info("Finished applying ScheduledWorkflow Resources")
 	return nil
 }

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 )
 
@@ -34,6 +35,8 @@ var storageTemplates = []string{
 func (r *DSPAReconciler) ReconcileStorage(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	storageSpecified := dsp.Spec.ObjectStorage != nil
 	// Storage field can be specified as an empty obj, confirm that subfields are also specified
 	externalStorageSpecified := params.UsingExternalStorage(dsp)
@@ -42,7 +45,7 @@ func (r *DSPAReconciler) ReconcileStorage(ctx context.Context, dsp *dspav1alpha1
 
 	// If external storage is specified, it takes precedence
 	if externalStorageSpecified {
-		r.Log.Info("Deploying external storage secret.")
+		log.Info("Deploying external storage secret.")
 		// If using external storage, we just need to create the secret
 		// for apiserver
 		err := r.Apply(dsp, params, storageSecret)
@@ -50,7 +53,7 @@ func (r *DSPAReconciler) ReconcileStorage(ctx context.Context, dsp *dspav1alpha1
 			return err
 		}
 	} else if deployMinio {
-		r.Log.Info("Applying object storage resources.")
+		log.Info("Applying object storage resources.")
 		for _, template := range storageTemplates {
 			err := r.Apply(dsp, params, template)
 			if err != nil {
@@ -69,11 +72,11 @@ func (r *DSPAReconciler) ReconcileStorage(ctx context.Context, dsp *dspav1alpha1
 			}
 		}
 	} else {
-		r.Log.Info("No externalstorage detected, and minio disabled. " +
+		log.Info("No externalstorage detected, and minio disabled. " +
 			"skipping application of storage Resources")
 		return nil
 	}
-	r.Log.Info("Finished applying storage Resources")
+	log.Info("Finished applying storage Resources")
 
 	return nil
 }

--- a/controllers/viewer_crd.go
+++ b/controllers/viewer_crd.go
@@ -30,12 +30,14 @@ var viewerCRDTemplates = []string{
 func (r *DSPAReconciler) ReconcileViewerCRD(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
+	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
 	if !dsp.Spec.ViewerCRD.Deploy {
-		r.Log.Info("Skipping Application of ViewerCRD Resources")
+		log.Info("Skipping Application of ViewerCRD Resources")
 		return nil
 	}
 
-	r.Log.Info("Applying ViewerCRD Resources")
+	log.Info("Applying ViewerCRD Resources")
 
 	for _, template := range viewerCRDTemplates {
 		err := r.Apply(dsp, params, template)
@@ -44,6 +46,6 @@ func (r *DSPAReconciler) ReconcileViewerCRD(dsp *dspav1alpha1.DataSciencePipelin
 		}
 	}
 
-	r.Log.Info("Finished applying ViewerCRD Resources")
+	log.Info("Finished applying ViewerCRD Resources")
 	return nil
 }


### PR DESCRIPTION
## Description
Log messages now includes the namespace and DSPA name that is being reconciled.

## How Has This Been Tested?
* Run `make podman-build podman-push IMG=quay.io/{USERNAME}/dspo`
* Run `make deploy IMG=quay.io/{USERNAME}/dspo`
* Create a DSPA
* Check if log linges shows namespace and DSPA name

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
