### PR TITLE
Add a role for Data Science Pipelines end user

### DIFF
--- a/config/internal/apiserver/role_ds-pipeline-user-access.yaml.tmpl
+++ b/config/internal/apiserver/role_ds-pipeline-user-access.yaml.tmpl
@@ -1,0 +1,15 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ds-pipeline-user-access-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-{{.Name}}
+    component: data-science-pipelines
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get

--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -28,6 +28,7 @@ var apiServerTemplates = []string{
 	"apiserver/artifact_script.yaml.tmpl",
 	"apiserver/role_ds-pipeline.yaml.tmpl",
 	"apiserver/role_pipeline-runner.yaml.tmpl",
+	"apiserver/role_ds-pipeline-user-access.yaml.tmpl",
 	"apiserver/rolebinding_ds-pipeline.yaml.tmpl",
 	"apiserver/rolebinding_pipeline-runner.yaml.tmpl",
 	"apiserver/sa_ds-pipeline.yaml.tmpl",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 Adding a role for the DSP end user to utlize for long term programmatic access.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Deploy DSPO and create a DSPA instance
- Create a ServiceAccount in a different namespace. Here's an example:
```
kind: ServiceAccount
apiVersion: v1
metadata:
  name: test-dsp-service-account
  namespace: test-dspa-sa
```

- Create a RoleBinding that binds the role defined in this PR, in the same namespace as the DSPA instance. Reference the SA in this RoleBinding. Here's a sample RoleBinding that can be applied:

```
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ds-pipeline-user-access-sample
  namespace: <same-namespace-as-DSP-instance>
subjects:
  - kind: ServiceAccount
    name: test-dsp-service-account
    namespace: test-dspa-sa
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: ds-pipeline-user-access-sample
```
- Create a token for this SA:
`export SA_TOKEN=$(oc sa new-token test-dsp-service-account -n test-dspa-sa)`

- Curl to the Pipelines API Server using this token and the UI route:
`ROUTE=$(oc get route ds-pipeline-ui-sample --template={{.spec.host}})`

```
curl -H "Authorization: Bearer ${SA_TOKEN}" https://${ROUTE}/apis/v1beta1/pipelines
```

You should find the demo pipeline listed out with it's specifications.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
