### PR TITLE
fix: remove conflicting tls proxy secret generator.

### DIFF
--- a/config/internal/apiserver/default/service.ml-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/default/service.ml-pipeline.yaml.tmpl
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   name: ml-pipeline
   namespace: {{.Namespace}}
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: ds-pipelines-proxy-tls-{{.Name}}
   labels:
     app: ds-pipeline-{{.Name}}
     component: data-science-pipelines


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves  https://issues.redhat.com/browse/RHOAIENG-2798

## Description of your changes:
This solves a race condition that existed because of a workaround we've implemented. KFP exposes a service that is backed by the apiserver pod. In Data Science Pipelines, we want this service name to be dynamic -- `ds-pipeline-{ DSPA NAME }}`. In KFP v2, the running pipeline pods call back to the apiserver via its service, and they rely on the hardcoded service name of `ml-pipeline` (https://github.com/kubeflow/pipelines/issues/9689). To temporarily work around this hardcoding, we're exposing both services -- our dynamically-named one and the hardcoded `ml-pipeline` one. (Both services point to the same apiserver pod.)

We use the [OpenShift service ca operator](https://docs.openshift.com/container-platform/4.12/security/certificates/service-serving-certificate.html#add-service-certificate_service-serving-certificate) to generate certs which we mount into the oauth proxy sidecar for the apiserver. This cert generation is triggered by an annotation on the service. When we created the yaml for the hardcoded `ml-pipeline` duplicate service, we mistakenly duplicated the annotation as well. This caused a race condition where sometimes the OpenShift service ca operator would see the `ml-pipeline` service first, causing our dynamically-named service to be in error state (message: `secret dspa-master/ds-pipelines-proxy-tls-{dspa-name} does not have corresponding service UID`). The workaround `ml-pipeline` service doesn't need the annotation, so we just remove it here.

see https://issues.redhat.com/browse/RHOAIENG-2798 for more details

## Testing instructions
1. deploy dspa, visit the api server route, ensure you hit oauth proxy, try a couple of times
2. inspect the `ds-pipelines-proxy-tls-sample` ensure the owner of this secret is the service named `ds-pipeline-<dspa_name>`
3. the `ml-pipeline` service is utilized by actual pipeline executions (due to hardcoded names in upstream kfp) so run one or two to confirm these remain unaffected, they should run to completion successfully (assuming no user code errors)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
