### PR TITLE
Hardcode obj store info in artifact script.

### DIFF
--- a/config/internal/apiserver/artifact_script.yaml.tmpl
+++ b/config/internal/apiserver/artifact_script.yaml.tmpl
@@ -9,10 +9,10 @@ data:
         if [ -f "$workspace_dest/$artifact_name" ]; then
             echo sending to: ${workspace_dest}/${artifact_name}
             tar -cvzf $1.tgz -C ${workspace_dest} ${artifact_name}
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint {{.ObjectStorageConnection.Endpoint}} cp $1.tgz s3://{{.ObjectStorageConnection.Bucket}}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         elif [ -f "$2" ]; then
             tar -cvzf $1.tgz -C $(dirname $2) ${artifact_name}
-            aws s3 --endpoint ${ARTIFACT_ENDPOINT} cp $1.tgz s3://${ARTIFACT_BUCKET}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+            aws s3 --endpoint {{.ObjectStorageConnection.Endpoint}} cp $1.tgz s3://{{.ObjectStorageConnection.Bucket}}/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
         else
             echo "$2 file does not exist. Skip artifact tracking for $1"
         fi


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #294 

Note that this resolves only the failing pods (i.e. scheduled runs will complete successfully). 

However big data passing still does not work, i.e. data doesn't get stored in s3, this is due to https://github.com/opendatahub-io/data-science-pipelines-operator/issues/300, which is larger in scope and requires further attention.

## Description of your changes:
As pointed out in #294 the env vars `ARTIFACT_ENDPOINT` and `ARTIFACT_BUCKET` are not being populated because the tekton annotations with the obj store details are not being added in scheduled runs, this will hard code those fields to allow for data passing to work.

## Testing instructions
1. Deploy dspo/dspa
2. Create a scheduled run that does data passing (e.g. iris example)
3. Confirm data shows up in s3
4. Also run flip-coin scheduled run, confirm it works without issues (previously it would fail at first pod)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
