### PR TITLE
Updating v2 manifests to utilize DSPO namePrefix

### DIFF
--- a/config/v2/cache/clusterrole.yaml
+++ b/config/v2/cache/clusterrole.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kubeflow-pipelines-cache-deployer-clusterrole
-  name: kubeflow-pipelines-cache-deployer-clusterrole
+    app: cache-deployer-clusterrole
+  name: cache-deployer-clusterrole
 rules:
 - apiGroups:
   - certificates.k8s.io

--- a/config/v2/cache/clusterrolebinding.yaml
+++ b/config/v2/cache/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+  name: cache-deployer-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeflow-pipelines-cache-deployer-clusterrole
+  name: cache-deployer-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kubeflow-pipelines-cache-deployer-sa
+  name: cache-deployer-sa
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/cache/serviceaccount.yaml
+++ b/config/v2/cache/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kubeflow-pipelines-cache-deployer-sa
+  name: cache-deployer-sa

--- a/config/v2/driver/clusterrole.yaml
+++ b/config/v2/driver/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: kfp-driver
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-cluster-access-clusterrole
+  name: driver-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/driver/clusterrolebinding.yaml
+++ b/config/v2/driver/clusterrolebinding.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/component: kfp-driver
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-cluster-access-clusterrolebinding
+  name: driver-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-driver-cluster-access-clusterrole
+  name: driver-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-driver
+  name: driver
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/driver/deployment.yaml
+++ b/config/v2/driver/deployment.yaml
@@ -4,17 +4,17 @@ metadata:
   labels:
     app.kubernetes.io/component: ckfp-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
+    app.kubernetes.io/name: driver
     app.kubernetes.io/part-of: kubeflow-pipeline
     app.kubernetes.io/version: devel
-  name: kfp-driver
+  name: driver
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: kfp-driver
       app.kubernetes.io/instance: default
-      app.kubernetes.io/name: kfp-driver
+      app.kubernetes.io/name: driver
       app.kubernetes.io/part-of: kubeflow-pipeline
   template:
     metadata:
@@ -24,7 +24,7 @@ spec:
         app: kfp-driver
         app.kubernetes.io/component: kfp-driver
         app.kubernetes.io/instance: default
-        app.kubernetes.io/name: kfp-driver
+        app.kubernetes.io/name: driver
         app.kubernetes.io/part-of: kubeflow-pipeline
         app.kubernetes.io/version: devel
     spec:
@@ -44,7 +44,7 @@ spec:
           value: tekton.dev/pipeline
         image: quay.io/internaldatahub/tekton-driver:2.0.0
         imagePullPolicy: Always
-        name: kfp-driver
+        name: driver
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -54,4 +54,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-driver
+      serviceAccountName: driver

--- a/config/v2/driver/role.yaml
+++ b/config/v2/driver/role.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kubeflow-pipeline
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-driver-role
+  name: driver-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/driver/rolebinding.yaml
+++ b/config/v2/driver/rolebinding.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/component: kfp-driver
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kubeflow-pipeline
-  name: kfp-driver-rolebinding
+  name: driver-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-driver-role
+  name: driver-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-driver
+  name: driver
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/driver/service.yaml
+++ b/config/v2/driver/service.yaml
@@ -5,12 +5,12 @@ metadata:
     app: kfp-driver
     app.kubernetes.io/component: kfp-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
+    app.kubernetes.io/name: driver
     app.kubernetes.io/part-of: kubeflow-pipeline
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-driver
+  name: driver
 spec:
   ports:
   - name: http-metrics
@@ -20,5 +20,5 @@ spec:
   selector:
     app.kubernetes.io/component: kfp-driver
     app.kubernetes.io/instance: default
-    app.kubernetes.io/name: kfp-driver
+    app.kubernetes.io/name: driver
     app.kubernetes.io/part-of: kubeflow-pipeline

--- a/config/v2/driver/serviceaccount.yaml
+++ b/config/v2/driver/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kubeflow-pipeline
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-driver
+  name: driver

