### PR TITLE
Add data-science-pipelines- nameprefix to v2 RBAC manifests

### DIFF
--- a/config/v2/cache/clusterrole.yaml
+++ b/config/v2/cache/clusterrole.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kubeflow-pipelines-cache-deployer-clusterrole
-  name: kubeflow-pipelines-cache-deployer-clusterrole
+    app: data-science-pipelines-cache-deployer-clusterrole
+  name: data-science-pipelines-cache-deployer-clusterrole
 rules:
 - apiGroups:
   - certificates.k8s.io

--- a/config/v2/cache/clusterrolebinding.yaml
+++ b/config/v2/cache/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+  name: data-science-pipelines-cache-deployer-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeflow-pipelines-cache-deployer-clusterrole
+  name: data-science-pipelines-cache-deployer-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kubeflow-pipelines-cache-deployer-sa
+  name: data-science-pipelines-cache-deployer-sa
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/cache/serviceaccount.yaml
+++ b/config/v2/cache/serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kubeflow-pipelines-cache-deployer-sa
+  name: data-science-pipelines-cache-deployer-sa

--- a/config/v2/driver/clusterrole.yaml
+++ b/config/v2/driver/clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: data-science-pipelines-operator
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-cluster-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipeline
+  name: data-science-pipelines-driver-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/driver/clusterrolebinding.yaml
+++ b/config/v2/driver/clusterrolebinding.yaml
@@ -3,15 +3,15 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: data-science-pipelines-operator
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-cluster-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipeline
+  name: data-science-pipelines-driver-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-driver-cluster-access-clusterrole
+  name: data-science-pipelines-driver-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-driver
+  name: data-science-pipelines-driver
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/driver/deployment.yaml
+++ b/config/v2/driver/deployment.yaml
@@ -2,30 +2,30 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: ckfp-driver
+    app.kubernetes.io/component: cdata-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
-    app.kubernetes.io/part-of: kubeflow-pipeline
+    app.kubernetes.io/name: data-science-pipelines-driver
+    app.kubernetes.io/part-of: data-science-pipeline
     app.kubernetes.io/version: devel
-  name: kfp-driver
+  name: data-science-pipelines-driver
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: kfp-driver
+      app.kubernetes.io/component: data-science-pipelines-driver
       app.kubernetes.io/instance: default
-      app.kubernetes.io/name: kfp-driver
-      app.kubernetes.io/part-of: kubeflow-pipeline
+      app.kubernetes.io/name: data-science-pipelines-driver
+      app.kubernetes.io/part-of: data-science-pipeline
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: kfp-driver
-        app.kubernetes.io/component: kfp-driver
+        app: data-science-pipelines-driver
+        app.kubernetes.io/component: data-science-pipelines-driver
         app.kubernetes.io/instance: default
-        app.kubernetes.io/name: kfp-driver
-        app.kubernetes.io/part-of: kubeflow-pipeline
+        app.kubernetes.io/name: data-science-pipelines-driver
+        app.kubernetes.io/part-of: data-science-pipeline
         app.kubernetes.io/version: devel
     spec:
       containers:
@@ -42,9 +42,9 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-driver:2.0.0
+        image: quay.io/internaldatahub/data-science-pipelines-driver:2.0.0
         imagePullPolicy: Always
-        name: kfp-driver
+        name: data-science-pipelines-driver
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -54,4 +54,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-driver
+      serviceAccountName: data-science-pipelines-driver

--- a/config/v2/driver/role.yaml
+++ b/config/v2/driver/role.yaml
@@ -3,11 +3,11 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/name: data-science-pipelines-operator
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kubeflow-pipeline
+    app.kubernetes.io/part-of: data-science-pipeline
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-driver-role
+  name: data-science-pipelines-driver-role
 rules:
 - apiGroups:
   - ""
@@ -49,7 +49,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - kubeflow.org
+  - data-science.org
   resources:
   - '*'
   verbs:
