### PR TITLE
Parameterize the oauth-proxy image as config var

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -29,6 +29,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.IMAGES_ARTIFACT
+  - name: IMAGES_OAUTHPROXY
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_OAUTHPROXY
   - name: IMAGES_PERSISTENTAGENT
     objref:
       kind: ConfigMap

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -6,3 +6,4 @@ IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
 IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
 IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:main-d9ee12b
+IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0

--- a/config/configmaps/files/config.yaml
+++ b/config/configmaps/files/config.yaml
@@ -1,6 +1,7 @@
 Images:
   ApiServer: $(IMAGES_APISERVER)
   Artifact: $(IMAGES_ARTIFACT)
+  OAuthProxy: $(IMAGES_OAUTHPROXY)
   PersistentAgent: $(IMAGES_PERSISTENTAGENT)
   ScheduledWorkflow: $(IMAGES_SCHEDULEDWORKFLOW)
   Cache: $(IMAGES_CACHE)

--- a/config/internal/apiserver/deployment.yaml.tmpl
+++ b/config/internal/apiserver/deployment.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-{{.Name}}","namespace":"{{.Namespace}}"}}'
             - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: {{.OAuthProxy}}
           ports:
             - containerPort: 8443
               name: oauth

--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-{{.Name}}","namespace":"{{.Namespace}}"}}'
             - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-ui-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: {{.OAuthProxy}}
           ports:
             - containerPort: 8443
               name: https

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,8 @@ spec:
             value: $(IMAGES_APISERVER)
           - name: IMAGES_ARTIFACT
             value: $(IMAGES_ARTIFACT)
+          - name: IMAGES_OAUTHPROXY
+            value: $(IMAGES_OAUTHPROXY)
           - name: IMAGES_PERSISTENTAGENT
             value: $(IMAGES_PERSISTENTAGENT)
           - name: IMAGES_SCHEDULEDWORKFLOW

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -59,6 +59,7 @@ const (
 	APIServerCacheImagePath       = "Images.Cache"
 	APIServerMoveResultsImagePath = "Images.MoveResultsImage"
 	MariaDBImagePath              = "Images.MariaDB"
+	OAuthProxyImagePath           = "Images.OAuthProxy"
 )
 
 const (
@@ -80,6 +81,7 @@ var requiredFields = []string{
 	APIServerCacheImagePath,
 	APIServerMoveResultsImagePath,
 	MariaDBImagePath,
+	OAuthProxyImagePath,
 }
 
 func GetConfigRequiredFields() []string {

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -40,6 +40,7 @@ type DSPAParams struct {
 	Owner                mf.Owner
 	APIServer            *dspa.APIServer
 	APIServerServiceName string
+	OAuthProxy           string
 	ScheduledWorkflow    *dspa.ScheduledWorkflow
 	PersistenceAgent     *dspa.PersistenceAgent
 	MlPipelineUI         *dspa.MlPipelineUI
@@ -359,6 +360,7 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 	p.MlPipelineUI = dsp.Spec.MlPipelineUI.DeepCopy()
 	p.MariaDB = dsp.Spec.MariaDB.DeepCopy()
 	p.Minio = dsp.Spec.Minio.DeepCopy()
+	p.OAuthProxy = config.GetStringConfigWithDefault(config.OAuthProxyImagePath, config.DefaultImageValue)
 
 	// TODO: If p.<component> is nil we should create defaults
 

--- a/controllers/testdata/declarative/case_0/config.yaml
+++ b/controllers/testdata/declarative/case_0/config.yaml
@@ -9,3 +9,4 @@ Images:
   MlPipelineUI: frontend:test0
   MariaDB: mariadb:test0
   Minio: minio:test0
+  OAuthProxy: oauth-proxy:test0

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp0","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp0","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: oauth-proxy:test0
           ports:
             - containerPort: 8443
               name: oauth

--- a/controllers/testdata/declarative/case_1/config.yaml
+++ b/controllers/testdata/declarative/case_1/config.yaml
@@ -7,3 +7,4 @@ Images:
   Cache: ubi-minimal:test1
   MoveResultsImage: busybox:test1
   MariaDB: mariadb:test1
+  OAuthProxy: oauth-proxy:test1

--- a/controllers/testdata/declarative/case_2/config.yaml
+++ b/controllers/testdata/declarative/case_2/config.yaml
@@ -7,3 +7,4 @@ Images:
   Cache: ubi-minimal:test2
   MoveResultsImage: busybox:test2
   MariaDB: mariadb:test2
+  OAuthProxy: oauth-proxy:test2

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp2","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp2","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: oauth-proxy:test2
           ports:
             - containerPort: 8443
               name: oauth

--- a/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp2","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-ui-testdsp2","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: oauth-proxy:test2
           ports:
             - containerPort: 8443
               name: https

--- a/controllers/testdata/declarative/case_3/config.yaml
+++ b/controllers/testdata/declarative/case_3/config.yaml
@@ -7,3 +7,4 @@ Images:
   Cache: ubi-minimal:test3
   MoveResultsImage: busybox:test3
   MariaDB: mariadb:test3
+  OAuthProxy: oauth-proxy:test3

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp3","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp3","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: oauth-proxy:test3
           ports:
             - containerPort: 8443
               name: oauth

--- a/kfdef/kfdef.yaml
+++ b/kfdef/kfdef.yaml
@@ -22,6 +22,8 @@ spec:
             value: registry.access.redhat.com/ubi8/ubi-micro:8.7
           - name: IMAGES_MARIADB
             value: registry.redhat.io/rhel8/mariadb-103:1-188
+          - name: IMAGES_OAUTHPROXY
+            value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
         repoRef:
           name: manifests
           path: config


### PR DESCRIPTION
Parameterize the oauth-proxy image as config var

## Description

Move the oauth-proxy image to configmap , so it can assigned value directly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use the below image for the deployment
Image: `quay.io/opendatahub/data-science-pipelines-operator:pr-120`
replace the value here:https://github.com/opendatahub-io/data-science-pipelines-operator/blob/fe12ad963f0c7f498c941f364ffccbe0985b53c0/config/base/params.env#L8

deploy the operator and check the yaml for testing.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