--- a/config/v2/exithandler/clusterrole.leaderelection.yaml
+++ b/config/v2/exithandler/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-leader-election-clusterrole
+  name: leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/exithandler/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/exithandler/controller/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-cluster-access-clusterrole
+  name: exithandler-controller-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/exithandler/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/exithandler/controller/clusterrole.tenantaccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-tenant-access-clusterrole
+  name: exithandler-controller-tenant-access-clusterrole
 rules:
 - apiGroups:
   - ""

--- a/config/v2/exithandler/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-cluster-access-clusterrolebinding
+  name: exithandler-controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-controller-cluster-access-clusterrole
+  name: exithandler-controller-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.leaderelection.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-leaderelection-clusterrolebinding
+  name: exithandler-controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-leader-election-clusterrole
+  name: exithandler-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/exithandler/controller/clusterrolebinding.tenantaccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-tenant-access-clusterrolebinding
+  name: exithandler-controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-controller-tenant-access-clusterrole
+  name: exithandler-controller-tenant-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/deployment.yaml
+++ b/config/v2/exithandler/controller/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-controller
+  name: exithandler-controller
 spec:
   replicas: 1
   selector:
@@ -47,7 +47,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
         image: quay.io/internaldatahub/tekton-exithandler-controller:2.0.0
-        name: kfp-exithandler-controller
+        name: exithandler-controller
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -57,4 +57,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-exithandler-controller
+      serviceAccountName: exithandler-controller

--- a/config/v2/exithandler/controller/role.yaml
+++ b/config/v2/exithandler/controller/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-role
+  name: exithandler-controller-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/exithandler/controller/rolebinding.yaml
+++ b/config/v2/exithandler/controller/rolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-controller-rolebinding
+  name: exithandler-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-exithandler-controller-role
+  name: exithandler-controller-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-controller
+  name: exithandler-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/controller/serviceaccount.yaml
+++ b/config/v2/exithandler/controller/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-exithandler-controller
+  name: exithandler-controller

--- a/config/v2/exithandler/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/exithandler/webhook/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-cluster-access-clusterrole
+  name: exithandler-webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
   - apiextensions.k8s.io

--- a/config/v2/exithandler/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/exithandler/webhook/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-cluster-access-clusterrolebinding
+  name: exithandler-webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfp-exithandler-webhook-cluster-access-clusterrole
+  name: exithandler-webhook-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-webhook
+  name: exithandler-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/webhook/deployment.yaml
+++ b/config/v2/exithandler/webhook/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-webhook
+  name: exithandler-webhook
 spec:
   replicas: 1
   selector:
@@ -68,4 +68,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfp-exithandler-webhook
+      serviceAccountName: exithandler-webhook

--- a/config/v2/exithandler/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/exithandler/webhook/mutatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfp-exithandler-webhook
+      name: exithandler-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: webhook.exithandler.custom.tekton.dev

--- a/config/v2/exithandler/webhook/role.yaml
+++ b/config/v2/exithandler/webhook/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-role
+  name: exithandler-webhook-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/exithandler/webhook/rolebinding.yaml
+++ b/config/v2/exithandler/webhook/rolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-webhook-rolebinding
+  name: exithandler-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfp-exithandler-webhook-role
+  name: exithandler-webhook-role
 subjects:
 - kind: ServiceAccount
-  name: kfp-exithandler-webhook
+  name: exithandler-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/exithandler/webhook/secret.yaml
+++ b/config/v2/exithandler/webhook/secret.yaml
@@ -6,4 +6,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
     pipeline.tekton.dev/release: devel
-  name: kfp-exithandler-webhook-certs
+  name: exithandler-webhook-certs

--- a/config/v2/exithandler/webhook/service.yaml
+++ b/config/v2/exithandler/webhook/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfp-exithandler-webhook
+  name: exithandler-webhook
   namespace: datasciencepipelinesapplications-controller
 spec:
   ports:

--- a/config/v2/exithandler/webhook/serviceaccount.yaml
+++ b/config/v2/exithandler/webhook/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfp-exithandler-webhook
+  name: exithandler-webhook

--- a/config/v2/exithandler/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/exithandler/webhook/validatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfp-exithandler-webhook
+      name: exithandler-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: validation.webhook.exithandler.custom.tekton.dev

--- a/config/v2/kfptask/clusterrole.leaderelection.yaml
+++ b/config/v2/kfptask/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-leader-election-clusterrole
+  name: leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/kfptask/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/kfptask/controller/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-cluster-access-clusterrole
+  name: controller-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/kfptask/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/kfptask/controller/clusterrole.tenantaccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-tenant-access-clusterrole
+  name: controller-tenant-access-clusterrole
 rules:
 - apiGroups:
   - ""

--- a/config/v2/kfptask/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-cluster-access-clusterrolebinding
+  name: controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfptask-controller-cluster-access-clusterrole
+  name: controller-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfptask-controller
+  name: controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.leaderelection.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-leaderelection-clusterrolebinding
+  name: controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfptask-leader-election-clusterrole
+  name: leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfptask-controller
+  name: controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/kfptask/controller/clusterrolebinding.tenantaccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-tenant-access-clusterrolebinding
+  name: controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfptask-controller-tenant-access-clusterrole
+  name: controller-tenant-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfptask-controller
+  name: controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/controller/deployment.yaml
+++ b/config/v2/kfptask/controller/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfptask-controller
+  name: controller
 spec:
   replicas: 1
   selector:
@@ -47,7 +47,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
         image: quay.io/internaldatahub/tekton-kfptask-controller:2.0.0
-        name: kfptask-controller
+        name: controller
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -57,4 +57,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfptask-controller
+      serviceAccountName: controller

--- a/config/v2/kfptask/controller/role.yaml
+++ b/config/v2/kfptask/controller/role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-role
+  name: controller-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/kfptask/controller/rolebinding.yaml
+++ b/config/v2/kfptask/controller/rolebinding.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-controller-rolebinding
+  name: controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfptask-controller-role
+  name: controller-role
 subjects:
 - kind: ServiceAccount
-  name: kfptask-controller
+  name: controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/controller/serviceaccount.yaml
+++ b/config/v2/kfptask/controller/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfptask-controller
+  name: controller

--- a/config/v2/kfptask/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/kfptask/webhook/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-webhook-cluster-access-clusterrole
+  name: webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
   - apiextensions.k8s.io

--- a/config/v2/kfptask/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/kfptask/webhook/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-webhook-cluster-access-clusterrolebinding
+  name: webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfptask-webhook-cluster-access-clusterrole
+  name: webhook-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfptask-webhook
+  name: webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/webhook/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/kfptask/webhook/clusterrolebinding.leaderelection.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-webhook-leaderelection-clusterrolebinding
+  name: webhook-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfptask-leader-election-clusterrole
+  name: leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: kfptask-webhook
+  name: webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/webhook/deployment.yaml
+++ b/config/v2/kfptask/webhook/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfptask-webhook
+  name: webhook
 spec:
   replicas: 1
   selector:
@@ -68,4 +68,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: kfptask-webhook
+      serviceAccountName: webhook

--- a/config/v2/kfptask/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/kfptask/webhook/mutatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfptask-webhook
+      name: webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: webhook.kfptask.custom.tekton.dev

--- a/config/v2/kfptask/webhook/role.yaml
+++ b/config/v2/kfptask/webhook/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-webhook-role
+  name: webhook-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/kfptask/webhook/rolebinding.yaml
+++ b/config/v2/kfptask/webhook/rolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-webhook-rolebinding
+  name: webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kfptask-webhook-role
+  name: webhook-role
 subjects:
 - kind: ServiceAccount
-  name: kfptask-webhook
+  name: webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/kfptask/webhook/secret.yaml
+++ b/config/v2/kfptask/webhook/secret.yaml
@@ -6,4 +6,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
     pipeline.tekton.dev/release: devel