@@ -69,7 +69,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/driver/rolebinding.yaml
+++ b/config/v2/driver/rolebinding.yaml
@@ -3,15 +3,15 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: data-science-pipelines-operator
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-rolebinding
+    app.kubernetes.io/part-of: data-science-pipeline
+  name: data-science-pipelines-driver-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-driver-role
+  name: data-science-pipelines-driver-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-driver
+  name: data-science-pipelines-driver
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/driver/service.yaml
+++ b/config/v2/driver/service.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kfp-driver
-    app.kubernetes.io/component: kfp-driver
+    app: data-science-pipelines-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
-    app.kubernetes.io/part-of: kubeflow-pipeline
+    app.kubernetes.io/name: data-science-pipelines-driver
+    app.kubernetes.io/part-of: data-science-pipeline
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-driver
+  name: data-science-pipelines-driver
 spec:
   ports:
   - name: http-metrics
@@ -18,7 +18,7 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
-    app.kubernetes.io/part-of: kubeflow-pipeline
+    app.kubernetes.io/name: data-science-pipelines-driver
+    app.kubernetes.io/part-of: data-science-pipeline

--- a/config/v2/driver/serviceaccount.yaml
+++ b/config/v2/driver/serviceaccount.yaml
@@ -3,8 +3,8 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: data-science-pipelines-operator
-    app.kubernetes.io/component: kfp-driver
+    app.kubernetes.io/component: data-science-pipelines-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kubeflow-pipeline
+    app.kubernetes.io/part-of: data-science-pipeline
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-driver
+  name: data-science-pipelines-driver

--- a/config/v2/exithandler/clusterrole.leaderelection.yaml
+++ b/config/v2/exithandler/clusterrole.leaderelection.yaml
@@ -3,8 +3,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-leader-election
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-leader-election
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/exithandler/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/exithandler/controller/clusterrole.clusteraccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-cluster-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/exithandler/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/exithandler/controller/clusterrole.tenantaccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-tenant-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-tenant-access-clusterrole
 rules:
 - apiGroups:
   - ""

--- a/config/v2/exithandler/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.clusteraccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-cluster-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-controller-cluster-access-clusterrole
+  name: data-science-pipelines-exithandler-controller-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.leaderelection.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-leaderelection-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-leader-election-clusterrole
+  name: data-science-pipelines-exithandler-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.tenantaccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-tenant-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-controller-tenant-access-clusterrole
+  name: data-science-pipelines-exithandler-controller-tenant-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/deployment.yaml
+++ b/config/v2/exithandler/controller/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller
 spec:
   replicas: 1
   selector:
@@ -17,17 +17,17 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: controller
-      app.kubernetes.io/part-of: kfp-tekton
+      app.kubernetes.io/part-of: data-science-pipelines-tekton
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: kfp-exithandler-controller
+        app: data-science-pipelines-exithandler-controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
-        app.kubernetes.io/part-of: kfp-tekton
+        app.kubernetes.io/part-of: data-science-pipelines-tekton
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -46,8 +46,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-exithandler-controller:2.0.0
-        name: kfp-exithandler-controller
+        image: quay.io/internaldatahub/data-science-pipelines-exithandler-controller:2.0.0
+        name: data-science-pipelines-exithandler-controller
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -57,4 +57,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-exithandler-controller
+      serviceAccountName: data-science-pipelines-exithandler-controller

--- a/config/v2/exithandler/controller/role.yaml
+++ b/config/v2/exithandler/controller/role.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-role
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-role
 rules:
 - apiGroups:
   - ""
@@ -29,7 +29,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/exithandler/controller/rolebinding.yaml
+++ b/config/v2/exithandler/controller/rolebinding.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-rolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-exithandler-controller-role
+  name: data-science-pipelines-exithandler-controller-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/serviceaccount.yaml
+++ b/config/v2/exithandler/controller/serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-exithandler-controller
+  name: data-science-pipelines-exithandler-controller

--- a/config/v2/exithandler/crd.yaml
+++ b/config/v2/exithandler/crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
     version: devel
   name: exithandlers.custom.tekton.dev
@@ -12,7 +12,7 @@ spec:
   names:
     categories:
     - tekton
-    - tekton-pipelines
+    - data-science-pipelines
     - openshift-pipelines
     kind: ExitHandler
     plural: exithandlers

--- a/config/v2/exithandler/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/exithandler/webhook/clusterrole.clusteraccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-cluster-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -70,7 +70,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/exithandler/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/exithandler/webhook/clusterrolebinding.clusteraccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-cluster-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-webhook-cluster-access-clusterrole
+  name: data-science-pipelines-exithandler-webhook-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-webhook
+  name: data-science-pipelines-exithandler-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/webhook/deployment.yaml
+++ b/config/v2/exithandler/webhook/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-webhook
+  name: data-science-pipelines-exithandler-webhook
 spec:
   replicas: 1
   selector:
