### PR TITLE
Add default values for v2 sample pipeline input parameters

### DIFF
--- a/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
@@ -238,10 +238,13 @@ data:
         inputDefinitions:
           parameters:
             min_max_scaler:
+              defaultValue: true
               parameterType: BOOLEAN
             neighbors:
+              defaultValue: 3
               parameterType: NUMBER_INTEGER
             standard_scaler:
+              defaultValue: false
               parameterType: BOOLEAN
         outputDefinitions:
           artifacts:

--- a/controllers/testdata/declarative/case_7/expected/created/sample-pipeline.yaml.tmpl
+++ b/controllers/testdata/declarative/case_7/expected/created/sample-pipeline.yaml.tmpl
@@ -237,10 +237,13 @@ data:
         inputDefinitions:
           parameters:
             min_max_scaler:
+              defaultValue: true
               parameterType: BOOLEAN
             neighbors:
+              defaultValue: 3
               parameterType: NUMBER_INTEGER
             standard_scaler:
+              defaultValue: false
               parameterType: BOOLEAN
         outputDefinitions:
           artifacts:


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #personal annoyances :) 

## Description of your changes:
Add default values to the input parameters of the v2 sample pipeline such that they are auto-filled

## Testing instructions
deploy DSPO. Create V2 DSPA, wait for it to be fully ready
Run the pre-loaded sample pipeline, verify that the input parameters (min_max_scaler=true, neighbors=3, standard_scalar=false)*

Note that standard_scalar seems to not pre-fill correctly, but this is due to a seperate bug (TODO: add link) where 'False' default values are simply not loaded.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
