### PR TITLE
add kfp-launcher config support.

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -316,9 +316,13 @@ type Resources struct {
 
 type ExternalStorage struct {
 	// +kubebuilder:validation:Required
-	Host                string `json:"host"`
-	Bucket              string `json:"bucket"`
-	Scheme              string `json:"scheme"`
+	Host   string `json:"host"`
+	Bucket string `json:"bucket"`
+	Scheme string `json:"scheme"`
+	// +kubebuilder:validation:Optional
+	Region string `json:"region"`
+	// +kubebuilder:validation:Optional
+	BasePath            string `json:"basePath"`
 	*S3CredentialSecret `json:"s3CredentialsSecret"`
 	// +kubebuilder:validation:Optional
 	Secure *bool `json:"secure"`

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -526,11 +526,15 @@ spec:
                     type: boolean
                   externalStorage:
                     properties:
+                      basePath:
+                        type: string
                       bucket:
                         type: string
                       host:
                         type: string
                       port:
+                        type: string
+                      region:
                         type: string
                       s3CredentialsSecret:
                         properties:

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -75,6 +75,10 @@ spec:
                   name: "{{.ObjectStorageConnection.CredentialsSecret.SecretName}}"
             - name: OBJECTSTORECONFIG_SECURE
               value: "{{.ObjectStorageConnection.Secure}}"
+            {{ if .ObjectStorageConnection.BasePath }}
+            - name: OBJECTSTORECONFIG_PIPELINEPATH
+              value: "{{.ObjectStorageConnection.BasePath}}"
+            {{ end }}
             - name: MINIO_SERVICE_SERVICE_HOST
               value: "{{.ObjectStorageConnection.Host}}"
             - name: MINIO_SERVICE_SERVICE_PORT

--- a/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
+++ b/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  {{ if .ObjectStorageConnection.BasePath }}
+  defaultPipelineRoot: s3://{{.ObjectStorageConnection.Bucket}}/{{.ObjectStorageConnection.BasePath}}
+  {{ else }}
+  defaultPipelineRoot: s3://{{.ObjectStorageConnection.Bucket}}
+  {{ end }}
+  providers: |
+    s3:
+      endpoint: {{.ObjectStorageConnection.Endpoint}}
+      region: {{.ObjectStorageConnection.Region}}
+      defaultProviderSecretRef:
+        secretName: {{.ObjectStorageConnection.CredentialsSecret.SecretName}}
+        accessKeyKey: {{.ObjectStorageConnection.CredentialsSecret.AccessKey}}
+        secretKeyKey: {{.ObjectStorageConnection.CredentialsSecret.SecretKey}}
+kind: ConfigMap
+metadata:
+  name: kfp-launcher
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-{{.Name}}
+    component: data-science-pipelines

--- a/config/samples/external-object-storage/dspa.yaml
+++ b/config/samples/external-object-storage/dspa.yaml
@@ -6,7 +6,8 @@ spec:
   objectStorage:
     externalStorage:
       bucket: rhods-dsp-dev
-      host: s3.amazonaws.com
+      host: s3.us-east-2.amazonaws.com
+      region: us-east-2
       s3CredentialsSecret:
         accessKey: k8saccesskey
         secretKey: k8ssecretkey

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -76,6 +76,8 @@ type ObjectStorageConnection struct {
 	Host              string
 	Port              string
 	Scheme            string
+	Region            string
+	BasePath          string
 	Secure            *bool
 	Endpoint          string // scheme://host:port
 	AccessKeyID       string
@@ -287,6 +289,11 @@ func (p *DSPAParams) SetupObjectParams(ctx context.Context, dsp *dspa.DataScienc
 		p.ObjectStorageConnection.Bucket = dsp.Spec.ObjectStorage.ExternalStorage.Bucket
 		p.ObjectStorageConnection.Host = dsp.Spec.ObjectStorage.ExternalStorage.Host
 		p.ObjectStorageConnection.Scheme = dsp.Spec.ObjectStorage.ExternalStorage.Scheme
+		p.ObjectStorageConnection.BasePath = dsp.Spec.ObjectStorage.ExternalStorage.BasePath
+		p.ObjectStorageConnection.Region = dsp.Spec.ObjectStorage.ExternalStorage.Region
+		if p.ObjectStorageConnection.Region == "" {
+			p.ObjectStorageConnection.Region = "auto"
+		}
 
 		if dsp.Spec.ObjectStorage.ExternalStorage.Secure == nil {
 			if p.ObjectStorageConnection.Scheme == "https" {
@@ -342,6 +349,7 @@ func (p *DSPAParams) SetupObjectParams(ctx context.Context, dsp *dspa.DataScienc
 		p.ObjectStorageConnection.Port = config.MinioPort
 		p.ObjectStorageConnection.Scheme = config.MinioScheme
 		p.ObjectStorageConnection.Secure = util.BoolPointer(false)
+		p.ObjectStorageConnection.Region = "minio"
 
 		if p.Minio.S3CredentialSecret != nil {
 			p.ObjectStorageConnection.CredentialsSecret = p.Minio.S3CredentialSecret


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-1707](https://issues.redhat.com//browse/RHOAIENG-1707)


## Description of your changes:
DSPO will now deploy a kfp-launcher config to accomodate: https://github.com/opendatahub-io/data-science-pipelines/pull/4

Thus allowing dspa's to be deployed in multiple namespaces, and not just restricted to kubeflow namespace 

## Testing instructions

DSPA: 

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample1
  namespace: dspa3
spec:
  dspVersion: v2
  apiServer:
    deploy: true
    image: quay.io/hukhan/ds-pipelines-api-server:pr-4
    argoLauncherImage: quay.io/hukhan/kfp-launcher:pr-4
    argoDriverImage: quay.io/hukhan/kfp-driver:pr-4
  persistenceAgent:
    deploy: true
    image: gcr.io/ml-pipeline/persistenceagent:2.0.2
  scheduledWorkflow:
    deploy: true
    image: gcr.io/ml-pipeline/scheduledworkflow:2.0.2
  mlmd:
    deploy: true
    grpc:
      image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
    envoy:
      image: gcr.io/ml-pipeline/metadata-envoy:2.0.2
  database:
    mariaDB:
      deploy: true
  objectStorage:
    externalStorage:
      bucket: rhods-dsp-dev
      host: s3.us-east-2.amazonaws.com
      region: us-east-2
      basePath: anotherpath/deeper
      s3CredentialsSecret:
        accessKey: k8saccesskey
        secretKey: k8ssecretkey
        secretName: aws-bucket-creds
      scheme: https
  mlpipelineUI:
    image: gcr.io/ml-pipeline/frontend:2.0.2
  workflowController:
    deploy: true
    image: gcr.io/ml-pipeline/workflow-controller:v3.3.10-license-compliance
```

for `objectStorage` you can also try the default minio: 

```
  objectStorage:
    minio:
      # Image field is required
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
```