@@ -17,17 +17,17 @@ spec:
       app.kubernetes.io/component: webhook
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: kfp-tekton
+      app.kubernetes.io/part-of: data-science-pipelines-tekton
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelines-webhook
+        app: data-science-pipelines-webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/part-of: kfp-tekton
+        app.kubernetes.io/part-of: data-science-pipelines-tekton
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -45,12 +45,12 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
-          value: kfp-exithandler-webhook
+          value: data-science-pipelines-exithandler-webhook
         - name: WEBHOOK_SECRET_NAME
-          value: kfp-exithandler-webhook-certs
+          value: data-science-pipelines-exithandler-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-exithandler-webhook:2.0.0
+        image: quay.io/internaldatahub/data-science-pipelines-exithandler-webhook:2.0.0
         name: webhook
         ports:
         - containerPort: 9090
@@ -68,4 +68,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-exithandler-webhook
+      serviceAccountName: data-science-pipelines-exithandler-webhook

--- a/config/v2/exithandler/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/exithandler/webhook/mutatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
   name: webhook.exithandler.custom.tekton.dev
 webhooks:
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfp-exithandler-webhook
+      name: data-science-pipelines-exithandler-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: webhook.exithandler.custom.tekton.dev

--- a/config/v2/exithandler/webhook/role.yaml
+++ b/config/v2/exithandler/webhook/role.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-role
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-webhook-role
 rules:
 - apiGroups:
   - ""
@@ -36,7 +36,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - kfp-exithandler-webhook-certs
+  - data-science-pipelines-exithandler-webhook-certs
   resources:
   - secrets
   verbs:
@@ -45,7 +45,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/exithandler/webhook/rolebinding.yaml
+++ b/config/v2/exithandler/webhook/rolebinding.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-rolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
+  name: data-science-pipelines-exithandler-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-exithandler-webhook-role
+  name: data-science-pipelines-exithandler-webhook-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-webhook
+  name: data-science-pipelines-exithandler-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/webhook/secret.yaml
+++ b/config/v2/exithandler/webhook/secret.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
-  name: kfp-exithandler-webhook-certs
+  name: data-science-pipelines-exithandler-webhook-certs

--- a/config/v2/exithandler/webhook/service.yaml
+++ b/config/v2/exithandler/webhook/service.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: tekton-pipelines-webhook
+    app: data-science-pipelines-webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-webhook
+  name: data-science-pipelines-exithandler-webhook
   namespace: datasciencepipelinesapplications-controller
 spec:
   ports:
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton

--- a/config/v2/exithandler/webhook/serviceaccount.yaml
+++ b/config/v2/exithandler/webhook/serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-exithandler-webhook
+  name: data-science-pipelines-exithandler-webhook

--- a/config/v2/exithandler/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/exithandler/webhook/validatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
   name: validation.webhook.exithandler.custom.tekton.dev
 webhooks:
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfp-exithandler-webhook
+      name: data-science-pipelines-exithandler-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: validation.webhook.exithandler.custom.tekton.dev

--- a/config/v2/kfptask/clusterrole.leaderelection.yaml
+++ b/config/v2/kfptask/clusterrole.leaderelection.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-leader-election
 rules:
 - apiGroups:

--- a/config/v2/kfptask/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/kfptask/controller/clusterrole.clusteraccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-cluster-access-clusterrole
 rules:
 - apiGroups:

--- a/config/v2/kfptask/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/kfptask/controller/clusterrole.tenantaccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-tenant-access-clusterrole
 rules:
 - apiGroups:

--- a/config/v2/kfptask/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.clusteraccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.tenantaccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/controller/deployment.yaml
+++ b/config/v2/kfptask/controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: controller
-      app.kubernetes.io/part-of: kfp-tekton
+      app.kubernetes.io/part-of: data-science-pipelines-tekton
   template:
     metadata:
       annotations:
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
-        app.kubernetes.io/part-of: kfp-tekton
+        app.kubernetes.io/part-of: data-science-pipelines-tekton
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -46,7 +46,7 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-kfptask-controller:2.0.0
+        image: quay.io/internaldatahub/data-science-pipelines-kfptask-controller:2.0.0
         name: kfptask-controller
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/v2/kfptask/controller/role.yaml
+++ b/config/v2/kfptask/controller/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-role
 rules:
 - apiGroups:
