### PR TITLE
enable kfp ui to retrieve artifacts.

### DIFF
--- a/config/internal/minio/default/service.yaml.tmpl
+++ b/config/internal/minio/default/service.yaml.tmpl
@@ -12,6 +12,14 @@ spec:
       port: 9000
       protocol: TCP
       targetPort: 9000
+    # Work around to enable kfp ui to fetch artifacts for viewer
+    # S3 generic endpoint for kfp UI only supports rest port
+    # since default minio is http, and we disable ssl via "AWS_SSL" env var
+    # https://github.com/opendatahub-io/data-science-pipelines/blob/83d7e719d08c73c2c535722b66b77cdf0cb4cd08/frontend/server/handlers/artifacts.ts#L104
+    - name: kfp-ui-http
+      port: 80
+      protocol: TCP
+      targetPort: 9000
   selector:
     app: minio-{{.Name}}
     component: data-science-pipelines

--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -52,6 +52,24 @@ spec:
               value: ds-pipeline-metadata-envoy-{{.Name}}
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{.ObjectStorageConnection.CredentialsSecret.SecretName}}
+                  key: {{.ObjectStorageConnection.CredentialsSecret.AccessKey}}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.ObjectStorageConnection.CredentialsSecret.SecretName}}
+                  key: {{.ObjectStorageConnection.CredentialsSecret.SecretKey}}
+            - name: AWS_REGION
+              value: {{.ObjectStorageConnection.Region}}
+            - name: AWS_S3_ENDPOINT
+              value: {{.ObjectStorageConnection.Host}}
+            {{ if eq .ObjectStorageConnection.Scheme "http"}}
+            - name: AWS_SSL
+              value: "false"
+            {{ end }}
           image: {{.MlPipelineUI.Image}}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/config/samples/dspa_simple_v2.yaml
+++ b/config/samples/dspa_simple_v2.yaml
@@ -10,3 +10,5 @@ spec:
       image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
   mlpipelineUI:
     image: quay.io/opendatahub/ds-pipelines-frontend:latest
+  workflowController:
+    deploy: true

--- a/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
@@ -53,6 +53,22 @@ spec:
               value: ds-pipeline-metadata-envoy-testdsp2
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp2"
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp2"
+            - name: AWS_REGION
+              value: "minio"
+            - name: AWS_S3_ENDPOINT
+              value: "minio-testdsp2.default.svc.cluster.local"
+            - name: AWS_SSL
+              value: "false"
           image: frontend:test2
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
@@ -53,6 +53,22 @@ spec:
               value: ds-pipeline-metadata-envoy-testdsp4
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp4"
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp4"
+            - name: AWS_REGION
+              value: "minio"
+            - name: AWS_S3_ENDPOINT
+              value: "minio-testdsp4.default.svc.cluster.local"
+            - name: AWS_SSL
+              value: "false"
           image: this-frontend-image-from-cr-should-be-used:test4
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
@@ -53,6 +53,22 @@ spec:
               value: ds-pipeline-metadata-envoy-testdsp5
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp5"
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp5"
+            - name: AWS_REGION
+              value: "minio"
+            - name: AWS_S3_ENDPOINT
+              value: "minio-testdsp5.default.svc.cluster.local"
+            - name: AWS_SSL
+              value: "false"
           image: frontend:test5
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
@@ -53,6 +53,22 @@ spec:
               value: ds-pipeline-metadata-envoy-testdsp7
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "mlpipeline-minio-artifact"
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "mlpipeline-minio-artifact"
+            - name: AWS_REGION
+              value: "minio"
+            - name: AWS_S3_ENDPOINT
+              value: "minio-testdsp7.default.svc.cluster.local"
+            - name: AWS_SSL
+              value: "false"
           image: frontend:test7
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
This is a work around for the kfp ui to be able to read artifacts within the preview section. KFP UI will not accept port specifications for the s3 generic config, it will default to port 80 or 443 for http/https connections, since our default minio is port 80, we have to enable that port, as well as add the aws required s3 generic env vars to kfp ui deployment.