### PR TITLE
align example pipeline yaml images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ Dockerfile.cross
 *.code-workspace
 *.vscode
 
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/example_pipelines/condition.py
+++ b/docs/example_pipelines/condition.py
@@ -24,11 +24,11 @@ def print_msg(msg: str):
 
 
 flip_coin_op = components.create_component_from_func(
-    flip_coin, base_image='quay.io/hukhan/python:alpine3.6')
+    flip_coin, base_image='registry.access.redhat.com/ubi8/python-39')
 print_op = components.create_component_from_func(
-    print_msg, base_image='quay.io/hukhan/python:alpine3.6')
+    print_msg, base_image='registry.access.redhat.com/ubi8/python-39')
 random_num_op = components.create_component_from_func(
-    random_num, base_image='quay.io/hukhan/python:alpine3.6')
+    random_num, base_image='registry.access.redhat.com/ubi8/python-39')
 
 
 @dsl.pipeline(
@@ -54,4 +54,9 @@ def flipcoin_pipeline():
 
 if __name__ == '__main__':
     from kfp_tekton.compiler import TektonCompiler
-    TektonCompiler().compile(flipcoin_pipeline, __file__.replace('.py', '.yaml'))
+    from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
+    config = TektonPipelineConf()
+    config.set_condition_image_name("registry.access.redhat.com/ubi8/python-39")
+    compiler = TektonCompiler()
+    compiler._set_pipeline_conf(config)
+    compiler.compile(flipcoin_pipeline, __file__.replace('.py', '.yaml'))

--- a/docs/example_pipelines/condition.yaml
+++ b/docs/example_pipelines/condition.yaml
@@ -81,7 +81,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         results:
         - name: Output
           type: string
@@ -91,7 +91,7 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Flip coin", "outputs":
-              [{"name": "Output", "type": "String"}], "version": "Flip coin@sha256=2895da7ed0b52f45e6d6a4d8837e4c1ee4ba99e14e5877320155243c67e4610e"}'
+              [{"name": "Output", "type": "String"}], "version": "Flip coin@sha256=32d5bd05b9fa18850505b73d6fb8489cc61f83033306230c8e4da12bdd8890e0"}'
     - name: random-num
       taskSpec:
         steps:
@@ -151,7 +151,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         results:
         - name: Output
           type: string
@@ -162,7 +162,7 @@ spec:
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Random num",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Random
-              num@sha256=28d899c9492aeb0e45072bedfa35313fbe788233de0fc7a14a81ff8ee071d627"}'
+              num@sha256=053403c9d093bbdb07a6da42e22012e69fa5132e38cc179dae5f3a629543650c"}'
       when:
       - input: $(tasks.condition-1.results.outcome)
         operator: in
@@ -196,7 +196,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         params:
         - name: random-num-Output
         metadata:
@@ -204,7 +204,7 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print msg", "outputs":
-              [], "version": "Print msg@sha256=c8484b77b0a3f045a812bd6b570ef17df03d4fde0ef50480243561a339f7b024"}'
+              [], "version": "Print msg@sha256=1d475b025fa0e9910c3c2827a8280bb0fb85abeba446658a944570e1de7f0f98"}'
       when:
       - input: $(tasks.condition-2.results.outcome)
         operator: in
@@ -238,7 +238,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         params:
         - name: random-num-Output
         metadata:
@@ -246,7 +246,7 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print msg", "outputs":
-              [], "version": "Print msg@sha256=c8484b77b0a3f045a812bd6b570ef17df03d4fde0ef50480243561a339f7b024"}'
+              [], "version": "Print msg@sha256=1d475b025fa0e9910c3c2827a8280bb0fb85abeba446658a944570e1de7f0f98"}'
       when:
       - input: $(tasks.condition-3.results.outcome)
         operator: in
@@ -311,7 +311,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         results:
         - name: Output
           type: string
@@ -322,7 +322,7 @@ spec:
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Random num",
               "outputs": [{"name": "Output", "type": "Integer"}], "version": "Random