@@ -30,7 +30,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/kfptask/controller/rolebinding.yaml
+++ b/config/v2/kfptask/controller/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/controller/serviceaccount.yaml
+++ b/config/v2/kfptask/controller/serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   namespace: datasciencepipelinesapplications-controller
   name: kfptask-controller

--- a/config/v2/kfptask/crd.yaml
+++ b/config/v2/kfptask/crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
     version: devel
   name: kfptasks.custom.tekton.dev
@@ -12,7 +12,7 @@ spec:
   names:
     categories:
     - tekton
-    - tekton-pipelines
+    - data-science-pipelines
     - openshift-pipelines
     kind: KfpTask
     plural: kfptasks

--- a/config/v2/kfptask/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/kfptask/webhook/clusterrole.clusteraccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
@@ -70,7 +70,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/kfptask/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/kfptask/webhook/clusterrolebinding.clusteraccess.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/webhook/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/kfptask/webhook/clusterrolebinding.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-webhook-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/webhook/deployment.yaml
+++ b/config/v2/kfptask/webhook/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
@@ -17,17 +17,17 @@ spec:
       app.kubernetes.io/component: webhook
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: kfp-tekton
+      app.kubernetes.io/part-of: data-science-pipelines-tekton
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelines-webhook
+        app: data-science-pipelines-webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/part-of: kfp-tekton
+        app.kubernetes.io/part-of: data-science-pipelines-tekton
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -50,7 +50,7 @@ spec:
           value: kfptask-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-kfptask-webhook:2.0.0
+        image: quay.io/internaldatahub/data-science-pipelines-kfptask-webhook:2.0.0
         name: webhook
         ports:
         - containerPort: 9090

--- a/config/v2/kfptask/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/kfptask/webhook/mutatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
   name: webhook.kfptask.custom.tekton.dev
 webhooks:

--- a/config/v2/kfptask/webhook/role.yaml
+++ b/config/v2/kfptask/webhook/role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-webhook-role
 rules:
 - apiGroups:
@@ -45,7 +45,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/kfptask/webhook/rolebinding.yaml
+++ b/config/v2/kfptask/webhook/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   name: kfptask-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/v2/kfptask/webhook/secret.yaml
+++ b/config/v2/kfptask/webhook/secret.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
   name: kfptask-webhook-certs

--- a/config/v2/kfptask/webhook/service.yaml
+++ b/config/v2/kfptask/webhook/service.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: tekton-pipelines-webhook
+    app: data-science-pipelines-webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton

--- a/config/v2/kfptask/webhook/serviceaccount.yaml
+++ b/config/v2/kfptask/webhook/serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: data-science-pipelines-operator
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
   namespace: datasciencepipelinesapplications-controller
   name: kfptask-webhook

--- a/config/v2/kfptask/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/kfptask/webhook/validatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: kfp-tekton
+    app.kubernetes.io/part-of: data-science-pipelines-tekton
     pipeline.tekton.dev/release: devel
   name: validation.webhook.kfptask.custom.tekton.dev
 webhooks:

--- a/config/v2/kustomization.yaml
+++ b/config/v2/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-pipelines
-namePrefix: data-science-pipelines-operator-
+namePrefix: data-science-pipelines-
 
 resources:
 - ./cache

--- a/config/v2/pipelineloop/clusterrole.leaderelection.yaml
+++ b/config/v2/pipelineloop/clusterrole.leaderelection.yaml
@@ -3,8 +3,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-leader-election
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-leader-election
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/pipelineloop/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrole.clusteraccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-cluster-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/pipelineloop/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrole.tenantaccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-tenant-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-tenant-access-clusterrole
 rules:
 - apiGroups:
   - ""

