### PR TITLE
Add pattern requirement for mariadb db/user name.

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -132,10 +132,14 @@ type MariaDB struct {
 	// +kubebuilder:validation:Optional
 	Deploy bool   `json:"deploy"`
 	Image  string `json:"image,omitempty"`
+	// The MariadB username that will be created. Should match `^[a-zA-Z0-9_]+`
 	// +kubebuilder:default:=mlpipeline
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	Username       string          `json:"username,omitempty"`
 	PasswordSecret *SecretKeyValue `json:"passwordSecret,omitempty"`
 	// +kubebuilder:default:=mlpipeline
+	// The database name that will be created. Should match `^[a-zA-Z0-9_]+`
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	DBName string `json:"pipelineDBName,omitempty"`
 	// +kubebuilder:default:="10Gi"
 	PVCSize   resource.Quantity     `json:"pvcSize,omitempty"`

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -187,6 +187,9 @@ spec:
                         type: object
                       pipelineDBName:
                         default: mlpipeline
+                        description: The database name that will be created. Should
+                          match `^[a-zA-Z0-9_]+`
+                        pattern: ^[a-zA-Z0-9_]+$
                         type: string
                       pvcSize:
                         anyOf:
@@ -235,6 +238,9 @@ spec:
                         type: object
                       username:
                         default: mlpipeline
+                        description: The MariadB username that will be created. Should
+                          match `^[a-zA-Z0-9_]+`
+                        pattern: ^[a-zA-Z0-9_]+$
                         type: string
                     type: object
                 type: object


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #207

## Description of your changes:
CRD validation now takes into account the regexes used to validate identifiers for mariadb user/db names

## Testing instructions
1. deploy dspo
2. deploy dspa with invalid user/db names for mariadb spec, example: 
```yaml
spec:
  database:
    mariaDB:
      pipelineDBName: test-fail
      username: test-fail
```
3. you should see an error reported from api server
4. deploy with valid pipeline db and user names, it should now work
```yaml
spec:
  database:
    mariaDB:
      pipelineDBName: test_pass
      username: test_pass
```
5. Try different combinations


**NOTE**:  that if a user had deployed a DSPA with invalid db identifier names (e.g: "test-fail"), then updated DSPO, DSPO will report errors for this DSPA until the offending DSPA invalid field is updated or removed, example: 
```
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:326
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234
2023-09-08T18:03:58Z DEBUG DataSciencePipelinesApplication Reconciler called. {"namespace": "dspa1", "dspa_name": "sample"}
2023-09-08T18:03:58Z ERROR Reconciler error {"controller": "datasciencepipelinesapplication", "controllerGroup": "datasciencepipelinesapplications.opendatahub.io", "controllerKind": "DataSciencePipelinesApplication", "DataSciencePipelinesApplication": {"name":"sample","namespace":"dspa1"}, "namespace": "dspa1", "name": "sample", "reconcileID": "2b0a4ca3-96b7-4a50-86a2-9cece3448e56", "error": "DataSciencePipelinesApplication.datasciencepipelinesapplications.opendatahub.io \"sample\" is invalid: spec.database.mariaDB.pipelineDBName: Invalid value: \"`te-st`\": spec.database.mariaDB.pipelineDBName in body should match '^[a-zA-Z0-9_]+$'"}

```


## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
