### PR TITLE
Add push artifact work around.

### DIFF
--- a/config/internal/apiserver/artifact_script.yaml.tmpl
+++ b/config/internal/apiserver/artifact_script.yaml.tmpl
@@ -3,9 +3,16 @@ data:
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {
-        if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
-            aws s3 --endpoint {{.ObjectStorageConnection.Endpoint}} cp $1.tgz s3://{{.ObjectStorageConnection.Bucket}}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        workspace_dir=$(echo $(context.taskRun.name) | sed -e "s/$(context.pipeline.name)-//g")
+        workspace_dest=/workspace/${workspace_dir}/artifacts/$(context.pipelineRun.name)/$(context.taskRun.name)
+        artifact_name=$(basename $2)
+        if [ -f "$workspace_dest/$artifact_name" ]; then
+            echo sending to: ${workspace_dest}/${artifact_name}
+            tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        elif [ -f "$2" ]; then
+            tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_0/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/configmap_artifact_script.yaml
@@ -3,9 +3,16 @@ data:
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {
-        if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
-            aws s3 --endpoint http://minio-testdsp0.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        workspace_dir=$(echo $(context.taskRun.name) | sed -e "s/$(context.pipeline.name)-//g")
+        workspace_dest=/workspace/${workspace_dir}/artifacts/$(context.pipelineRun.name)/$(context.taskRun.name)
+        artifact_name=$(basename $2)
+        if [ -f "$workspace_dest/$artifact_name" ]; then
+            echo sending to: ${workspace_dest}/${artifact_name}
+            tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        elif [ -f "$2" ]; then
+            tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_2/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/configmap_artifact_script.yaml
@@ -3,9 +3,16 @@ data:
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {
-        if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
-            aws s3 --endpoint http://minio-testdsp2.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        workspace_dir=$(echo $(context.taskRun.name) | sed -e "s/$(context.pipeline.name)-//g")
+        workspace_dest=/workspace/${workspace_dir}/artifacts/$(context.pipelineRun.name)/$(context.taskRun.name)
+        artifact_name=$(basename $2)
+        if [ -f "$workspace_dest/$artifact_name" ]; then
+            echo sending to: ${workspace_dest}/${artifact_name}
+            tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        elif [ -f "$2" ]; then
+            tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_4/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/configmap_artifact_script.yaml
@@ -3,9 +3,16 @@ data:
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {
-        if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
-            aws s3 --endpoint http://minio-testdsp4.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        workspace_dir=$(echo $(context.taskRun.name) | sed -e "s/$(context.pipeline.name)-//g")
+        workspace_dest=/workspace/${workspace_dir}/artifacts/$(context.pipelineRun.name)/$(context.taskRun.name)
+        artifact_name=$(basename $2)
+        if [ -f "$workspace_dest/$artifact_name" ]; then
+            echo sending to: ${workspace_dest}/${artifact_name}
+            tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        elif [ -f "$2" ]; then
+            tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi

--- a/controllers/testdata/declarative/case_5/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/configmap_artifact_script.yaml
@@ -3,9 +3,16 @@ data:
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {
-        if [ -f "$2" ]; then
-            tar -cvzf $1.tgz $2
-            aws s3 --endpoint http://minio-testdsp5.default.svc.cluster.local:9000 cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        workspace_dir=$(echo $(context.taskRun.name) | sed -e "s/$(context.pipeline.name)-//g")
+        workspace_dest=/workspace/${workspace_dir}/artifacts/$(context.pipelineRun.name)/$(context.taskRun.name)
+        artifact_name=$(basename $2)
+        if [ -f "$workspace_dest/$artifact_name" ]; then
+            echo sending to: ${workspace_dest}/${artifact_name}
+            tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        elif [ -f "$2" ]; then
+            tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi


### PR DESCRIPTION
Resolves:  https://github.com/opendatahub-io/data-science-pipelines-operator/issues/214

## Description
The workaround identifies artifacts in workspace and pushes them to s3 storage.

## How Has This Been Tested?
On live ocp cluster. Run pipeline and confirm artifacts are stored in s3 when doing data passing, or save to output path.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