-  name: kfptask-webhook-certs
+  name: webhook-certs

--- a/config/v2/kfptask/webhook/service.yaml
+++ b/config/v2/kfptask/webhook/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: kfptask-webhook
+  name: webhook
   namespace: datasciencepipelinesapplications-controller
 spec:
   ports:

--- a/config/v2/kfptask/webhook/serviceaccount.yaml
+++ b/config/v2/kfptask/webhook/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
   namespace: datasciencepipelinesapplications-controller
-  name: kfptask-webhook
+  name: webhook

--- a/config/v2/kfptask/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/kfptask/webhook/validatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kfptask-webhook
+      name: webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: validation.webhook.kfptask.custom.tekton.dev

--- a/config/v2/pipelineloop/clusterrole.leaderelection.yaml
+++ b/config/v2/pipelineloop/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-leader-election-clusterrole
+  name: pipelineloop-leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/pipelineloop/controller/clusterrole.clusteraccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-cluster-access-clusterrole
+  name: pipelineloop-controller-cluster-access-clusterrole
 rules:
 - apiGroups:
   - tekton.dev

--- a/config/v2/pipelineloop/controller/clusterrole.tenantaccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrole.tenantaccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-tenant-access-clusterrole
+  name: pipelineloop-controller-tenant-access-clusterrole
 rules:
 - apiGroups:
   - ""

--- a/config/v2/pipelineloop/controller/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-cluster-access-clusterrolebinding
+  name: pipelineloop-controller-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-controller-cluster-access-clusterrole
+  name: pipelineloop-controller-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.leaderelection.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-leaderelection-clusterrolebinding
+  name: pipelineloop-controller-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-leader-election-clusterrole
+  name: pipelineloop-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/clusterrolebinding.tenantaccess.yaml
+++ b/config/v2/pipelineloop/controller/clusterrolebinding.tenantaccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-tenant-access-clusterrolebinding
+  name: pipelineloop-controller-tenant-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-controller-tenant-access-clusterrole
+  name: pipelineloop-controller-tenant-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/deployment.yaml
+++ b/config/v2/pipelineloop/controller/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelineloop-controller
+        app: tektonpipelineloop-controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
@@ -46,8 +46,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-pipelineloop-controller:2.0.0
-        name: tekton-pipelineloop-controller
+        image: quay.io/internaldatahub/tektonpipelineloop-controller:2.0.0
+        name: pipelineloop-controller
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -57,4 +57,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: tekton-pipelineloop-controller
+      serviceAccountName: pipelineloop-controller

--- a/config/v2/pipelineloop/controller/role.yaml
+++ b/config/v2/pipelineloop/controller/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-role
+  name: pipelineloop-controller-role
 rules:
 - apiGroups:
   - ""

--- a/config/v2/pipelineloop/controller/rolebinding.yaml
+++ b/config/v2/pipelineloop/controller/rolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-controller-rolebinding
+  name: pipelineloop-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: tekton-pipelineloop-controller-role
+  name: pipelineloop-controller-role
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/controller/serviceaccount.yaml
+++ b/config/v2/pipelineloop/controller/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipeline-loops
     app.kubernetes.io/name: data-science-pipelines-operator
   namespace: datasciencepipelinesapplications-controller
-  name: tekton-pipelineloop-controller
+  name: pipelineloop-controller

--- a/config/v2/pipelineloop/webhook/clusterrole.clusteraccess.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrole.clusteraccess.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrole
+  name: pipelineloop-webhook-cluster-access-clusterrole
 rules:
 - apiGroups:
   - apiextensions.k8s.io

--- a/config/v2/pipelineloop/webhook/clusterrolebinding.clusteraccess.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrolebinding.clusteraccess.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrolebinding
+  name: pipelineloop-webhook-cluster-access-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-webhook-cluster-access-clusterrole
+  name: pipelineloop-webhook-cluster-access-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/clusterrolebinding.leaderelection.yaml
+++ b/config/v2/pipelineloop/webhook/clusterrolebinding.leaderelection.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-leaderelection-clusterrolebinding
+  name: pipelineloop-webhook-leaderelection-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-pipelineloop-leader-election-clusterrole
+  name: pipelineloop-leader-election-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/deployment.yaml
+++ b/config/v2/pipelineloop/webhook/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook
 spec:
   replicas: 1
   selector:
@@ -45,12 +45,12 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
-          value: tekton-pipelineloop-webhook
+          value: tektonpipelineloop-webhook
         - name: WEBHOOK_SECRET_NAME
-          value: tekton-pipelineloop-webhook-certs
+          value: tektonpipelineloop-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
-        image: quay.io/internaldatahub/tekton-pipelineloop-webhook:2.0.0
+        image: quay.io/internaldatahub/tektonpipelineloop-webhook:2.0.0
         name: webhook
         ports:
         - containerPort: 9090
@@ -68,4 +68,4 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: tekton-pipelineloop-webhook
+      serviceAccountName: pipelineloop-webhook

--- a/config/v2/pipelineloop/webhook/mutatingwebhookconfig.yaml
+++ b/config/v2/pipelineloop/webhook/mutatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: tekton-pipelineloop-webhook
+      name: pipelineloop-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: webhook.pipelineloop.custom.tekton.dev

--- a/config/v2/pipelineloop/webhook/role.yaml
+++ b/config/v2/pipelineloop/webhook/role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-role
+  name: pipelineloop-webhook-role
 rules:
 - apiGroups:
   - ""
@@ -35,7 +35,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - tekton-pipelineloop-webhook-certs
+  - tektonpipelineloop-webhook-certs
   resources:
   - secrets
   verbs:

--- a/config/v2/pipelineloop/webhook/rolebinding.yaml
+++ b/config/v2/pipelineloop/webhook/rolebinding.yaml
@@ -5,12 +5,12 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-webhook-rolebinding
+  name: pipelineloop-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: tekton-pipelineloop-webhook-role
+  name: pipelineloop-webhook-role
 subjects:
 - kind: ServiceAccount
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller

--- a/config/v2/pipelineloop/webhook/service.yaml
+++ b/config/v2/pipelineloop/webhook/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: devel
     pipeline.tekton.dev/release: devel
     version: devel
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook
   namespace: datasciencepipelinesapplications-controller
 spec:
   ports:

--- a/config/v2/pipelineloop/webhook/serviceaccount.yaml
+++ b/config/v2/pipelineloop/webhook/serviceaccount.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipeline-loops
     app.kubernetes.io/name: data-science-pipelines-operator
   namespace: datasciencepipelinesapplications-controller
-  name: tekton-pipelineloop-webhook
+  name: pipelineloop-webhook

--- a/config/v2/pipelineloop/webhook/validatingwebhookconfig.yaml
+++ b/config/v2/pipelineloop/webhook/validatingwebhookconfig.yaml
@@ -12,7 +12,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: tekton-pipelineloop-webhook
+      name: pipelineloop-webhook
       namespace: datasciencepipelinesapplications-controller
   failurePolicy: Fail
   name: validation.webhook.pipelineloop.custom.tekton.dev

--- a/config/v2/tektoncrds/scc.anyuid.yaml
+++ b/config/v2/tektoncrds/scc.anyuid.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     kubernetes.io/description: kubeflow-anyuid provides all features of the restricted
       SCC but allows users to run with any UID and any GID.
-  name: kubeflow-anyuid-kfp-tekton
+  name: anyuid-operator-tekton
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
@@ -33,10 +33,10 @@ users:
 - system:serviceaccount:kubeflow:minio
 - system:serviceaccount:kubeflow:default
 - system:serviceaccount:kubeflow:pipeline-runner
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
+- system:serviceaccount:kubeflow:cache
+- system:serviceaccount:kubeflow:cache-deployer-sa
 - system:serviceaccount:kubeflow:metadata-grpc-server
