### PR TITLE
Fix go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,5 +123,6 @@ replace (
 	github.com/miekg/dns v1.0.14 => github.com/miekg/dns v1.1.25
 	github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705 => github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705
 	go.opentelemetry.io/contrib v0.20.0 => go.opentelemetry.io/contrib v0.44.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1 => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	google.golang.org/grpc => google.golang.org/grpc v1.56.3
 )


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-2259](https://issues.redhat.com/browse/RHOAIENG-2259)

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Fixing go.mod dependencies/packages related snyk CVEs.
Imported my fork in synk and made sure the relevant CVEs were fixed with this update.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
