### PR TITLE
Add secure pr build triggers.

### DIFF
--- a/.github/workflows/build-prs-trigger.yaml
+++ b/.github/workflows/build-prs-trigger.yaml
@@ -1,0 +1,27 @@
+name: Trigger build images for PRs
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - closed
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  upload-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Save PR payload
+        shell: bash
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.pull_request.number }} >> ./pr/pr_number
+          echo ${{ github.event.pull_request.state }} >> ./pr/pr_state
+          echo ${{ github.event.pull_request.head.sha }} >> ./pr/head_sha
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -1,29 +1,69 @@
 name: Build images for PRs
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["Trigger build images for PRs"]
     types:
-      - opened
-      - reopened
-      - closed
-      - synchronize
-permissions:
-  pull-requests: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+      - completed
 env:
   IMAGE_REPO_DSPO: data-science-pipelines-operator
-  SOURCE_BRANCH: ${{ github.event.pull_request.head.sha }}
   QUAY_ORG: opendatahub
   QUAY_ID: ${{ secrets.QUAY_ID }}
   QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-  TARGET_IMAGE_TAG: pr-${{ github.event.pull_request.number }}
   GH_USER_EMAIL: 140449482+dsp-developers@users.noreply.github.com
   GH_USER_NAME: dsp-developers
 jobs:
-  build-pr-image:
-    if: github.event.pull_request.state == 'open'
+  fetch-data:
+    name: Fetch workflow payload
     runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      pr_state: ${{ steps.vars.outputs.pr_state }}
+      pr_number: ${{ steps.vars.outputs.pr_number }}
+      head_sha: ${{ steps.vars.outputs.head_sha }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+      - shell: bash
+        id: vars
+        run: |
+          pr_number=$(cat ./pr_number)
+          pr_state=$(cat ./pr_state)
+          head_sha=$(cat ./head_sha)
+          echo "pr_number=${pr_number}" >> $GITHUB_OUTPUT
+          echo "pr_state=${pr_state}" >> $GITHUB_OUTPUT
+          echo "head_sha=${head_sha}" >> $GITHUB_OUTPUT
+
+  build-pr-image:
+    if: needs.fetch-data.outputs.pr_state == 'open'
+    runs-on: ubuntu-latest
+    needs: fetch-data
+    concurrency:
+      group: ${{ github.workflow }}-build-pr-image-${{ needs.fetch-data.outputs.pr_number }}
+      cancel-in-progress: true
+    env:
+      SOURCE_BRANCH: ${{ needs.fetch-data.outputs.head_sha }}
+      TARGET_IMAGE_TAG: pr-${{ needs.fetch-data.outputs.pr_number }}
     steps:
       - uses: actions/checkout@v3
       - name: Build Image
@@ -33,6 +73,15 @@ jobs:
           IMAGE_REPO: ${{ env.IMAGE_REPO_DSPO }}
           DOCKERFILE: Dockerfile
           GH_REPO: ${{ github.repository }}
+      - name: Echo PR metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_REPO_DSPO }}:${{ env.TARGET_IMAGE_TAG }}
+        run: |
+          echo ${{ needs.fetch-data.outputs.head_sha }}
+          echo ${{ needs.fetch-data.outputs.pr_number }}
+          echo ${{ needs.fetch-data.outputs.pr_state }}
       - name: Send comment
         shell: bash
         env:
@@ -66,7 +115,7 @@ jobs:
           cd $(mktemp -d)
           git clone git@github.com:opendatahub-io/data-science-pipelines-operator.git
           cd data-science-pipelines-operator/
-          git fetch origin pull/${{ github.event.pull_request.number }}/head
+          git fetch origin pull/${{ needs.fetch-data.outputs.pr_number }}/head
           git checkout -b pullrequest ${{ env.SOURCE_BRANCH }}
           make deploy IMG="${{ env.IMG }}"
           ```
@@ -76,11 +125,17 @@ jobs:
           EOF
           fi
 
-          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/body-file.txt
+          gh pr comment ${{ needs.fetch-data.outputs.pr_number }} --body-file /tmp/body-file.txt
 
   clean-pr-images:
-    if: github.event.pull_request.state == 'closed'
+    if: needs.fetch-data.outputs.pr_state == 'closed'
     runs-on: ubuntu-latest
+    needs: fetch-data
+    concurrency:
+      group: ${{ github.workflow }}-clean-pr-images-${{ needs.fetch-data.outputs.pr_number }}
+      cancel-in-progress: true
+    env:
+      TARGET_IMAGE_TAG: pr-${{ needs.fetch-data.outputs.pr_number }}
     steps:
       - name: Delete PR image
         shell: bash


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Related #https://github.com/opendatahub-io/data-science-pipelines-operator/pull/243

## Description of your changes:
GH does not allow PR workflows to access secrets (for obvious reasons). This pr proposes a secure way to execute pr image builds in an unprivileged environment. Workflows triggered via `workflow_run` event are always triggered from default branch, as such can access repository tickets. 

## Testing instructions
Tested with a fork pr [here](https://github.com/HumairAK/data-science-pipelines-operator/pull/6). 
Triggered workflow when pr closed:  [1](https://github.com/HumairAK/data-science-pipelines-operator/actions/runs/5754669055/job/15600458922)
Triggered work when pr opened: [2](https://github.com/HumairAK/data-science-pipelines-operator/actions/runs/5754626535)


## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
