### PR TITLE
Add timeout to db/storage health checks, increase reconcile concurrency 

### DIFF
--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -20,6 +20,7 @@ import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"time"
 )
 
 const (
@@ -102,6 +103,14 @@ var requiredFields = []string{
 	MariaDBImagePath,
 	OAuthProxyImagePath,
 }
+
+// DefaultDBConnectionTimeout is the default DB storage healthcheck timeout
+const DefaultDBConnectionTimeout = time.Second * 15
+
+// DefaultObjStoreConnectionTimeout is the default Object storage healthcheck timeout
+const DefaultObjStoreConnectionTimeout = time.Second * 15
+
+const DefaultMaxConcurrentReconciles = 10
 
 func GetConfigRequiredFields() []string {
 	return requiredFields

--- a/controllers/database.go
+++ b/controllers/database.go
@@ -20,11 +20,9 @@ import (
 	"database/sql"
 	b64 "encoding/base64"
 	"fmt"
-	"time"
-
 	_ "github.com/go-sql-driver/mysql"
-
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 )
 
 const dbSecret = "mariadb/secret.yaml.tmpl"
@@ -40,7 +38,7 @@ var dbTemplates = []string{
 // extract to var for mocking in testing
 var ConnectAndQueryDatabase = func(host, port, username, password, dbname string) bool {
 	// Create a context with a timeout of 1 second
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), config.DefaultDBConnectionTimeout)
 	defer cancel()
 
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", username, password, host, port, dbname)
@@ -52,7 +50,6 @@ var ConnectAndQueryDatabase = func(host, port, username, password, dbname string
 
 	testStatement := "SELECT 1;"
 	_, err = db.QueryContext(ctx, testStatement)
-
 	return err == nil
 }
 

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -573,6 +574,9 @@ func (r *DSPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return reconcileRequests
 			})).
 		// TODO: Add watcher for ui cluster rbac since it has no owner
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: config.DefaultMaxConcurrentReconciles,
+		}).
 		Complete(r)
 }
 

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -21,13 +21,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
-	"time"
-
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
+	"net/http"
 )
 
 const storageSecret = "minio/secret.yaml.tmpl"
@@ -79,7 +78,7 @@ var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoin
 		return false
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, config.DefaultObjStoreConnectionTimeout)
 	defer cancel()
 
 	// Attempt to run Stat on the Object.  It doesn't necessarily have to exist, we just want to verify we can successfully run an authenticated s3 command

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
@@ -77,6 +78,9 @@ var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoin
 		log.Info(fmt.Sprintf("Could not connect to object storage endpoint: %s", endpoint))
 		return false
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
 
 	// Attempt to run Stat on the Object.  It doesn't necessarily have to exist, we just want to verify we can successfully run an authenticated s3 command
 	_, err = minioClient.StatObject(ctx, bucket, "some-random-object", minio.GetObjectOptions{})


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #280
May also address #260 -- not confirmed.

## Description of your changes:
Add 1second time out to db/storage healthcheck.
Also add concurrent reconciles so when deploying multiple DSPAs they do not get backlogged (as much) in watcher queue.

## Testing instructions
1. Deploy DSPO from this pr
2. Deploy 3 dspa's simultaneously 
3. Ensure that the status field is updated in ~1seconds for all 3 (confirm 1s timeout on db/storage health check) 
4. Also ensure that pods start spinning up at the same time for all 3 (confirm concurrent reconciles)
5. Regression checks:
  * Ensure when db/s3 info is invalid the status is reported as such in the dspa CR status field 
  * Ensure valid external db/s3 configurations result in full DSPA deployment (run a flip coin to sanity check)
  * Ensure valid external s3 + default mariadb results in full dSPA deployment (run a flip coin to sanity check)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