--- a/config/v2/pipelineloop/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.clusteraccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-cluster-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-controller-cluster-access-clusterrole
+  name: data-science-pipelines-pipelineloop-controller-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.leaderelection.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-leaderelection-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-leader-election-clusterrole
+  name: data-science-pipelines-pipelineloop-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.tenantaccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-tenant-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-controller-tenant-access-clusterrole
+  name: data-science-pipelines-pipelineloop-controller-tenant-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/deployment.yaml
+++ b/config/v2/pipelineloop/controller/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller
 spec:
   replicas: 1
   selector:
@@ -17,17 +17,17 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: controller
-      app.kubernetes.io/part-of: tekton-pipeline-loops
+      app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelineloop-controller
+        app: data-science-pipelines-pipelineloop-controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
-        app.kubernetes.io/part-of: tekton-pipeline-loops
+        app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -46,8 +46,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-pipelineloop-controller:2.0.0
-        name: tekton-pipelineloop-controller
+        image: quay.io/internaldatahub/data-science-pipelines-pipelineloop-controller:2.0.0
+        name: data-science-pipelines-pipelineloop-controller
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -57,4 +57,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: tekton-pipelineloop-controller
+      serviceAccountName: data-science-pipelines-pipelineloop-controller

--- a/config/v2/pipelineloop/controller/role.yaml
+++ b/config/v2/pipelineloop/controller/role.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-role
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-role
 rules:
 - apiGroups:
   - ""
@@ -28,7 +28,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/pipelineloop/controller/rolebinding.yaml
+++ b/config/v2/pipelineloop/controller/rolebinding.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-rolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: tekton-pipelineloop-controller-role
+  name: data-science-pipelines-pipelineloop-controller-role
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/serviceaccount.yaml
+++ b/config/v2/pipelineloop/controller/serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     app.kubernetes.io/name: data-science-pipelines-operator
   namespace: datasciencepipelinesapplications-controller
-  name: tekton-pipelineloop-controller
+  name: data-science-pipelines-pipelineloop-controller

--- a/config/v2/pipelineloop/crd.yaml
+++ b/config/v2/pipelineloop/crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     pipeline.tekton.dev/release: devel
     version: devel
   name: pipelineloops.custom.tekton.dev
@@ -12,7 +12,7 @@ spec:
   names:
     categories:
     - tekton
-    - tekton-pipelines
+    - data-science-pipelines
     - openshift-pipelines
     kind: PipelineLoop
     plural: pipelineloops

--- a/config/v2/pipelineloop/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrole.clusteraccess.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrole
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -70,7 +70,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/pipelineloop/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrolebinding.clusteraccess.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrole
+  name: data-science-pipelines-pipelineloop-webhook-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrolebinding.leaderelection.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-leaderelection-clusterrolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-webhook-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-leader-election-clusterrole
+  name: data-science-pipelines-pipelineloop-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/deployment.yaml
+++ b/config/v2/pipelineloop/webhook/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook
 spec:
   replicas: 1
   selector:
@@ -17,17 +17,17 @@ spec:
       app.kubernetes.io/component: webhook
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: tekton-pipeline-loops
+      app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelines-webhook
+        app: data-science-pipelines-webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/part-of: tekton-pipeline-loops
+        app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
         app.kubernetes.io/version: devel
         pipeline.tekton.dev/release: devel
         version: devel
@@ -45,12 +45,12 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
-          value: tekton-pipelineloop-webhook
+          value: data-science-pipelines-pipelineloop-webhook
         - name: WEBHOOK_SECRET_NAME
-          value: tekton-pipelineloop-webhook-certs
+          value: data-science-pipelines-pipelineloop-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-pipelineloop-webhook:2.0.0
+        image: quay.io/internaldatahub/data-science-pipelines-pipelineloop-webhook:2.0.0
         name: webhook
         ports:
         - containerPort: 9090
@@ -68,4 +68,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: tekton-pipelineloop-webhook
+      serviceAccountName: data-science-pipelines-pipelineloop-webhook

--- a/config/v2/pipelineloop/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/pipelineloop/webhook/mutatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     pipeline.tekton.dev/release: devel
   name: webhook.pipelineloop.custom.tekton.dev
 webhooks:
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: tekton-pipelineloop-webhook
+      name: data-science-pipelines-pipelineloop-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: webhook.pipelineloop.custom.tekton.dev

--- a/config/v2/pipelineloop/webhook/role.yaml
+++ b/config/v2/pipelineloop/webhook/role.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-role
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-webhook-role
 rules:
 - apiGroups:
   - ""
