### PR TITLE
Update ObjectStore HealthCheck to use StatObject

### DIFF
--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -79,9 +79,9 @@ var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoin
 	if err != nil {
 		switch err := err.(type) {
 
-		// In the singular case that the Error is NoSuchKey, we can verify that the endpoint worked and the object just doesn't exist
+		// In the case that the Error is NoSuchKey (or NoSuchBucket), we can verify that the endpoint worked and the object just doesn't exist
 		case minio.ErrorResponse:
-			if err.Code == "NoSuchKey" {
+			if err.Code == "NoSuchKey" || err.Code == "NoSuchBucket" {
 				return true
 			}
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,15 +18,16 @@ package controllers
 
 import (
 	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"go.uber.org/zap/zapcore"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,7 +74,7 @@ var _ = BeforeEach(func() {
 	ConnectAndQueryDatabase = func(host string, port string, username string, password string, dbname string) bool {
 		return true
 	}
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint string, accesskey, secretkey []byte, secure bool) bool {
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool) bool {
 		return true
 	}
 })


### PR DESCRIPTION
- Provided Credentials may not necessarily have ListBucket permissions, so update the Object Store Health Check to use StatObject instead

## The issue resolved by this Pull Request:
Resolves #262 

## Description of your changes:
Updates DSPA ObjectStore prereq Health Check to use StatObject instead of ListBuckets.  We cannot assume that the provided credentials have ListBuckets permissions granted, so updating the verification command to StatObject (which is used as part of GetObject/ReadObject and required for the underlying DataSciencePipelines functionality)

## Testing instructions
Attempt to create a DSPA with externalStorage, and use credentials that only have PutObject, GetObject, and DeleteObject permissions.  Ensure that the DSPA eventually passes the health check (ObjectStorageAvailable CR condition = `true`).  Additional test cases include using default objectStorage and externally hosted, but non-AWS storage options such as minio, ceph, etc.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
