### PR TITLE
Update kfdef to correctly replace versions

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Prepare for Upgrade Testing
         run: |
           # Update the KfDef manifest with the candidate version
-          sed -i "s/main/${{ inputs.candidate-version }}/" ${{ env.RESOURCES_DIR }}/kfdef/kfdef.yaml
+          sed -i "s/${{ inputs.released-version }}/${{ inputs.candidate-version }}/" ${{ env.RESOURCES_DIR }}/kfdef/kfdef.yaml
         working-directory: ${{ env.RESOURCES_DIR }}/kfdef
 
       - name: Print KfDef Manifest Contents


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #216 

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Updating the replace statement in the step to prepare kfdef for upgrade testing, to correctly replace versions. Currently, it attempts to replace `main` with the `candidate` version, but since the kfdef's already been updated to replace `main` with the `released` version, the kfdef update doesn't happen. Check this run on my fork for instance: https://github.com/DharmitD/data-science-pipelines-operator/actions/runs/6164537886/job/16730453973
If you look at the printed kfdef contents, the uri still points to `1.2.x` which I've subbed in as the released branch in the workflow inputs.

This fix would replace `released` version with the `candidate` version in the kfdef. Example run of this fix on my fork: https://github.com/DharmitD/data-science-pipelines-operator/actions/runs/6164537886/job/16730453973
Notice that the kfdef uri now points to `1.3.x` (the candidate version) and the kfdef is `configured` in the next step, not left `unchanged`.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
