### PR TITLE
Add MLMD components to Network Policy

### DIFF
--- a/config/internal/common/mlmd-envoy-dashboard-access-policy.yaml.tmpl
+++ b/config/internal/common/mlmd-envoy-dashboard-access-policy.yaml.tmpl
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ds-pipelines-envoy-{{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: ds-pipeline-metadata-envoy-{{ .Name }}
+      component: data-science-pipelines
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9090
+      from:
+        - podSelector:
+            matchLabels:
+              app: odh-dashboard
+          namespaceSelector: {}
+        - podSelector:
+            matchLabels:
+              component: data-science-pipelines
+  policyTypes:
+    - Ingress

--- a/config/internal/common/policy.yaml.tmpl
+++ b/config/internal/common/policy.yaml.tmpl
@@ -45,6 +45,18 @@ spec:
             matchLabels:
               app: ds-pipeline-scheduledworkflow-{{.Name}}
               component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-metadata-envoy-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-metadata-grpc-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-metadata-writer-{{.Name}}
+              component: data-science-pipelines
       ports:
         - protocol: TCP
           port: 8888

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -21,6 +21,7 @@ import (
 
 var commonTemplates = []string{
 	"common/policy.yaml.tmpl",
+	"common/mlmd-envoy-dashboard-access-policy.yaml.tmpl",
 }
 
 const commonCusterRolebindingTemplate = "common/clusterrolebinding.yaml.tmpl"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding MLMD components to the DSPA Network Policy, and provide ODH dashboard access to the metadata envoy service. Closes https://github.com/opendatahub-io/data-science-pipelines-operator/issues/160

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Deployed a DSPO and DSPA instance with these updates
- Deployed an ODH dashboard instance by applying the ODH core kfdef in the same namespace where DSPO was deployed.
- Ensured that the MLMD components were up, metadata envoy service was running.
- curled to the envoy service from the dashboard pod.
`$ curl ds-pipeline-metadata-envoy-sample.test-dspa-3.svc.cluster.local:9090
upstream connect error or disconnect/reset before headers. reset reason: remote reset`
Dashboard was able to reach the envoy service.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