-              num@sha256=28d899c9492aeb0e45072bedfa35313fbe788233de0fc7a14a81ff8ee071d627"}'
+              num@sha256=053403c9d093bbdb07a6da42e22012e69fa5132e38cc179dae5f3a629543650c"}'
       when:
       - input: $(tasks.condition-4.results.outcome)
         operator: in
@@ -356,7 +356,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         params:
         - name: random-num-2-Output
         metadata:
@@ -364,7 +364,7 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print msg", "outputs":
-              [], "version": "Print msg@sha256=c8484b77b0a3f045a812bd6b570ef17df03d4fde0ef50480243561a339f7b024"}'
+              [], "version": "Print msg@sha256=1d475b025fa0e9910c3c2827a8280bb0fb85abeba446658a944570e1de7f0f98"}'
       when:
       - input: $(tasks.condition-5.results.outcome)
         operator: in
@@ -398,7 +398,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: quay.io/hukhan/python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
         params:
         - name: random-num-2-Output
         metadata:
@@ -406,7 +406,7 @@ spec:
             pipelines.kubeflow.org/cache_enabled: "true"
           annotations:
             pipelines.kubeflow.org/component_spec_digest: '{"name": "Print msg", "outputs":
-              [], "version": "Print msg@sha256=c8484b77b0a3f045a812bd6b570ef17df03d4fde0ef50480243561a339f7b024"}'
+              [], "version": "Print msg@sha256=1d475b025fa0e9910c3c2827a8280bb0fb85abeba446658a944570e1de7f0f98"}'
       when:
       - input: $(tasks.condition-6.results.outcome)
         operator: in
@@ -452,7 +452,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
     - name: condition-2
       params:
       - name: operand1
@@ -493,7 +493,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
       when:
       - input: $(tasks.condition-1.results.outcome)
         operator: in
@@ -539,7 +539,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
       when:
       - input: $(tasks.condition-1.results.outcome)
         operator: in
@@ -585,7 +585,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
     - name: condition-5
       params:
       - name: operand1
@@ -626,7 +626,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
       when:
       - input: $(tasks.condition-4.results.outcome)
         operator: in
@@ -672,7 +672,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: python:alpine3.6
+          image: registry.access.redhat.com/ubi8/python-39
       when:
       - input: $(tasks.condition-4.results.outcome)
         operator: in


### PR DESCRIPTION
Some tasks and especially root task in pipeline uses: `quay.io/hukhan/python:alpine3.6`
see:
https://github.com/opendatahub-io/data-science-pipelines-operator/blob/b34fbb8402efd3f2092c7931f683d5b906809961/docs/example_pipelines/condition.yaml#L84

other steps used (dockerhub):
`image: python:alpine3.6`
see:
https://github.com/opendatahub-io/data-science-pipelines-operator/blob/b34fbb8402efd3f2092c7931f683d5b906809961/docs/example_pipelines/condition.yaml#L455

so this changes aligns images _from all tasks, to root task image_.

## The issue resolved by this Pull Request:
Might incur in pipeline failure "in the middle" as the tasks using different image might incur in backoff etc.

Example as I followed the quickstart in: https://github.com/opendatahub-io/data-science-pipelines-operator#quickstart

![Screenshot 2023-09-01 at 16 11 23](https://github.com/opendatahub-io/data-science-pipelines-operator/assets/1699252/43323360-52ff-42d4-a627-7b03e7d1c492)

Pipeline definition file as coming in this PR with the changes applied, using the same image as the root task does not brake in the middle:

![Screenshot 2023-09-01 at 16 26 44](https://github.com/opendatahub-io/data-science-pipelines-operator/assets/1699252/e3f2379a-6e71-44f9-b3fb-483e1c632be6)

qed.

## Description of your changes:
Aligns task's images to root task image (`quay.io/hukhan/python:alpine3.6`)

cc @danielezonca @HumairAK @rareddy if any other suggestions?

## Testing instructions
manually verified expected behaviour as documented above.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
