### PR TITLE
Add gh to jira action.

### DIFF
--- a/.github/workflows/gh-to-jira.yaml
+++ b/.github/workflows/gh-to-jira.yaml
@@ -1,0 +1,77 @@
+name: Create Jira Issue from GH Release
+run-name: GH Release to Jira.
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        default: 'Data Science Pipelines'
+        description: 'ODH Component'
+        required: true
+      target_release:
+        description: 'Target Downstream Release'
+        required: true
+      gh_org:
+        default: 'opendatahub-io'
+        description: 'Upstream GH Org'
+        required: true
+      repos:
+        default: |
+          [{"repo_name":"data-science-pipelines","target_release":"UPDATE","previous_release":"UPDATE"},{"repo_name":"data-science-pipelines-operator","target_release":"UPDATE","previous_release":"UPDATE"}]
+        description: 'Upstream Source Repos & Tags'
+        required: true
+      labels:
+        default: 'qe/verify'
+        required: true
+        description: ""
+      jira_server:
+        default: 'https://issues.redhat.com'
+        required: true
+        description: "Jira Server"
+      jira_project:
+        default: "RHODS"
+        required: true
+        description: "Jira Project"
+      jira_labels:
+        default: "MLOps"
+        required: true
+        description: "Jira Labels to Add"
+      jira_issue_type:
+        default: "Story"
+        required: true
+        description: "Jira Issue Type"
+      jira_priority:
+        default: 'Normal'
+        required: true
+        description: "Jira Priority to Set"
+
+jobs:
+  gh-to-jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          repository: HumairAK/gh-to-jira
+          fetch-depth: '0'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Submit Jira
+        env:
+          GITHUB_TOKEN: ${{ secrets.GTJ_GH_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.GTJ_JIRA_TOKEN }}
+          REPOS: ${{ inputs.repos }}
+        run: |
+          python src --component="${{ inputs.component }}" \
+            --target_release="${{ inputs.target_release }}" \
+            --org="${{ inputs.gh_org }}" \
+            --labels="${{ inputs.labels }}" \
+            --jira_server="${{ inputs.jira_server }}" \
+            --jira_project="${{ inputs.jira_project }}" \
+            --jira_labels="${{ inputs.jira_labels }}" \
+            --jira_issue_type="${{ inputs.jira_issue_type }}" \
+            --jira_priority="${{ inputs.jira_priority }}"


### PR DESCRIPTION
Resolves: https://github.com/red-hat-data-services/data-science-pipelines-operator/issues/44
Related: https://github.com/opendatahub-io/data-science-pipelines-operator/issues/177

## Description
Workflow to provide support for downtream jira support.

Collects all prs given a label filter set between the tag range provided for each repos, and submits to the designated jira project.

## How Has This Been Tested?
Tested from my fork to a playground jira instance.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
