### PR TITLE
Parameterize DSPO max concurrency count

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -106,5 +106,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.ZAP_LOG_LEVEL
+  - name: MAX_CONCURRENT_RECONCILES
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MAX_CONCURRENT_RECONCILES
 configurations:
   - params.yaml

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -11,4 +11,4 @@ IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro:8.8
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1
 IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
 ZAP_LOG_LEVEL=info
-MAX_CONCURRENT_RECONCILES=20
+MAX_CONCURRENT_RECONCILES=10

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -11,3 +11,4 @@ IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro:8.8
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1
 IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
 ZAP_LOG_LEVEL=info
+MAX_CONCURRENT_RECONCILES=20

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         args:
         - --leader-elect
         - --zap-log-level=$(ZAP_LOG_LEVEL)
-        - --MaxConcurrentReconciles=20
+        - --MaxConcurrentReconciles=$(MAX_CONCURRENT_RECONCILES)
         - --config
         - /home/config
         image: $(IMAGES_DSPO)
@@ -60,6 +60,8 @@ spec:
             value: $(IMAGES_MLMDWRITER)
           - name: ZAP_LOG_LEVEL
             value: $(ZAP_LOG_LEVEL)
+          - name: MAX_CONCURRENT_RECONCILES
+            value: $(MAX_CONCURRENT_RECONCILES)
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
         args:
         - --leader-elect
         - --zap-log-level=$(ZAP_LOG_LEVEL)
+        - --MaxConcurrentReconciles=20
         - --config
         - /home/config
         image: $(IMAGES_DSPO)

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -48,9 +48,10 @@ const finalizerName = "datasciencepipelinesapplications.opendatahub.io/finalizer
 // DSPAReconciler reconciles a DSPAParams object
 type DSPAReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Log           logr.Logger
-	TemplatesPath string
+	Scheme                       *runtime.Scheme
+	Log                          logr.Logger
+	TemplatesPath                string
+	MaxConcurrentReconcilesParam int
 }
 
 func (r *DSPAReconciler) Apply(owner mf.Owner, params *DSPAParams, template string, fns ...mf.Transformer) error {
@@ -576,7 +577,7 @@ func (r *DSPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			})).
 		// TODO: Add watcher for ui cluster rbac since it has no owner
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: config.DefaultMaxConcurrentReconciles,
+			MaxConcurrentReconciles: r.MaxConcurrentReconcilesParam,
 		}).
 		Complete(r)
 }

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -48,10 +48,10 @@ const finalizerName = "datasciencepipelinesapplications.opendatahub.io/finalizer
 // DSPAReconciler reconciles a DSPAParams object
 type DSPAReconciler struct {
 	client.Client
-	Scheme                       *runtime.Scheme
-	Log                          logr.Logger
-	TemplatesPath                string
-	MaxConcurrentReconcilesParam int
+	Scheme                  *runtime.Scheme
+	Log                     logr.Logger
+	TemplatesPath           string
+	MaxConcurrentReconciles int
 }
 
 func (r *DSPAReconciler) Apply(owner mf.Owner, params *DSPAParams, template string, fns ...mf.Transformer) error {
@@ -577,7 +577,7 @@ func (r *DSPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			})).
 		// TODO: Add watcher for ui cluster rbac since it has no owner
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: r.MaxConcurrentReconcilesParam,
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
 		}).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -139,11 +139,11 @@ func main() {
 	}
 
 	if err = (&controllers.DSPAReconciler{
-		Client:                       mgr.GetClient(),
-		Scheme:                       mgr.GetScheme(),
-		Log:                          ctrl.Log,
-		TemplatesPath:                "config/internal/",
-		MaxConcurrentReconcilesParam: maxConcurrentReconciles,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Log:                     ctrl.Log,
+		TemplatesPath:           "config/internal/",
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DSPAParams")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -103,12 +103,14 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var configPath string
+	var maxConcurrentReconciles int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&configPath, "config", "", "Path to JSON file containing config")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&maxConcurrentReconciles, "MaxConcurrentReconciles", config.DefaultMaxConcurrentReconciles, "Maximum concurrent reconciles")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
@@ -137,10 +139,11 @@ func main() {
 	}
 
 	if err = (&controllers.DSPAReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Log:           ctrl.Log,
-		TemplatesPath: "config/internal/",
+		Client:                       mgr.GetClient(),
+		Scheme:                       mgr.GetScheme(),
+		Log:                          ctrl.Log,
+		TemplatesPath:                "config/internal/",
+		MaxConcurrentReconcilesParam: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DSPAParams")
 		os.Exit(1)


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #368

## Description of your changes:
Added a new argument "MaxConcurrentReconciles" in the manager.yaml file and read the value from the argument to use it in the controller.
## Testing instructions
Pull my branch and once you deploy it, we should be able to see the worker count in the logs as below:
Starting workers	{"controller": "datasciencepipelinesapplication", "controllerGroup": "datasciencepipelinesapplications.opendatahub.io", "controllerKind": "DataSciencePipelinesApplication", "worker count": 10}
If you want to update the count, update "MaxConcurrentReconciles" arg in manager.yaml file and redeploy to see the updated count in logs. 
If you want to see the usage of "DefaultMaxConcurrentReconciles"  which is set to 10, remove the "MaxConcurrentReconciles" arg in manager.yaml file and redeploy to see the worker count automatically updates to 10.
## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
