### PR TITLE
Use unauthenticated images for go-toolset.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi8/go-toolset:1.18.9-8 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-8 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Related https://github.com/opendatahub-io/data-science-pipelines-operator/issues/177

## Description of your changes:
changing the go-toolset to use the registry that doesn't require authentication same as for the ubi image further down the dockerfile.


## Testing instructions
none needed, the images are identical.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
