### PR TITLE
Bugfix: Images Specified in DSPA CRs should override DSPO defaults

### DIFF
--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -366,10 +366,15 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 
 	if p.APIServer != nil {
 
-		p.APIServer.Image = config.GetStringConfigWithDefault(config.APIServerImagePath, config.DefaultImageValue)
-		p.APIServer.ArtifactImage = config.GetStringConfigWithDefault(config.APIServerArtifactImagePath, config.DefaultImageValue)
-		p.APIServer.CacheImage = config.GetStringConfigWithDefault(config.APIServerCacheImagePath, config.DefaultImageValue)
-		p.APIServer.MoveResultsImage = config.GetStringConfigWithDefault(config.APIServerMoveResultsImagePath, config.DefaultImageValue)
+		serverImageFromConfig := config.GetStringConfigWithDefault(config.APIServerImagePath, config.DefaultImageValue)
+		artifactImageFromConfig := config.GetStringConfigWithDefault(config.APIServerArtifactImagePath, config.DefaultImageValue)
+		cacheImageFromConfig := config.GetStringConfigWithDefault(config.APIServerCacheImagePath, config.DefaultImageValue)
+		moveResultsImageFromConfig := config.GetStringConfigWithDefault(config.APIServerMoveResultsImagePath, config.DefaultImageValue)
+
+		setStringDefault(serverImageFromConfig, &p.APIServer.Image)
+		setStringDefault(artifactImageFromConfig, &p.APIServer.ArtifactImage)
+		setStringDefault(cacheImageFromConfig, &p.APIServer.CacheImage)
+		setStringDefault(moveResultsImageFromConfig, &p.APIServer.MoveResultsImage)
 
 		setResourcesDefault(config.APIServerResourceRequirements, &p.APIServer.Resources)
 
@@ -381,11 +386,13 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 		}
 	}
 	if p.PersistenceAgent != nil {
-		p.PersistenceAgent.Image = config.GetStringConfigWithDefault(config.PersistenceAgentImagePath, config.DefaultImageValue)
+		persistenceAgentImageFromConfig := config.GetStringConfigWithDefault(config.PersistenceAgentImagePath, config.DefaultImageValue)
+		setStringDefault(persistenceAgentImageFromConfig, &p.PersistenceAgent.Image)
 		setResourcesDefault(config.PersistenceAgentResourceRequirements, &p.PersistenceAgent.Resources)
 	}
 	if p.ScheduledWorkflow != nil {
-		p.ScheduledWorkflow.Image = config.GetStringConfigWithDefault(config.ScheduledWorkflowImagePath, config.DefaultImageValue)
+		scheduledWorkflowImageFromConfig := config.GetStringConfigWithDefault(config.ScheduledWorkflowImagePath, config.DefaultImageValue)
+		setStringDefault(scheduledWorkflowImageFromConfig, &p.ScheduledWorkflow.Image)
 		setResourcesDefault(config.ScheduledWorkflowResourceRequirements, &p.ScheduledWorkflow.Resources)
 	}
 	if p.MlPipelineUI != nil {

--- a/controllers/testdata/declarative/case_4/config.yaml
+++ b/controllers/testdata/declarative/case_4/config.yaml
@@ -1,9 +1,10 @@
 # When a DSPA with a custom db/storage secret, and custom artifact script is deployed.
 Images:
   ApiServer: this-apiserver-image-from-config-should-not-be-used:test4
-  Artifact: artifact-manager:test4
-  PersistentAgent: persistenceagent:test4
-  ScheduledWorkflow: scheduledworkflow:test4
-  Cache: ubi-minimal:test4
-  MoveResultsImage: busybox:test4
-  MariaDB: mariadb:test4
+  Artifact: this-artifact-manager-image-from-config-should-not-be-used:test4
+  PersistentAgent: this-persistenceagent-image-from-config-should-not-be-used:test4
+  ScheduledWorkflow: this-scheduledworkflow-image-from-config-should-not-be-used:test4
+  Cache: this-ubi-minimal-image-from-config-should-not-be-used:test4
+  MoveResultsImage: this-busybox-image-from-config-should-not-be-used:test4
+  MariaDB: this-mariadb-image-from-config-should-not-be-used:test4
+  OAuthProxy: oauth-proxy:test4

--- a/controllers/testdata/declarative/case_4/config.yaml
+++ b/controllers/testdata/declarative/case_4/config.yaml
@@ -1,0 +1,9 @@
+# When a DSPA with a custom db/storage secret, and custom artifact script is deployed.
+Images:
+  ApiServer: this-apiserver-image-from-config-should-not-be-used:test4
+  Artifact: artifact-manager:test4
+  PersistentAgent: persistenceagent:test4
+  ScheduledWorkflow: scheduledworkflow:test4
+  Cache: ubi-minimal:test4
+  MoveResultsImage: busybox:test4
+  MariaDB: mariadb:test4

--- a/controllers/testdata/declarative/case_4/deploy/00_cr.yaml
+++ b/controllers/testdata/declarative/case_4/deploy/00_cr.yaml
@@ -1,0 +1,89 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: testdsp4
+spec:
+  apiServer:
+    deploy: true
+    image: this-apiserver-image-from-cr-should-be-used:test4
+    enableSamplePipeline: false
+    applyTektonCustomResource: true
+    archiveLogs: false
+    artifactImage: artifact-manager:test4
+    cacheImage: ubi-minimal:test4
+    moveResultsImage: busybox:test4
+    injectDefaultScript: true
+    stripEOF: true
+    enableOauth: true
+    terminateStatus: Cancelled
+    trackArtifacts: true
+    dbConfigConMaxLifetimeSec: 125
+    collectMetrics: true
+    autoUpdatePipelineDefaultVersion: true
+    resources:
+      requests:
+        cpu: "1231m"
+        memory: "1Gi"
+      limits:
+        cpu: "2522m"
+        memory: "5Gi"
+  persistenceAgent:
+    deploy: true
+    image: persistenceagent:test4
+    numWorkers: 5
+    resources:
+      requests:
+        cpu: "1233m"
+        memory: "1Gi"
+      limits:
+        cpu: "2524m"
+        memory: "5Gi"
+  scheduledWorkflow:
+    deploy: true
+    image: scheduledworkflow:test4
+    cronScheduleTimezone: EST
+    resources:
+      requests:
+        cpu: "1235m"
+        memory: "1Gi"
+      limits:
+        cpu: "2526m"
+        memory: "5Gi"
+  mlpipelineUI:
+    deploy: true
+    image: frontend:test4
+    configMap: some-test-configmap
+    resources:
+      requests:
+        cpu: "1239m"
+        memory: "1Gi"
+      limits:
+        cpu: "2530m"
+        memory: "5Gi"
+  database:
+    mariaDB:
+      deploy: true
+      image: mariadb:test4
+      username: testuser
+      pipelineDBName: randomDBName
+      pvcSize: 32Gi
+      resources:
+        requests:
+          cpu: "1212m"
+          memory: "1Gi"
+        limits:
+          cpu: "2554m"
+          memory: "5Gi"
+  objectStorage:
+    minio:
+      deploy: true
+      image: minio:test4
+      bucket: mlpipeline
+      pvcSize: 40Gi
+      resources:
+        requests:
+          cpu: "1334m"
+          memory: "1Gi"
+        limits:
+          cpu: "2535m"
+          memory: "5Gi"

--- a/controllers/testdata/declarative/case_4/deploy/00_cr.yaml
+++ b/controllers/testdata/declarative/case_4/deploy/00_cr.yaml
@@ -9,9 +9,9 @@ spec:
     enableSamplePipeline: false
     applyTektonCustomResource: true
     archiveLogs: false
-    artifactImage: artifact-manager:test4
-    cacheImage: ubi-minimal:test4
-    moveResultsImage: busybox:test4
+    artifactImage: this-artifact-manager-image-from-cr-should-be-used:test4
+    cacheImage: this-ubi-minimal-image-from-cr-should-be-used:test4
+    moveResultsImage: this-busybox-image-from-cr-should-be-used:test4
     injectDefaultScript: true
     stripEOF: true
     enableOauth: true
@@ -29,7 +29,7 @@ spec:
         memory: "5Gi"
   persistenceAgent:
     deploy: true
-    image: persistenceagent:test4
+    image: this-persistenceagent-image-from-cr-should-be-used:test4
     numWorkers: 5
     resources:
       requests:
@@ -40,7 +40,7 @@ spec:
         memory: "5Gi"
   scheduledWorkflow:
     deploy: true
-    image: scheduledworkflow:test4
+    image: this-scheduledworkflow-image-from-cr-should-be-used:test4
     cronScheduleTimezone: EST
     resources:
       requests:
@@ -51,7 +51,7 @@ spec:
         memory: "5Gi"
   mlpipelineUI:
     deploy: true
-    image: frontend:test4
+    image: this-frontend-image-from-cr-should-be-used:test4
     configMap: some-test-configmap
     resources:
       requests:
@@ -63,7 +63,7 @@ spec:
   database:
     mariaDB:
       deploy: true
-      image: mariadb:test4
+      image: this-mariadb-image-from-cr-should-be-used:test4
       username: testuser
       pipelineDBName: randomDBName
       pvcSize: 32Gi
@@ -77,7 +77,7 @@ spec:
   objectStorage:
     minio:
       deploy: true
-      image: minio:test4
+      image: this-minio-image-from-cr-should-be-used:test4
       bucket: mlpipeline
       pvcSize: 40Gi
       resources:

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-testdsp4
+  namespace: default
+  labels:
+    app: ds-pipeline-testdsp4
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-testdsp4
+      component: data-science-pipelines
+  template:
+    metadata:
+      labels:
+        app: ds-pipeline-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-testdsp4
+            - --upstream=http://localhost:8888
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp4","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp4","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          ports:
+            - containerPort: 8443
+              name: oauth
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+        - env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "testuser"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp4"
+            - name: DBCONFIG_DBNAME
+              value: "randomDBName"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp4.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ARTIFACT_BUCKET
+              value: "mlpipeline"
+            - name: ARTIFACT_ENDPOINT
+              value: "http://minio-testdsp4.default.svc.cluster.local:9000"
+            - name: ARTIFACT_SCRIPT
+              valueFrom:
+                configMapKeyRef:
+                  key: "artifact_script"
+                  name: "ds-pipeline-artifact-script-testdsp4"
+            - name: ARTIFACT_IMAGE
+              value: "artifact-manager:test4"
+            - name: ARCHIVE_LOGS
+              value: "false"
+            - name: TRACK_ARTIFACTS
+              value: "true"
+            - name: STRIP_EOF
+              value: "true"
+            - name: PIPELINE_RUNTIME
+              value: "tekton"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp4"
+            - name: INJECT_DEFAULT_SCRIPT
+              value: "true"
+            - name: APPLY_TEKTON_CUSTOM_RESOURCE
+              value: "true"
+            - name: TERMINATE_STATUS
+              value: "Cancelled"
+            - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
+              value: "true"
+            - name: DBCONFIG_CONMAXLIFETIMESEC
+              value: "125"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "mlpipeline-minio-artifact"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "mlpipeline-minio-artifact"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp4.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: CACHE_IMAGE
+              value: "ubi-minimal:test4"
+            - name: MOVERESULTS_IMAGE
+              value: "busybox:test4"
+          image: this-apiserver-image-from-cr-should-be-used:test4
+          imagePullPolicy: Always
+          name: ds-pipeline-api-server
+          ports:
+            - containerPort: 8888
+              name: http
+              protocol: TCP
+            - containerPort: 8887
+              name: grpc
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 1231m
+              memory: 1Gi
+            limits:
+              cpu: 2522m
+              memory: 5Gi
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-proxy-tls-testdsp4
+            defaultMode: 420
+      serviceAccountName: ds-pipeline-testdsp4
+

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-testdsp4","namespace":"default"}}'
             - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-testdsp4","verb":"get","resourceAPIGroup":"route.openshift.io"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+          image: oauth-proxy:test4
           ports:
             - containerPort: 8443
               name: oauth
@@ -91,7 +91,7 @@ spec:
                   key: "artifact_script"
                   name: "ds-pipeline-artifact-script-testdsp4"
             - name: ARTIFACT_IMAGE
-              value: "artifact-manager:test4"
+              value: "this-artifact-manager-image-from-cr-should-be-used:test4"
             - name: ARCHIVE_LOGS
               value: "false"
             - name: TRACK_ARTIFACTS
@@ -135,9 +135,9 @@ spec:
             - name: MINIO_SERVICE_SERVICE_PORT
               value: "9000"
             - name: CACHE_IMAGE
-              value: "ubi-minimal:test4"
+              value: "this-ubi-minimal-image-from-cr-should-be-used:test4"
             - name: MOVERESULTS_IMAGE
-              value: "busybox:test4"
+              value: "this-busybox-image-from-cr-should-be-used:test4"
           image: this-apiserver-image-from-cr-should-be-used:test4
           imagePullPolicy: Always
           name: ds-pipeline-api-server
@@ -185,4 +185,3 @@ spec:
             secretName: ds-pipelines-proxy-tls-testdsp4
             defaultMode: 420
       serviceAccountName: ds-pipeline-testdsp4
-

--- a/controllers/testdata/declarative/case_4/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/configmap_artifact_script.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+data:
+  artifact_script: |-
+    #!/usr/bin/env sh
+    push_artifact() {
+        if [ -f "$2" ]; then
+            tar -cvzf $1.tgz $2
+            aws s3 --endpoint http://minio-testdsp4.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        else
+            echo "$2 file does not exist. Skip artifact tracking for $1"
+        fi
+    }
+    push_log() {
+        cat /var/log/containers/$PODNAME*$NAMESPACE*step-main*.log > step-main.log
+        push_artifact main-log step-main.log
+    }
+    strip_eof() {
+        if [ -f "$2" ]; then
+            awk 'NF' $2 | head -c -1 > $1_temp_save && cp $1_temp_save $2
+        fi
+    }
+kind: ConfigMap
+metadata:
+  name: ds-pipeline-artifact-script-testdsp4
+  namespace: default
+  labels:
+    app: ds-pipeline-testdsp4
+    component: data-science-pipelines

--- a/controllers/testdata/declarative/case_4/expected/created/mariadb_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mariadb_deployment.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb-testdsp4
+  namespace: default
+  labels:
+    app: mariadb-testdsp4
+    component: data-science-pipelines
+spec:
+  strategy:
+    type: Recreate  # Need this since backing PVC is ReadWriteOnce, which creates resource lock condition in default Rolling strategy
+  selector:
+    matchLabels:
+      app: mariadb-testdsp4
+      component: data-science-pipelines
+  template:
+    metadata:
+      labels:
+        app: mariadb-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - name: mariadb
+          image: this-mariadb-image-from-cr-should-be-used:test4
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-i"
+                - "-c"
+                - >-
+                  MYSQL_PWD=$MYSQL_PASSWORD mysql -h 127.0.0.1 -u $MYSQL_USER -D
+                  $MYSQL_DATABASE -e 'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3306
+            timeoutSeconds: 1
+          env:
+            - name: MYSQL_USER
+              value: "testuser"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp4"
+            - name: MYSQL_DATABASE
+              value: "randomDBName"
+            - name: MYSQL_ALLOW_EMPTY_PASSWORD
+              value: "true"
+          resources:
+            requests:
+              cpu: 1212m
+              memory: 1Gi
+            limits:
+              cpu: 2554m
+              memory: 5Gi
+          volumeMounts:
+            - name: mariadb-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-testdsp4

--- a/controllers/testdata/declarative/case_4/expected/created/minio_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/minio_deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-testdsp4
+  namespace: default
+  labels:
+    app: minio-testdsp4
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: minio-testdsp4
+      component: data-science-pipelines
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "mlpipeline-minio-artifact"
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "mlpipeline-minio-artifact"
+          image: this-minio-image-from-cr-should-be-used:test4
+          name: minio
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 1334m
+              memory: 1Gi
+            limits:
+              cpu: 2535m
+              memory: 5Gi
+          volumeMounts:
+            - mountPath: /data
+              name: data
+              subPath: minio
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-testdsp4

--- a/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-ui-testdsp4
+  namespace: default
+  labels:
+    app: ds-pipeline-ui-testdsp4
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-ui-testdsp4
+      component: data-science-pipelines
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ds-pipeline-ui-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-ui-testdsp4
+            - --upstream=http://localhost:3000
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-ui-testdsp4","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-ui-testdsp4","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: oauth-proxy:test4
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+        - env:
+            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+              value: /etc/config/viewer-pod-template.json
+            - name: MINIO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "mlpipeline-minio-artifact"
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "mlpipeline-minio-artifact"
+            - name: ALLOW_CUSTOM_VISUALIZATIONS
+              value: "true"
+            - name: ARGO_ARCHIVE_LOGS
+              value: "true"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp4
+            - name: ML_PIPELINE_SERVICE_PORT
+              value: '8888'
+          image: this-frontend-image-from-cr-should-be-used:test4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          name: ds-pipeline-ui
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - '-'
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 1239m
+              memory: 1Gi
+            limits:
+              cpu: 2530m
+              memory: 5Gi
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-volume
+              readOnly: true
+      serviceAccountName: ds-pipeline-ui-testdsp4
+      volumes:
+        - configMap:
+            name: some-test-configmap
+            defaultMode: 420
+          name: config-volume
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-ui-proxy-tls-testdsp4
+            defaultMode: 420

--- a/controllers/testdata/declarative/case_4/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/persistence-agent_deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-persistenceagent-testdsp4
+  namespace: default
+  labels:
+    app: ds-pipeline-persistenceagent-testdsp4
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-persistenceagent-testdsp4
+      component: data-science-pipelines
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ds-pipeline-persistenceagent-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - env:
+            - name: NAMESPACE
+              value: "default"
+          image: this-persistenceagent-image-from-cr-should-be-used:test4
+          imagePullPolicy: IfNotPresent
+          name: ds-pipeline-persistenceagent
+          command:
+            - persistence_agent
+            - "--logtostderr=true"
+            - "--ttlSecondsAfterWorkflowFinish=86400"
+            - "--numWorker=5"
+            - "--mlPipelineAPIServerName=ds-pipeline-testdsp4"
+            - "--namespace=testdsp4"
+            - "--mlPipelineServiceHttpPort=8888"
+            - "--mlPipelineServiceGRPCPort=8887"
+          livenessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - persistence_agent
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - persistence_agent
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 1233m
+              memory: 1Gi
+            limits:
+              cpu: 2524m
+              memory: 5Gi
+      serviceAccountName: ds-pipeline-persistenceagent-testdsp4

--- a/controllers/testdata/declarative/case_4/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/scheduled-workflow_deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ds-pipeline-scheduledworkflow-testdsp4
+  namespace: default
+  labels:
+    app: ds-pipeline-scheduledworkflow-testdsp4
+    component: data-science-pipelines
+spec:
+  selector:
+    matchLabels:
+      app: ds-pipeline-scheduledworkflow-testdsp4
+      component: data-science-pipelines
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ds-pipeline-scheduledworkflow-testdsp4
+        component: data-science-pipelines
+    spec:
+      containers:
+        - env:
+            - name: CRON_SCHEDULE_TIMEZONE
+              value: "EST"
+          image: this-scheduledworkflow-image-from-cr-should-be-used:test4
+          imagePullPolicy: IfNotPresent
+          name: ds-pipeline-scheduledworkflow
+          command:
+            - controller
+            - "--logtostderr=true"
+            - "--namespace=default"
+          livenessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - controller
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -x
+                - controller
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 1235m
+              memory: 1Gi
+            limits:
+              cpu: 2526m
+              memory: 5Gi
+      serviceAccountName: ds-pipeline-scheduledworkflow-testdsp4

--- a/controllers/testutil/equalities.go
+++ b/controllers/testutil/equalities.go
@@ -18,11 +18,12 @@ package testutil
 
 import (
 	"fmt"
+	"reflect"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
-	"reflect"
 )
 
 // CompareResourceProcs maps object kind's to their associated comparison procedures.
@@ -119,7 +120,7 @@ func deploymentsAreEqual(expected, actual *unstructured.Unstructured) (bool, err
 		for i, expectedEnv := range expectedContainer.Env {
 			actualEnv := actualContainer.Env[i]
 			if !reflect.DeepEqual(expectedEnv, actualEnv) {
-				return false, notEqualMsg(fmt.Sprintf("Container Env [expected: %s, actual: %s]", expectedEnv.Name, actualEnv.Name))
+				return false, notEqualMsg(fmt.Sprintf("Container Env [expected: %s=%s, actual: %s=%s]", expectedEnv.Name, expectedEnv.Value, actualEnv.Name, actualEnv.Value))
 			}
 		}
 
@@ -139,7 +140,7 @@ func deploymentsAreEqual(expected, actual *unstructured.Unstructured) (bool, err
 			return false, notEqualMsg("Container Name")
 		}
 		if expectedContainer.Image != actualContainer.Image {
-			return false, notEqualMsg("Container Image")
+			return false, notEqualMsg(fmt.Sprintf("Container Image [expected: %s, actual: %s]", expectedContainer.Image, actualContainer.Image))
 		}
 	}
 


### PR DESCRIPTION
Fixes #67 

If the `image` field is specified in a DSPA CR, it should take precedence over the image defaults provided in the DSPO config.

## Description
Changes DSPAParams behavior to only set the XXXX.Image component if it is not specified in the DSPA CR

## How Has This Been Tested?
- Deploy operator built from PR.
- Create DSPA from stardard dspa simple, verify 'normal' images used
- Create DSPA with `image` field specified for APIServer, PersistenceAgent, ScheduledWorkflow, and UI.  Also set ArtifactImage, CacheImage, and MoveResultImage in apiServer spec.  These can be fake values.  Verify the specified images have overrident the ones used from first DSPA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
