### PR TITLE
Updating NW Policy to have notebook pod connect to DSP APIServer

### DIFF
--- a/config/internal/common/tekton/policy.yaml.tmpl
+++ b/config/internal/common/tekton/policy.yaml.tmpl
@@ -64,6 +64,12 @@ spec:
             matchLabels:
               app: ds-pipeline-metadata-writer-{{.Name}}
               component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              opendatahub.io/dashboard: 'true'
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{.Namespace}}
       ports:
         - protocol: TCP
           port: 8888


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-1689](https://issues.redhat.com/browse/RHOAIENG-1689)

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Updating the DSPA network policy to have notebook pod connect to DSP APIServer, so that the notebook pods could connect to the DSP API Server without OAuth token interference.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
Deploy DSPO and a DSPA instance based on these changes.

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
