### PR TITLE
Bugfix: Benign modified DSPA object error

### DIFF
--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -276,6 +276,12 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	log.Info("Updating CR status")
+	// Refresh DSPA before updating
+	err = r.Get(ctx, req.NamespacedName, dspa)
+	if err != nil {
+		log.Info(err.Error())
+		return ctrl.Result{}, err
+	}
 
 	crReady := r.buildCondition(config.CrReady, dspa, config.MinimumReplicasAvailable)
 	crReady.Type = config.CrReady
@@ -297,6 +303,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 	dspa.Status.Conditions = conditions
 
+	// Update Status
 	err = r.Status().Update(ctx, dspa)
 	if err != nil {
 		log.Info(err.Error())


### PR DESCRIPTION
Must retrieve DSPA state before calling Update() in reconciler

## Description
Add a Get() object fetch immediately before Update() call is made in the DSPA Status update procedure.  This will guarantee CR is in latest state, which is what was causing the error (but only once, since future loops *would* probably have the latest status)

## How Has This Been Tested?
1. Build and deploy DSPO (testing image: quay.io/gmfrasca/data-science-pipelines-operator:reconcile-bugfix-0.0.1)
2. Tail the DSPO log (oc logs -n $DSPO_NAMESPACE -f $DSPO_POD_NAME)
3. In a seperate terminal, create a DSPA
4. Wait for DSPA to fully come up
5. Delete a pod to cause DSPA status to change (persistenceagent or scheduledworkflow are good for this)
6. Make sure no Reconciler Error appears in the DSPO log

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
