### PR TITLE
Fix GH workflow to clone dsp-developers/odh-manifests fork

### DIFF
--- a/.github/workflows/odh-manifests-PR-sync.yml
+++ b/.github/workflows/odh-manifests-PR-sync.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Send pull-request
         run: |
           LATEST_TAG=$(git describe --tags --always --abbrev=0)
-          REPOSITORY="opendatahub-io/odh-manifests"
+          REPOSITORY="dsp-developers/odh-manifests"
           FOLDER="bin/$REPOSITORY"
           BRANCH_NAME="chore-update-scripts-to-$LATEST_TAG"
 


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #178 

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Updating the workflow to create a sync PR into odh-manifests, to have the dsp-developers' fork cloned instead of opendatahub-io/odh-manifests.
## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
