### PR TITLE
default to deploying dspo's main tag

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -5,5 +5,5 @@ IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:main
 IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
 IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
-IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:main-d9ee12b
+IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:main
 IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0


### PR DESCRIPTION
I noticed when deploying DSPO by pointing a kfdef at this repository, I get a month-old version of DSPO. When I do the same for dashboard, I get main. We might as well default to main too ... if someone is pointing at DSPO or building it from source, they probably want bleeding edge anyway.

## How Has This Been Tested?
I didn't test it yet.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
