### PR TITLE
Fix Scheduled Workflow role to allow create runs

### DIFF
--- a/config/internal/scheduled-workflow/role.yaml.tmpl
+++ b/config/internal/scheduled-workflow/role.yaml.tmpl
@@ -23,6 +23,7 @@ rules:
       - kubeflow.org
     resources:
       - scheduledworkflows
+      - scheduledworkflows/finalizers
     verbs:
       - create
       - get


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Recurring runs are not creating pipeline runs after triggered. Scheduled Workflow pod is returning the following error:

```
Error creating workflow in namespace (kverlaen-dsp): pipelineruns.tekton.dev "runofdemoiris-training06a9wjmp-1-3349978302" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>: &{TypeMeta:{Kind:Workflow APIVersion:tekton.dev/v1beta1} ObjectMeta:{Name:runofdemoiris-training06a9wjmp-1-3349978302 GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[pipeline/runid:c79c0e77-321a-43db-aa36-e3fcc199f741 scheduledworkflows.kubeflow.org/isOwnedByScheduledWorkflow:true scheduledworkflows.kubeflow.org/scheduledWorkflowName:runofdemoiris-training06a9wjmp scheduledworkflows.kubeflow.org/workflowEpoch:1682717340 scheduledworkflows.kubeflow.org/workflowIndex:1] Annotations:map[] OwnerReferences:[{APIVersion:kubeflow.org/v1beta1 Kind:ScheduledWorkflow Name:runofdemoiris-training06a9wjmp UID:81a2204b-1d41-4fc0-8e3f-980c28a2...
```

This PR will add `scheduledworkflows/finalizers` to the Scheduled Workflow role to fix.

## How Has This Been Tested?
* Deploy Data Science Pipelines Operator, and create a DSPA CR
* Create a Recurring run from the sample pipeline already available in the deployment. Set to run every 1 minute
* Watch the pipeline runs triggered every minute

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
