### PR TITLE
Add Unit Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,15 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... --tags=test_all -coverprofile cover.out
+
+.PHONY: unittest
+unittest: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -v --tags=test_unit -coverprofile cover.out
+
+.PHONY: functest
+functest: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... --tags=test_functional -coverprofile cover.out
 
 ##@ Build
 

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -1,0 +1,115 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployAPIServer(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedAPIServerName := "ds-pipeline-testdspa"
+
+	// Construct DSPASpec with deployed APIServer
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			APIServer: &dspav1alpha1.APIServer{
+				Deploy: true,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert APIServer Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedAPIServerName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileAPIServer(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert APIServer Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedAPIServerName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDontDeployAPIServer(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedAPIServerName := "ds-pipeline-testdspa"
+
+	// Construct DSPASpec with non-deployed APIServer
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			APIServer: &dspav1alpha1.APIServer{
+				Deploy: false,
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	// Ensure APIServer Deployment doesn't yet exist
+	created, err := reconciler.IsResourceCreated(ctx, dspa, testDSPAName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileAPIServer(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure APIServer Deployment still doesn't exist
+	created, err = reconciler.IsResourceCreated(ctx, dspa, expectedAPIServerName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -1,0 +1,87 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestDeployCommonPolicies(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedNetworkPolicyName := "ds-pipelines-testdspa"
+	expectedEnvoyNetworkPolicyName := "ds-pipelines-envoy-testdspa"
+
+	// Construct Basic DSPA Spec
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert Common NetworkPolicies don't yet exist
+	np := &networkingv1.NetworkPolicy{}
+	created, err := reconciler.IsResourceCreated(ctx, np, expectedNetworkPolicyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	np = &networkingv1.NetworkPolicy{}
+	created, err = reconciler.IsResourceCreated(ctx, np, expectedEnvoyNetworkPolicyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileCommon(dspa, params)
+	assert.Nil(t, err)
+
+	// Assert Common NetworkPolicies now exist
+	np = &networkingv1.NetworkPolicy{}
+	created, err = reconciler.IsResourceCreated(ctx, np, expectedNetworkPolicyName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+
+	np = &networkingv1.NetworkPolicy{}
+	created, err = reconciler.IsResourceCreated(ctx, np, expectedEnvoyNetworkPolicyName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/database_test.go
+++ b/controllers/database_test.go
@@ -1,0 +1,126 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployDatabase(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedDatabaseName := "mariadb-testdspa"
+
+	// Construct DSPA Spec with deployed MariaDB Database
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert Database Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedDatabaseName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileDatabase(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert Database Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedDatabaseName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDontDeployDatabase(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedDatabaseName := "mariadb-testdspa"
+
+	// Construct DSPA Spec with non-deployed MariaDB Database
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: false,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert Database Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedDatabaseName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileDatabase(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert Database Deployment still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedDatabaseName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/dspipeline_controller_func_test.go
+++ b/controllers/dspipeline_controller_func_test.go
@@ -1,3 +1,6 @@
+//go:build test_all || test_functional
+// +build test_all test_functional
+
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +20,7 @@ package controllers
 
 import (
 	"fmt"
+
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
 	. "github.com/onsi/ginkgo/v2"

--- a/controllers/dspipeline_fake_controller.go
+++ b/controllers/dspipeline_fake_controller.go
@@ -1,0 +1,89 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func NewFakeController() *DSPAReconciler {
+	// Setup Fake Client Builder
+	FakeBuilder := fake.NewClientBuilder()
+
+	// Create Scheme
+	FakeScheme := scheme.Scheme
+	utilruntime.Must(clientgoscheme.AddToScheme(FakeScheme))
+	utilruntime.Must(buildv1.AddToScheme(FakeScheme))
+	utilruntime.Must(imagev1.AddToScheme(FakeScheme))
+	utilruntime.Must(routev1.AddToScheme(FakeScheme))
+	utilruntime.Must(dspav1alpha1.AddToScheme(FakeScheme))
+	FakeBuilder.WithScheme(FakeScheme)
+
+	// Build Fake Client
+	FakeClient := FakeBuilder.Build()
+
+	// Generate DSPAReconciler using Fake Client
+	r := &DSPAReconciler{
+		Client:        FakeClient,
+		Log:           ctrl.Log.WithName("controllers").WithName("ds-pipelines-controller"),
+		Scheme:        FakeScheme,
+		TemplatesPath: "../config/internal/",
+	}
+
+	return r
+}
+
+func CreateNewTestObjects() (context.Context, *DSPAParams, *DSPAReconciler) {
+	return context.Background(), &DSPAParams{}, NewFakeController()
+}
+
+func (r *DSPAReconciler) IsResourceCreated(ctx context.Context, obj client.Object, name, namespace string) (bool, error) {
+	// Fake Request for verification
+	nn := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	// Fetch
+	err := r.Get(ctx, nn, obj)
+
+	// Err shouldnt be thrown if resource exists
+	// TODO: implement better verification
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	return true, nil
+}

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -431,8 +431,8 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 	p.ScheduledWorkflow = dsp.Spec.ScheduledWorkflow.DeepCopy()
 	p.PersistenceAgent = dsp.Spec.PersistenceAgent.DeepCopy()
 	p.MlPipelineUI = dsp.Spec.MlPipelineUI.DeepCopy()
-	p.MariaDB = dsp.Spec.MariaDB.DeepCopy()
-	p.Minio = dsp.Spec.Minio.DeepCopy()
+	p.MariaDB = dsp.Spec.Database.MariaDB.DeepCopy()
+	p.Minio = dsp.Spec.ObjectStorage.Minio.DeepCopy()
 	p.OAuthProxy = config.GetStringConfigWithDefault(config.OAuthProxyImagePath, config.DefaultImageValue)
 	p.MLMD = dsp.Spec.MLMD.DeepCopy()
 

--- a/controllers/mlmd_test.go
+++ b/controllers/mlmd_test.go
@@ -1,0 +1,278 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployMLMD(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedMLMDEnvoyName := "ds-pipeline-metadata-envoy-testdspa"
+	expectedMLMDGRPCName := "ds-pipeline-metadata-grpc-testdspa"
+	expectedMLMDWriterName := "ds-pipeline-metadata-writer-testdspa"
+
+	// Construct DSPA Spec with MLMD Enabled
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			APIServer: &dspav1alpha1.APIServer{
+				// TODO: This appears to be required which is out-of-spec (.Spec.APIServer should be fully defaultable),
+				// but test throws an nil pointer panic if it isn't provided.
+				// possibly due to test setup - Investigate.
+				ArchiveLogs: true,
+			},
+			MLMD: &dspav1alpha1.MLMD{
+				Deploy: true,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileMLMD(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDontDeployMLMD(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedMLMDEnvoyName := "ds-pipeline-metadata-envoy-testdspa"
+	expectedMLMDGRPCName := "ds-pipeline-metadata-grpc-testdspa"
+	expectedMLMDWriterName := "ds-pipeline-metadata-writer-testdspa"
+
+	// Construct DSPA Spec with MLMD Not Enabled
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			APIServer: &dspav1alpha1.APIServer{
+				// TODO: This appears to be required which is out-of-spec (.Spec.APIServer should be fully defaultable),
+				// but test throws an nil pointer panic if it isn't provided.
+				// possibly due to test setup - Investigate.
+				ArchiveLogs: true,
+			},
+			MLMD: &dspav1alpha1.MLMD{
+				Deploy: false,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileMLMD(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources stil doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDefaultDeployBehaviorMLMD(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedMLMDEnvoyName := "ds-pipeline-metadata-envoy-testdspa"
+	expectedMLMDGRPCName := "ds-pipeline-metadata-grpc-testdspa"
+	expectedMLMDWriterName := "ds-pipeline-metadata-writer-testdspa"
+
+	// Construct DSPA Spec with MLMD Spec not defined
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			APIServer: &dspav1alpha1.APIServer{
+				// TODO: This appears to be required which is out-of-spec (.Spec.APIServer should be fully defaultable),
+				// but test throws an nil pointer panic if it isn't provided.
+				// possibly due to test setup - Investigate.
+				ArchiveLogs: true,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources doesn't yet exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileMLMD(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Envoy resources still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDEnvoyName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-GRPC resources still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDGRPCName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Ensure MLMD-Writer resources still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedMLMDWriterName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/mlpipeline_ui_test.go
+++ b/controllers/mlpipeline_ui_test.go
@@ -1,0 +1,183 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployUI(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedUIName := "ds-pipeline-ui-testdspa"
+
+	// Construct DSPASpec with deployed UI
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			MlPipelineUI: &dspav1alpha1.MlPipelineUI{
+				Deploy: true,
+				Image:  "test-image:latest",
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure UI Deployement doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileUI(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure UI Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDontDeployUI(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedUIName := "ds-pipeline-ui-testdspa"
+
+	// Construct DSPASpec with non-deployed UI
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			MlPipelineUI: &dspav1alpha1.MlPipelineUI{
+				Deploy: false,
+				Image:  "uiimage",
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure UI Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileUI(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure UI Deployment still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDefaultDeployBehaviorUI(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedUIName := "ds-pipeline-ui-testdspa"
+
+	// Construct DSPASpec without UI defined
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+
+	// Ensure UI Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileUI(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure UI Deployment still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedUIName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/persistence_agent_test.go
+++ b/controllers/persistence_agent_test.go
@@ -1,0 +1,117 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployPersistenceAgent(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedPersistenceAgentName := "ds-pipeline-persistenceagent-testdspa"
+
+	// Construct DSPASpec with deployed PersistenceAgent
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			PersistenceAgent: &dspav1alpha1.PersistenceAgent{
+				Deploy: true,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure PersistenceAgent Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedPersistenceAgentName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcilePersistenceAgent(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure PersistenceAgent Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedPersistenceAgentName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDontDeployPersistenceAgent(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedPersistenceAgentName := "ds-pipeline-persistenceagent-testdspa"
+
+	// Construct DSPASpec with non-deployed PersistenceAgent
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			PersistenceAgent: &dspav1alpha1.PersistenceAgent{
+				Deploy: false,
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	// Ensure PersistenceAgent Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedPersistenceAgentName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcilePersistenceAgent(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure PersistenceAgent Deployment still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedPersistenceAgentName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/scheduled_workflow_test.go
+++ b/controllers/scheduled_workflow_test.go
@@ -1,0 +1,118 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeployScheduledWorkflow(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedScheduledWorkflowName := "ds-pipeline-scheduledworkflow-testdspa"
+
+	// Construct DSPASpec with deployed ScheduledWorkflow
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			ScheduledWorkflow: &dspav1alpha1.ScheduledWorkflow{
+				Deploy: true,
+			},
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Ensure ScheduledWorkflow Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedScheduledWorkflowName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileScheduledWorkflow(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure ScheduledWorkflow Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedScheduledWorkflowName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+
+}
+
+func TestDontDeployScheduledWorkflow(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedScheduledWorkflowName := "ds-pipeline-scheduledworkflow-testdspa"
+
+	// Construct DSPASpec with non-deployed ScheduledWorkflow
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			ScheduledWorkflow: &dspav1alpha1.ScheduledWorkflow{
+				Deploy: false,
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	// Ensure ScheduledWorkflow Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedScheduledWorkflowName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileScheduledWorkflow(dspa, params)
+	assert.Nil(t, err)
+
+	// Ensure ScheduledWorkflow Deployment still doesn't exist
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedScheduledWorkflowName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -1,0 +1,183 @@
+//go:build test_all || test_unit
+
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestDeployStorage(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedStorageName := "minio-testdspa"
+
+	// Construct DSPA Spec with deployed Minio Object Storage
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: true,
+					Image:  "someimage",
+					Resources: &dspav1alpha1.ResourceRequirements{ //TODO: fails without this block.  Why?
+						Requests: &dspav1alpha1.Resources{
+							CPU:    resource.MustParse("250m"),
+							Memory: resource.MustParse("500Mi"),
+						},
+						Limits: &dspav1alpha1.Resources{
+							CPU:    resource.MustParse("500m"),
+							Memory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert ObjectStorage Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileStorage(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert ObjectStorage Deployment now exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+}
+func TestDontDeployStorage(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedStorageName := "minio-testdspa"
+
+	// Construct DSPA Spec with non-deployed Minio Object Storage
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1alpha1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.Nil(t, err)
+
+	// Assert ObjectStorage Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileStorage(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert ObjectStorage Deployment still doesn't exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}
+
+func TestDefaultDeployBehaviorStorage(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedStorageName := "minio-testdspa"
+
+	// Construct DSPA Spec with deployed Minio Object Storage
+	dspa := &dspav1alpha1.DataSciencePipelinesApplication{
+		Spec: dspav1alpha1.DSPASpec{
+			Database: &dspav1alpha1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1alpha1.MariaDB{
+					Deploy: true,
+				},
+			},
+			ObjectStorage: &dspav1alpha1.ObjectStorage{
+				DisableHealthCheck: false,
+			},
+		},
+	}
+
+	// Enrich DSPA with name+namespace
+	dspa.Name = testDSPAName
+	dspa.Namespace = testNamespace
+
+	// Create Context, Fake Controller and Params
+	ctx, params, reconciler := CreateNewTestObjects()
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	assert.NotNil(t, err) // DSPAParams should throw an error if no objstore is provided
+
+	// Assert ObjectStorage Deployment doesn't yet exist
+	deployment := &appsv1.Deployment{}
+	created, err := reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+
+	// Run test reconciliation
+	err = reconciler.ReconcileStorage(ctx, dspa, params)
+	assert.Nil(t, err)
+
+	// Assert ObjectStorage Deployment still doesn't exists
+	deployment = &appsv1.Deployment{}
+	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedStorageName, testNamespace)
+	assert.False(t, created)
+	assert.Nil(t, err)
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,3 +1,5 @@
+//go:build test_all || test_functional
+
 /*
 Copyright 2023.
 

--- a/controllers/testutil/util.go
+++ b/controllers/testutil/util.go
@@ -19,14 +19,16 @@ package testutil
 import (
 	"context"
 	"fmt"
+
+	"io/ioutil"
+	"os"
+	"time"
+
 	mf "github.com/manifestival/manifestival"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -71,6 +72,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #162

## Description of your changes:
- Implements the concept of 'unit' and 'func' test classes
- Adds 2 new Make commands: `make functest` and `make unittest`, which run their respective classes of tests using build labels denoted below
- `make test` still runs both unit and functional tests.
- Updates suite_test.go to run as a functional-class test suite (apply build label `test_functional`)
- Add unit tests for all sub-reconciliation functions (build label `test_unit`)


## Testing instructions
- run `make test`, ensure all passing
- run `make functest`, ensure passes
- run `make unittest`, ensure passes and >20% code coverage (specified as minimum target in issue spec)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