-- system:serviceaccount:kubeflow:kubeflow-pipelines-metadata-writer
+- system:serviceaccount:kubeflow:metadata-writer
 - system:serviceaccount:kubeflow:ml-pipeline
 - system:serviceaccount:kubeflow:ml-pipeline-persistenceagent
 - system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow
@@ -44,14 +44,14 @@ users:
 - system:serviceaccount:kubeflow:ml-pipeline-viewer-crd-service-account
 - system:serviceaccount:kubeflow:ml-pipeline-visualizationserver
 - system:serviceaccount:kubeflow:mysql
-- system:serviceaccount:kubeflow:kfp-csi-s3
-- system:serviceaccount:kubeflow:kfp-csi-attacher
-- system:serviceaccount:kubeflow:kfp-csi-provisioner
-- system:serviceaccount:openshift-pipelines:kfp-driver
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-controller
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-webhook
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-controller
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-webhook
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-s3
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-attacher
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-provisioner
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-driver
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-exithandler-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-exithandler-webhook
+- system:serviceaccount:openshift-pipelines:tektonpipelineloop-controller
+- system:serviceaccount:openshift-pipelines:tektonpipelineloop-webhook
 volumes:
 - configMap
 - downwardAPI

--- a/config/v2/tektoncrds/scc.privileged.yaml
+++ b/config/v2/tektoncrds/scc.privileged.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     kubernetes.io/description: kubeflow-anyuid provides all features of the restricted
       SCC but allows users to run with any UID and any GID.
-  name: kubeflow-privileged-kfp-tekton
+  name: privileged-operator-tekton
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
@@ -33,10 +33,10 @@ users:
 - system:serviceaccount:kubeflow:minio
 - system:serviceaccount:kubeflow:default
 - system:serviceaccount:kubeflow:pipeline-runner
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache
-- system:serviceaccount:kubeflow:kubeflow-pipelines-cache-deployer-sa
+- system:serviceaccount:kubeflow:cache
+- system:serviceaccount:kubeflow:cache-deployer-sa
 - system:serviceaccount:kubeflow:metadata-grpc-server
-- system:serviceaccount:kubeflow:kubeflow-pipelines-metadata-writer
+- system:serviceaccount:kubeflow:metadata-writer
 - system:serviceaccount:kubeflow:ml-pipeline
 - system:serviceaccount:kubeflow:ml-pipeline-persistenceagent
 - system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow
@@ -44,14 +44,14 @@ users:
 - system:serviceaccount:kubeflow:ml-pipeline-viewer-crd-service-account
 - system:serviceaccount:kubeflow:ml-pipeline-visualizationserver
 - system:serviceaccount:kubeflow:mysql
-- system:serviceaccount:kubeflow:kfp-csi-s3
-- system:serviceaccount:kubeflow:kfp-csi-attacher
-- system:serviceaccount:kubeflow:kfp-csi-provisioner
-- system:serviceaccount:openshift-pipelines:kfp-driver
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-controller
-- system:serviceaccount:openshift-pipelines:kfp-exithandler-webhook
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-controller
-- system:serviceaccount:openshift-pipelines:tekton-pipelineloop-webhook
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-s3
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-attacher
+- system:serviceaccount:kubeflow:data-science-pipelines-operator-csi-provisioner
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-driver
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-exithandler-controller
+- system:serviceaccount:openshift-pipelines:data-science-pipelines-operator-exithandler-webhook
+- system:serviceaccount:openshift-pipelines:tektonpipelineloop-controller
+- system:serviceaccount:openshift-pipelines:tektonpipelineloop-webhook
 volumes:
 - configMap
 - downwardAPI


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #378 

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Updated names of v2 manifests to remove mentions of Kfp, and utlize the `data-science-pipelines-operator-` namePrefix.
Updated `serviceAccountname` to `serviceAccountName` based on an error prompting to do so, while deploying v2.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
deployed a v2 instance using `make v2deploy` to make sure all resources came up with the `data-science-pipelines-operator-` prefix correctly.

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
