### PR TITLE
Leverage ObjStore Routes for Prereq Health Checks

### DIFF
--- a/config/internal/minio/route.yaml.tmpl
+++ b/config/internal/minio/route.yaml.tmpl
@@ -13,3 +13,6 @@ spec:
     weight: 100
   port:
     targetPort: 9000
+  tls:
+    termination: Edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/config/samples/dspa_healthcheck.yaml
+++ b/config/samples/dspa_healthcheck.yaml
@@ -1,0 +1,26 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: sample
+spec:
+  apiServer:
+    deploy: true
+    enableSamplePipeline: false
+    # If developing against a cluster using self-signed certs, then uncomment this field.
+    # cABundle:
+      # configMapName: kube-root-ca.crt
+      # configMapKey: ca.crt
+  # One of minio or externalStorage must be specified for objectStorage
+  # This example illustrates minimal deployment with minio
+  # This is NOT supported and should be used for dev testing/experimentation only.
+  # See dspa_simple_external_storage.yaml for an example with external connection.
+  objectStorage:
+    disableHealthCheck: false
+    enableExternalRoute: true
+    minio:
+      # Image field is required
+      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
+  # Optional
+  mlpipelineUI:
+    # Image field is required
+    image: 'quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui'


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-1643](https://issues.redhat.com//browse/RHOAIENG-1643)

## Description of your changes:
Leverage the Object store external route to perform the Health check.

## Testing instructions

Deploy DSPO

```
# git clone and checkout the PR branch
make deploy IMG=quay.io/opendatahub/data-science-pipelines-operator:pr-519
```
Deploy DSPA instance using dspa_healthcheck.yaml file and check the logs to see if the Minio object store health check is successful.

Note: Please create a CA bundle to avoid custom cert issues while testing and update the same under apiServer section as show in the dspa_healthcheck.yaml file. Created configmap with ca cert as shown below:
kind: ConfigMap
apiVersion: v1
metadata:
  name: my-ca
data:
  ca.crt: |