@@ -35,7 +35,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - tekton-pipelineloop-webhook-certs
+  - data-science-pipelines-pipelineloop-webhook-certs
   resources:
   - secrets
   verbs:
@@ -44,7 +44,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - tekton-pipelines
+  - data-science-pipelines
   - openshift-pipelines
   resources:
   - podsecuritypolicies

--- a/config/v2/pipelineloop/webhook/rolebinding.yaml
+++ b/config/v2/pipelineloop/webhook/rolebinding.yaml
@@ -4,13 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-rolebinding
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
+  name: data-science-pipelines-pipelineloop-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: tekton-pipelineloop-webhook-role
+  name: data-science-pipelines-pipelineloop-webhook-role
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/service.yaml
+++ b/config/v2/pipelineloop/webhook/service.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: tekton-pipelines-webhook
+    app: data-science-pipelines-webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller
 spec:
   ports:
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops

--- a/config/v2/pipelineloop/webhook/serviceaccount.yaml
+++ b/config/v2/pipelineloop/webhook/serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     app.kubernetes.io/name: data-science-pipelines-operator
   namespace: datasciencepipelinesapplications-controller
-  name: tekton-pipelineloop-webhook
+  name: data-science-pipelines-pipelineloop-webhook

--- a/config/v2/pipelineloop/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/pipelineloop/webhook/validatingwebhookconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     pipeline.tekton.dev/release: devel
   name: validation.webhook.pipelineloop.custom.tekton.dev
 webhooks:
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: tekton-pipelineloop-webhook
+      name: data-science-pipelines-pipelineloop-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: validation.webhook.pipelineloop.custom.tekton.dev

--- a/config/v2/tektoncrds/crd.yaml
+++ b/config/v2/tektoncrds/crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipeline-loops
+    app.kubernetes.io/part-of: data-science-pipelines-pipeline-loops
     pipeline.tekton.dev/release: devel
     version: devel
   name: breaktasks.custom.tekton.dev
@@ -12,7 +12,7 @@ spec:
   names:
     categories:
     - tekton
-    - tekton-pipelines
+    - data-science-pipelines
     kind: BreakTask
     plural: breaktasks
   scope: Namespaced

--- a/config/v2/tektoncrds/scc.anyuid.yaml
+++ b/config/v2/tektoncrds/scc.anyuid.yaml
@@ -15,9 +15,9 @@ groups:
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: kubeflow-anyuid provides all features of the restricted
+    kubernetes.io/description: data-science-anyuid provides all features of the restricted
       SCC but allows users to run with any UID and any GID.
-  name: kubeflow-anyuid-kfp-tekton
+  name: data-science-anyuid-data-science-pipelines-tekton
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
@@ -29,29 +29,29 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:kubeflow:metadatadb
-- system:serviceaccount:kubeflow:minio
-- system:serviceaccount:kubeflow:default
-- system:serviceaccount:kubeflow:pipeline-runner
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
-- system:serviceaccount:kubeflow:metadata-grpc-server
-- system:serviceaccount:kubeflow:kubeflow-pipelines-metadata-writer
-- system:serviceaccount:kubeflow:ml-pipeline
-- system:serviceaccount:kubeflow:ml-pipeline-persistenceagent
-- system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow
-- system:serviceaccount:kubeflow:ml-pipeline-ui
-- system:serviceaccount:kubeflow:ml-pipeline-viewer-crd-service-account
-- system:serviceaccount:kubeflow:ml-pipeline-visualizationserver
-- system:serviceaccount:kubeflow:mysql
-- system:serviceaccount:kubeflow:kfp-csi-s3
-- system:serviceaccount:kubeflow:kfp-csi-attacher
-- system:serviceaccount:kubeflow:kfp-csi-provisioner
-- system:serviceaccount:openshift-pipelines:kfp-driver
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-controller
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-webhook
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-controller
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-webhook
+- system:serviceaccount:data-science:metadatadb
+- system:serviceaccount:data-science:minio
+- system:serviceaccount:data-science:default
+- system:serviceaccount:data-science:pipeline-runner
+- system:serviceaccount:data-science:data-science-pipelines-cache
+- system:serviceaccount:data-science:data-science-pipelines-cache-deployer-sa
+- system:serviceaccount:data-science:metadata-grpc-server
+- system:serviceaccount:data-science:data-science-pipelines-metadata-writer
+- system:serviceaccount:data-science:ml-pipeline
+- system:serviceaccount:data-science:ml-pipeline-persistenceagent
+- system:serviceaccount:data-science:ml-pipeline-scheduledworkflow
+- system:serviceaccount:data-science:ml-pipeline-ui
+- system:serviceaccount:data-science:ml-pipeline-viewer-crd-service-account
+- system:serviceaccount:data-science:ml-pipeline-visualizationserver
+- system:serviceaccount:data-science:mysql
+- system:serviceaccount:data-science:data-science-pipelines-csi-s3
+- system:serviceaccount:data-science:data-science-pipelines-csi-attacher
+- system:serviceaccount:data-science:data-science-pipelines-csi-provisioner
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-driver
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-exithandler-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-exithandler-webhook
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-pipelineloop-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-pipelineloop-webhook
 volumes:
 - configMap
 - downwardAPI

