### PR TITLE
Extracted DB and Object Storage Error Logs to display on DSPA

### DIFF
--- a/controllers/database.go
+++ b/controllers/database.go
@@ -21,10 +21,13 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 
+	"time"
+
+	"errors"
+
 	_ "github.com/go-sql-driver/mysql"
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
-	"time"
 )
 
 const dbSecret = "mariadb/secret.yaml.tmpl"
@@ -37,7 +40,7 @@ var mariadbTemplates = []string{
 }
 
 // extract to var for mocking in testing
-var ConnectAndQueryDatabase = func(host, port, username, password, dbname string, dbConnectionTimeout time.Duration) bool {
+var ConnectAndQueryDatabase = func(host, port, username, password, dbname string, dbConnectionTimeout time.Duration) (bool, error) {
 	// Create a context with a timeout of 1 second
 	ctx, cancel := context.WithTimeout(context.Background(), dbConnectionTimeout)
 	defer cancel()
@@ -45,22 +48,23 @@ var ConnectAndQueryDatabase = func(host, port, username, password, dbname string
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", username, password, host, port, dbname)
 	db, err := sql.Open("mysql", connectionString)
 	if err != nil {
-		return false
+		return false, err
 	}
 	defer db.Close()
 
 	testStatement := "SELECT 1;"
 	_, err = db.QueryContext(ctx, testStatement)
-	return err == nil
+	return err == nil, nil
 }
 
 func (r *DSPAReconciler) isDatabaseAccessible(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication,
-	params *DSPAParams) bool {
+	params *DSPAParams) (bool, error) {
 	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 
 	if params.DatabaseHealthCheckDisabled(dsp) {
-		log.V(1).Info("Database health check disabled, assuming database is available and ready.")
-		return true
+		infoMessage := "Database health check disabled, assuming database is available and ready."
+		log.V(1).Info(infoMessage)
+		return true, nil
 	}
 
 	log.Info("Performing Database Health Check")
@@ -68,8 +72,9 @@ func (r *DSPAReconciler) isDatabaseAccessible(ctx context.Context, dsp *dspav1al
 	usingExternalDB := params.UsingExternalDB(dsp)
 	usingMariaDB := !databaseSpecified || dsp.Spec.Database.MariaDB != nil
 	if !usingMariaDB && !usingExternalDB {
-		log.Info("Could not connect to Database: Unsupported Type")
-		return false
+		errorMessage := "Could not connect to Database: Unsupported Type"
+		log.Error(nil, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	decodePass, _ := b64.StdEncoding.DecodeString(params.DBConnection.Password)
@@ -77,18 +82,20 @@ func (r *DSPAReconciler) isDatabaseAccessible(ctx context.Context, dsp *dspav1al
 
 	log.V(1).Info(fmt.Sprintf("Database Heath Check connection timeout: %s", dbConnectionTimeout))
 
-	dbHealthCheckPassed := ConnectAndQueryDatabase(params.DBConnection.Host,
+	dbHealthCheckPassed, err := ConnectAndQueryDatabase(params.DBConnection.Host,
 		params.DBConnection.Port,
 		params.DBConnection.Username,
 		string(decodePass),
 		params.DBConnection.DBName,
 		dbConnectionTimeout)
-	if dbHealthCheckPassed {
-		log.Info("Database Health Check Successful")
-	} else {
+
+	if err != nil {
 		log.Info("Unable to connect to Database")
+	} else {
+		log.Info("Database Health Check Successful")
 	}
-	return dbHealthCheckPassed
+
+	return dbHealthCheckPassed, err
 }
 
 func (r *DSPAReconciler) ReconcileDatabase(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication,

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -24,13 +24,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/util"
-	"time"
 )
 
 const storageSecret = "minio/secret.yaml.tmpl"
@@ -94,7 +95,7 @@ func getHttpsTransportWithCACert(log logr.Logger, pemCerts []byte) (*http.Transp
 	return transport, nil
 }
 
-var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
+var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 	cred := createCredentialProvidersChain(string(accesskey), string(secretkey))
 
 	opts := &minio.Options{
@@ -105,16 +106,18 @@ var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoin
 	if len(pemCerts) != 0 {
 		tr, err := getHttpsTransportWithCACert(log, pemCerts)
 		if err != nil {
-			log.Error(err, "Encountered error when processing custom ca bundle.")
-			return false
+			errorMessage := "Encountered error when processing custom ca bundle."
+			log.Error(err, errorMessage)
+			return false, errors.New(errorMessage)
 		}
 		opts.Transport = tr
 	}
 
 	minioClient, err := minio.New(endpoint, opts)
 	if err != nil {
-		log.Info(fmt.Sprintf("Could not connect to object storage endpoint: %s", endpoint))
-		return false
+		errorMessage := fmt.Sprintf("Could not connect to object storage endpoint: %s", endpoint)
+		log.Error(err, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, objStoreConnectionTimeout)
@@ -128,68 +131,74 @@ var ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoin
 		// In the case that the Error is NoSuchKey (or NoSuchBucket), we can verify that the endpoint worked and the object just doesn't exist
 		case minio.ErrorResponse:
 			if err.Code == "NoSuchKey" || err.Code == "NoSuchBucket" {
-				return true
+				return true, err
 			}
 		}
 
 		if util.IsX509UnknownAuthorityError(err) {
-			log.Error(err, "Encountered x509 UnknownAuthorityError when connecting to ObjectStore. "+
-				"If using an tls S3 connection with  self-signed certs, you may specify a custom CABundle "+
-				"to mount on the DSP API Server via the DSPA cr under the spec.cABundle field. If you have already "+
-				"provided a CABundle, verify the validity of the provided CABundle.")
-			return false
+			errorMessage := "Encountered x509 UnknownAuthorityError when connecting to ObjectStore. " +
+				"If using an tls S3 connection with  self-signed certs, you may specify a custom CABundle " +
+				"to mount on the DSP API Server via the DSPA cr under the spec.cABundle field. If you have already " +
+				"provided a CABundle, verify the validity of the provided CABundle."
+			log.Error(err, errorMessage)
+			return false, errors.New(errorMessage)
 		}
 
 		// Every other error means the endpoint in inaccessible, or the credentials provided do not have, at a minimum GetObject, permissions
-		log.Info(fmt.Sprintf("Could not connect to (%s), Error: %s", endpoint, err.Error()))
-		return false
+		errorMessage := fmt.Sprintf("Could not connect to (%s), Error: %s", endpoint, err.Error())
+		log.Error(err, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	// Getting here means the health check passed
-	return true
+	return true, nil
 }
 
 func (r *DSPAReconciler) isObjectStorageAccessible(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication,
-	params *DSPAParams) bool {
+	params *DSPAParams) (bool, error) {
 	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 	if params.ObjectStorageHealthCheckDisabled(dsp) {
-		log.V(1).Info("Object Storage health check disabled, assuming object store is available and ready.")
-		return true
+		infoMessage := "Object Storage health check disabled, assuming object store is available and ready."
+		log.V(1).Info(infoMessage)
+		return true, nil
 	}
 
 	log.Info("Performing Object Storage Health Check")
 
 	endpoint, err := joinHostPort(params.ObjectStorageConnection.Host, params.ObjectStorageConnection.Port)
 	if err != nil {
-		log.Error(err, "Could not determine Object Storage Endpoint")
-		return false
+		errorMessage := "Could not determine Object Storage Endpoint"
+		log.Error(err, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	accesskey, err := base64.StdEncoding.DecodeString(params.ObjectStorageConnection.AccessKeyID)
 	if err != nil {
-		log.Error(err, "Could not decode Object Storage Access Key ID")
-		return false
+		errorMessage := "Could not decode Object Storage Access Key ID"
+		log.Error(err, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	secretkey, err := base64.StdEncoding.DecodeString(params.ObjectStorageConnection.SecretAccessKey)
 	if err != nil {
-		log.Error(err, "Could not decode Object Storage Secret Access Key")
-		return false
+		errorMessage := "Could not decode Object Storage Secret Access Key"
+		log.Error(err, errorMessage)
+		return false, errors.New(errorMessage)
 	}
 
 	objStoreConnectionTimeout := config.GetDurationConfigWithDefault(config.ObjStoreConnectionTimeoutConfigName, config.DefaultObjStoreConnectionTimeout)
 
 	log.V(1).Info(fmt.Sprintf("Object Store connection timeout: %s", objStoreConnectionTimeout))
 
-	verified := ConnectAndQueryObjStore(ctx, log, endpoint, params.ObjectStorageConnection.Bucket, accesskey, secretkey,
+	verified, err := ConnectAndQueryObjStore(ctx, log, endpoint, params.ObjectStorageConnection.Bucket, accesskey, secretkey,
 		*params.ObjectStorageConnection.Secure, params.APICustomPemCerts, objStoreConnectionTimeout)
 
-	if verified {
-		log.Info("Object Storage Health Check Successful")
-	} else {
+	if err != nil {
 		log.Info("Object Storage Health Check Failed")
+	} else {
+		log.Info("Object Storage Health Check Successful")
 	}
-	return verified
+	return verified, err
 }
 
 // ReconcileStorage will set up Storage Connection.

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
 	"time"
 
@@ -270,8 +271,8 @@ func TestDefaultDeployBehaviorStorage(t *testing.T) {
 
 func TestIsDatabaseAccessibleTrue(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return true
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return true, nil
 	}
 
 	testNamespace := "testnamespace"
@@ -302,14 +303,14 @@ func TestIsDatabaseAccessibleTrue(t *testing.T) {
 		},
 	}
 
-	verified := reconciler.isObjectStorageAccessible(ctx, dspa, params)
-	assert.True(t, verified)
+	verified, err := reconciler.isObjectStorageAccessible(ctx, dspa, params)
+	assert.True(t, verified, err)
 }
 
 func TestIsDatabaseNotAccessibleFalse(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return false
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return false, errors.New("Object Store is not Accessible")
 	}
 
 	testNamespace := "testnamespace"
@@ -340,14 +341,14 @@ func TestIsDatabaseNotAccessibleFalse(t *testing.T) {
 		},
 	}
 
-	verified := reconciler.isObjectStorageAccessible(ctx, dspa, params)
-	assert.False(t, verified)
+	verified, err := reconciler.isObjectStorageAccessible(ctx, dspa, params)
+	assert.False(t, verified, err)
 }
 
 func TestDisabledHealthCheckReturnsTrue(t *testing.T) {
 	// Override the live connection function with a mock version that would always return false if called
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return false
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return false, errors.New("Object Store is not Accessible")
 	}
 
 	testNamespace := "testnamespace"
@@ -378,16 +379,16 @@ func TestDisabledHealthCheckReturnsTrue(t *testing.T) {
 		},
 	}
 
-	verified := reconciler.isObjectStorageAccessible(ctx, dspa, params)
+	verified, err := reconciler.isObjectStorageAccessible(ctx, dspa, params)
 	// if health check is disabled this should always return True
 	// even thought the mock connection function would return false if called
-	assert.True(t, verified)
+	assert.True(t, verified, err)
 }
 
 func TestIsDatabaseAccessibleBadAccessKey(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return true
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return true, nil
 	}
 
 	testNamespace := "testnamespace"
@@ -418,14 +419,14 @@ func TestIsDatabaseAccessibleBadAccessKey(t *testing.T) {
 		},
 	}
 
-	verified := reconciler.isObjectStorageAccessible(ctx, dspa, params)
-	assert.False(t, verified)
+	verified, err := reconciler.isObjectStorageAccessible(ctx, dspa, params)
+	assert.False(t, verified, err)
 }
 
 func TestIsDatabaseAccessibleBadSecretKey(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return true
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return true, nil
 	}
 
 	testNamespace := "testnamespace"
@@ -456,8 +457,8 @@ func TestIsDatabaseAccessibleBadSecretKey(t *testing.T) {
 		},
 	}
 
-	verified := reconciler.isObjectStorageAccessible(ctx, dspa, params)
-	assert.False(t, verified)
+	verified, err := reconciler.isObjectStorageAccessible(ctx, dspa, params)
+	assert.False(t, verified, err)
 }
 
 func TestJoinHostPort(t *testing.T) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -73,11 +73,11 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeEach(func() {
 	By("Overriding the Database and Object Store live connection functions with trivial stubs")
-	ConnectAndQueryDatabase = func(host string, port string, username string, password string, dbname string, dbConnectionTimeout time.Duration) bool {
-		return true
+	ConnectAndQueryDatabase = func(host string, port string, username string, password string, dbname string, dbConnectionTimeout time.Duration) (bool, error) {
+		return true, nil
 	}
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) bool {
-		return true
+	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts []byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+		return true, nil
 	}
 })
 


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #451 

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Extracted DB and Object Storage Error Logs which were only visible in DSPO to display on DSPA Conditions with a brief message of any error.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

1. Deploy DSPO
2. Deploy a Minio in a self-signed external OCP cluster (preferablly different from the dsp host cluster) 
```
oc new-project minio
oc -n minio apply -f https://gist.githubusercontent.com/HumairAK/f1358278ab70dde2ee074d1a35f8f058/raw/f234ba638f408c3aff8ed836858d0d1e332f43be/minio.yaml

# Retrieve the route
$MINIO_ROUTE=$(oc get routes -n minio minio-secure --template={{.spec.host}})
```
3. On DSP host cluster, deploy a dspa, first without the cabundle:
```
kind: Secret
apiVersion: v1
metadata:
  name: s3secret
  namespace: dspa
stringData:
  customaccessKey: accesskey
  customsecretKey: secretkey
type: Opaque
---
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
  namespace: dspa
spec:
  apiServer:
    enableSamplePipeline: false
  objectStorage:
    externalStorage:
      bucket: mlpipeline
      host: $MINIO_ROUTE  # <------------- add the route retrieved earlier !
      s3CredentialsSecret:
        accessKey: customaccessKey
        secretKey: customsecretKey
        secretName: s3secret
      scheme: https
  mlpipelineUI:
    image: 'quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui'
```
4. Check DSPO logs, you should see an error mentioning x509 and instructions on adding a cabundle.
5. Verify in the Conditions for sample DSPA instance that Condition Type **ObjectStoreAvailable** shows the same error mentioned in DSPO logs.
![Screenshot from 2023-11-23 16-45-35](https://github.com/opendatahub-io/data-science-pipelines-operator/assets/38726729/165676e9-d351-426b-b5a3-ea345e0e9660)



## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
