### PR TITLE
Added storageClassName in the PVCs for Minio and MariaDB

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -194,6 +194,9 @@ type MariaDB struct {
 	// Customize the size of the PVC created for the default MariaDB instance. Default: 10Gi
 	// +kubebuilder:default:="10Gi"
 	PVCSize resource.Quantity `json:"pvcSize,omitempty"`
+	// Volume Mode Filesystem storageClass to use for PVC creation
+	// +kubebuilder:validation:Optional
+	StorageClassName string `json:"storageClassName,omitempty"`
 	// Specify custom Pod resource requirements for this component.
 	Resources *ResourceRequirements `json:"resources,omitempty"`
 }
@@ -230,6 +233,9 @@ type Minio struct {
 	// Customize the size of the PVC created for the Minio instance. Default: 10Gi
 	// +kubebuilder:default:="10Gi"
 	PVCSize resource.Quantity `json:"pvcSize,omitempty"`
+	// Volume Mode Filesystem storageClass to use for PVC creation
+	// +kubebuilder:validation:Optional
+	StorageClassName string `json:"storageClassName,omitempty"`
 	// Specify custom Pod resource requirements for this component.
 	Resources *ResourceRequirements `json:"resources,omitempty"`
 	// Specify a custom image for Minio pod.

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -279,6 +279,9 @@ spec:
                                 x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for PVC creation
+                        type: string
                       username:
                         default: mlpipeline
                         description: 'The MariadB username that will be created. Should
@@ -617,6 +620,9 @@ spec:
                         - secretKey
                         - secretName
                         type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for PVC creation
+                        type: string
                     required:
                     - image
                     type: object

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -280,7 +280,8 @@ spec:
                             type: object
                         type: object
                       storageClassName:
-                        description: Volume Mode Filesystem storageClass to use for PVC creation
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
                         type: string
                       username:
                         default: mlpipeline
@@ -621,7 +622,8 @@ spec:
                         - secretName
                         type: object
                       storageClassName:
-                        description: Volume Mode Filesystem storageClass to use for PVC creation
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
                         type: string
                     required:
                     - image

--- a/config/internal/mariadb/pvc.yaml.tmpl
+++ b/config/internal/mariadb/pvc.yaml.tmpl
@@ -9,7 +9,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: {{.MariaDB.StorageClassName}}
+  {{- if .MariaDB.StorageClassName }}
+    storageClassName: {{.MariaDB.StorageClassName}}
+  {{- end }}
   resources:
     requests:
       storage: {{.MariaDB.PVCSize}}

--- a/config/internal/mariadb/pvc.yaml.tmpl
+++ b/config/internal/mariadb/pvc.yaml.tmpl
@@ -9,6 +9,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: {{.MariaDB.StorageClassName}}
   resources:
     requests:
       storage: {{.MariaDB.PVCSize}}

--- a/config/internal/minio/pvc.yaml.tmpl
+++ b/config/internal/minio/pvc.yaml.tmpl
@@ -9,7 +9,9 @@ metadata:
 spec:
     accessModes:
         - ReadWriteOnce
-    storageClassName: {{.Minio.StorageClassName}}
+    {{- if .Minio.StorageClassName }}
+      storageClassName: {{.Minio.StorageClassName}}
+    {{- end }}
     resources:
         requests:
             storage: {{.Minio.PVCSize}}

--- a/config/internal/minio/pvc.yaml.tmpl
+++ b/config/internal/minio/pvc.yaml.tmpl
@@ -9,6 +9,7 @@ metadata:
 spec:
     accessModes:
         - ReadWriteOnce
+    storageClassName: {{.Minio.StorageClassName}}
     resources:
         requests:
             storage: {{.Minio.PVCSize}}

--- a/config/samples/custom-configs/dspa.yaml
+++ b/config/samples/custom-configs/dspa.yaml
@@ -78,6 +78,7 @@ spec:
       passwordSecret:
         name: testdbsecret
         key: password
+      storageClassName: ""
   objectStorage:
     minio:
       deploy: true
@@ -91,6 +92,7 @@ spec:
         limits:
           cpu: 250m
           memory: 1Gi
+      storageClassName: ""
       s3CredentialsSecret:
         secretName: teststoragesecret
         accessKey: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Resolves #192

## Description of your changes:

1. Added StorageClassName field under minio and mariaDB sections in the CRD and in minio & mariaDB structs.

2. Added StorageClassName in the PVC template file for minio and mariaDB.

## Testing instructions

-  Deploy DSPO and create a dspa instance using the dspa.yaml file in this path- config/samples/custom-configs.
-  Check the storageClassName assigned with default value by looking at the pvc created for minio and mariaDB.
-  dspa.yaml file can be edited with a different storageClassName to see if its getting assigned.

## Checklist
* The commits are squashed in a cohesive manner and have meaningful messages.
* Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
* The developer has manually tested the changes and verified that the changes work