--- a/config/v2/tektoncrds/scc.privileged.yaml
+++ b/config/v2/tektoncrds/scc.privileged.yaml
@@ -15,9 +15,9 @@ groups:
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: kubeflow-anyuid provides all features of the restricted
+    kubernetes.io/description: data-science-anyuid provides all features of the restricted
       SCC but allows users to run with any UID and any GID.
-  name: kubeflow-privileged-kfp-tekton
+  name: data-science-privileged-data-science-pipelines-tekton
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
@@ -29,29 +29,29 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:kubeflow:metadatadb
-- system:serviceaccount:kubeflow:minio
-- system:serviceaccount:kubeflow:default
-- system:serviceaccount:kubeflow:pipeline-runner
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
-- system:serviceaccount:kubeflow:metadata-grpc-server
-- system:serviceaccount:kubeflow:kubeflow-pipelines-metadata-writer
-- system:serviceaccount:kubeflow:ml-pipeline
-- system:serviceaccount:kubeflow:ml-pipeline-persistenceagent
-- system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow
-- system:serviceaccount:kubeflow:ml-pipeline-ui
-- system:serviceaccount:kubeflow:ml-pipeline-viewer-crd-service-account
-- system:serviceaccount:kubeflow:ml-pipeline-visualizationserver
-- system:serviceaccount:kubeflow:mysql
-- system:serviceaccount:kubeflow:kfp-csi-s3
-- system:serviceaccount:kubeflow:kfp-csi-attacher
-- system:serviceaccount:kubeflow:kfp-csi-provisioner
-- system:serviceaccount:openshift-pipelines:kfp-driver
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-controller
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-webhook
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-controller
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-webhook
+- system:serviceaccount:data-science:metadatadb
+- system:serviceaccount:data-science:minio
+- system:serviceaccount:data-science:default
+- system:serviceaccount:data-science:pipeline-runner
+- system:serviceaccount:data-science:data-science-pipelines-cache
+- system:serviceaccount:data-science:data-science-pipelines-cache-deployer-sa
+- system:serviceaccount:data-science:metadata-grpc-server
+- system:serviceaccount:data-science:data-science-pipelines-metadata-writer
+- system:serviceaccount:data-science:ml-pipeline
+- system:serviceaccount:data-science:ml-pipeline-persistenceagent
+- system:serviceaccount:data-science:ml-pipeline-scheduledworkflow
+- system:serviceaccount:data-science:ml-pipeline-ui
+- system:serviceaccount:data-science:ml-pipeline-viewer-crd-service-account
+- system:serviceaccount:data-science:ml-pipeline-visualizationserver
+- system:serviceaccount:data-science:mysql
+- system:serviceaccount:data-science:data-science-pipelines-csi-s3
+- system:serviceaccount:data-science:data-science-pipelines-csi-attacher
+- system:serviceaccount:data-science:data-science-pipelines-csi-provisioner
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-driver
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-exithandler-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-exithandler-webhook
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-pipelineloop-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-pipelineloop-webhook
 volumes:
 - configMap
 - downwardAPI


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #379 

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Updating the RBAC manifests ((Cluster)Roles, (Cluster)RoleBindings and ServiceAccounts) to reference each other with the data-science-pipelines- prefix, and adding the auto-prefixer to the v2 kustomization.yaml

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
