### PR TITLE
Fix Leader Election Cluster Role Names

### DIFF
--- a/config/v2/exithandler/clusterrole.leaderelection.yaml
+++ b/config/v2/exithandler/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfp-exithandler-leader-election
+  name: kfp-exithandler-leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/kfptask/clusterrole.leaderelection.yaml
+++ b/config/v2/kfptask/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: kfp-tekton
-  name: kfptask-leader-election
+  name: kfptask-leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/v2/pipelineloop/clusterrole.leaderelection.yaml
+++ b/config/v2/pipelineloop/clusterrole.leaderelection.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipeline-loops
-  name: tekton-pipelineloop-leader-election
+  name: tekton-pipelineloop-leader-election-clusterrole
 rules:
 - apiGroups:
   - coordination.k8s.io


### PR DESCRIPTION
## Description of your changes:
Fixes names for leader election clusterroles (missing -clusterrole suffix) 

## Testing instructions
`make v2deploy` and ensure leader election clusterroles properly map to their appropriate clusterrolebindings

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
