### PR TITLE
Run PR builds on only code changes...

### DIFF
--- a/.github/workflows/build-prs-trigger.yaml
+++ b/.github/workflows/build-prs-trigger.yaml
@@ -1,6 +1,10 @@
 name: Trigger build images for PRs
 on:
   pull_request:
+    paths:
+      - controllers/**
+      - api/**
+      - config/**
     types:
       - opened
       - reopened
@@ -21,6 +25,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} >> ./pr/pr_number
           echo ${{ github.event.pull_request.state }} >> ./pr/pr_state
           echo ${{ github.event.pull_request.head.sha }} >> ./pr/head_sha
+          echo ${{ github.event.action }} >> ./pr/event_action
       - uses: actions/upload-artifact@v2
         with:
           name: pr

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -22,6 +22,7 @@ jobs:
       pr_state: ${{ steps.vars.outputs.pr_state }}
       pr_number: ${{ steps.vars.outputs.pr_number }}
       head_sha: ${{ steps.vars.outputs.head_sha }}
+      event_action: ${{ steps.vars.outputs.event_action }}
     steps:
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
@@ -50,9 +51,11 @@ jobs:
           pr_number=$(cat ./pr_number)
           pr_state=$(cat ./pr_state)
           head_sha=$(cat ./head_sha)
+          event_action=$(cat ./event_action)
           echo "pr_number=${pr_number}" >> $GITHUB_OUTPUT
           echo "pr_state=${pr_state}" >> $GITHUB_OUTPUT
           echo "head_sha=${head_sha}" >> $GITHUB_OUTPUT
+          echo "head_sha=${event_action}" >> event_action
 
   build-pr-image:
     if: needs.fetch-data.outputs.pr_state == 'open'
@@ -82,6 +85,7 @@ jobs:
           echo ${{ needs.fetch-data.outputs.head_sha }}
           echo ${{ needs.fetch-data.outputs.pr_number }}
           echo ${{ needs.fetch-data.outputs.pr_state }}
+          echo ${{ needs.fetch-data.outputs.event_action }}
       - name: Send comment
         shell: bash
         env:
@@ -91,7 +95,7 @@ jobs:
           git config user.email "${{ env.GH_USER_EMAIL }}"
           git config user.name "${{ env.GH_USER_NAME }}"
 
-          action=${{ github.event.action }}
+          action=${{ needs.fetch-data.outputs.event_action }}
 
           if [[ "$action" == "synchronize" ]]; then
             echo "Change to PR detected. A new PR build was completed." >> /tmp/body-file.txt


### PR DESCRIPTION
Also pass the gh event action for the build action trigger so we can respond accordingly to action type.

## The issue resolved by this Pull Request:
Resolves https://github.com/opendatahub-io/data-science-pipelines-operator/issues/253

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
