### PR TITLE
Add Nightly Build/Test GHAction stub

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -1,0 +1,21 @@
+name: Nightly Testing
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.x'
+      - name: Run Build
+        run: make build
+      - name: Run Unit Tests
+        run: make unittest
+      - name: Run Functional Tests
+        run: make functest
+      # TODO: implement some sort of notification mechanism


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #372

## Description of your changes:
Add a simple GH Workflow that runs Nightly.  To start we simply run a sample build and execute unit and functional tests. 

## Testing instructions
Verify logs from https://github.com/gmfrasca/data-science-pipelines-operator/actions/workflows/nightly_tests.yml looks good.  Depending on permissions you may be able to run it manually yourself as well (this is the reason for `workflow_dispatch: {}` in the triggers)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
