### PR TITLE
Fix artifact passing for recurring runs.

### DIFF
--- a/config/internal/apiserver/artifact_script.yaml.tmpl
+++ b/config/internal/apiserver/artifact_script.yaml.tmpl
@@ -5,7 +5,7 @@ data:
     push_artifact() {
         if [ -f "$2" ]; then
             tar -cvzf $1.tgz $2
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint {{.ObjectStorageConnection.Endpoint}} cp $1.tgz s3://{{.ObjectStorageConnection.Bucket}}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_0/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/configmap_artifact_script.yaml
@@ -5,7 +5,7 @@ data:
     push_artifact() {
         if [ -f "$2" ]; then
             tar -cvzf $1.tgz $2
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint http://minio-testdsp0.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_2/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/configmap_artifact_script.yaml
@@ -5,7 +5,7 @@ data:
     push_artifact() {
         if [ -f "$2" ]; then
             tar -cvzf $1.tgz $2
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint http://minio-testdsp2.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_3/expected/not_created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_3/expected/not_created/configmap_artifact_script.yaml
@@ -5,7 +5,7 @@ data:
     push_artifact() {
         if [ -f "$2" ]; then
             tar -cvzf $1.tgz $2
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint http://minio-testdsp3.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi


### PR DESCRIPTION
## Description
Due to a bug in upstream code, scheduled run pipelines are not getting the k8s annotations on the tekton pods that contain the artifact endpoint and bucket info. As such artifact passing works in regular (non-scheduled) runs but not for recurring runs, failing at the copy-artifacts container step.

Hardcoding these values within the artifact script serves as a sufficient work around for this problem.


## How Has This Been Tested?
On an ocp cluster running in osia.

Instructions 

`make deploy IMG="quay.io/opendatahub/data-science-pipelines-operator:pr-111"`

Then create a recurring run and confirm it finishes to completion successfully, the run should utilize artifact passing (for example flip-coin example). Confirm by checking bucket for artifacts, and the container "step-copy-artifacts".

Also confirm regular runs remain unaffected.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
