### PR TITLE
Infer the "secure" field in dspa based on scheme

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -215,9 +215,8 @@ type ExternalStorage struct {
 	Bucket              string `json:"bucket"`
 	Scheme              string `json:"scheme"`
 	*S3CredentialSecret `json:"s3CredentialsSecret"`
-	// +kubebuilder:default:=true
 	// +kubebuilder:validation:Optional
-	Secure bool `json:"secure"`
+	Secure *bool `json:"secure"`
 	// +kubebuilder:validation:Optional
 	Port string `json:"port"`
 }

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -457,7 +457,6 @@ spec:
                       scheme:
                         type: string
                       secure:
-                        default: true
                         type: boolean
                     required:
                     - bucket

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -40,3 +40,7 @@ func GetDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.Depl
 	}
 	return nil
 }
+
+func BoolPointer(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Infer the "secure" field in dspa based on the scheme which resolves #157 

## How Has This Been Tested?
Manually tested this on Openshift Cluster to ensure removing this field doesn't hinder anything.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
