### PR TITLE
Adding a variable for minio-service endpoint

### DIFF
--- a/config/internal/apiserver/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline.yaml.tmpl
@@ -29,7 +29,7 @@ data:
               "parent_task": "data-prep"}], "validate-model": [{"name": "train-model-model",
               "parent_task": "train-model"}]}'
             tekton.dev/artifact_bucket: mlpipeline
-            tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+            tekton.dev/artifact_endpoint: ${MINIO_SERVICE_SERVICE_HOST}:${MINIO_SERVICE_SERVICE_PORT}
             tekton.dev/artifact_endpoint_scheme: http://
             tekton.dev/artifact_items: '{"data-prep": [["X_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test"],
               ["X_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train"],

--- a/controllers/testdata/declarative/case_2/expected/created/sample-pipeline.yaml.tmpl
+++ b/controllers/testdata/declarative/case_2/expected/created/sample-pipeline.yaml.tmpl
@@ -29,7 +29,7 @@ data:
               "parent_task": "data-prep"}], "validate-model": [{"name": "train-model-model",
               "parent_task": "train-model"}]}'
             tekton.dev/artifact_bucket: mlpipeline
-            tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+            tekton.dev/artifact_endpoint: ${MINIO_SERVICE_SERVICE_HOST}:${MINIO_SERVICE_SERVICE_PORT}
             tekton.dev/artifact_endpoint_scheme: http://
             tekton.dev/artifact_items: '{"data-prep": [["X_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test"],
               ["X_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train"],

--- a/docs/example_pipelines/condition.yaml
+++ b/docs/example_pipelines/condition.yaml
@@ -14,7 +14,7 @@ metadata:
       "random-num-2"}], "print-msg-4": [{"name": "random-num-2-Output", "parent_task":
       "random-num-2"}]}'
     tekton.dev/artifact_bucket: mlpipeline
-    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint: ${MINIO_SERVICE_SERVICE_HOST}:${MINIO_SERVICE_SERVICE_PORT}
     tekton.dev/artifact_endpoint_scheme: http://
     tekton.dev/artifact_items: '{"flip-coin": [["Output", "$(results.Output.path)"]],
       "print-msg": [], "print-msg-2": [], "print-msg-3": [], "print-msg-4": [], "random-num":


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://github.com/opendatahub-io/data-science-pipelines-operator/issues/375

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Replacing hardcode references to minio-service endpoints with an environment variable.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
* Build an image with changes in this PR. This is the image I built with these changes: `quay.io/rhn_support_ddalvi/data-science-pipelines-operator:minio-revised`
* Deploy DSPO and create a DSPA instance
* Make sure minio pod comes up correctly
* Create a run using the default pipeline to make sure it goes through correctly.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
