### PR TITLE
feat: add rhoai overlay.

### DIFF
--- a/.github/resources/argo-lite/kustomization.yaml
+++ b/.github/resources/argo-lite/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opendatahub
 resources:
-  - ../../../config/argo
+  - ../../../config/overlays/make-argodeploy
 patchesStrategicMerge:
   - patch/argo_server_deployment.yaml

--- a/.github/resources/argo-lite/patch/argo_server_deployment.yaml
+++ b/.github/resources/argo-lite/patch/argo_server_deployment.yaml
@@ -14,4 +14,4 @@ spec:
               memory: 500Mi
             requests:
               cpu: 20m
-              memory: 100m
+              memory: 100Mi

--- a/config/argo/deployment.argo-server.yaml
+++ b/config/argo/deployment.argo-server.yaml
@@ -17,7 +17,7 @@ spec:
       - args:
         - server
         env: []
-        image: quay.io/argoproj/argocli:v3.4.12
+        image: $(IMAGES_ARGO_SERVER)
         name: argo-server
         ports:
         - containerPort: 2746

--- a/config/argo/params.yaml
+++ b/config/argo/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment
+- path: data
+  kind: ConfigMap

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
   - ../prometheus
   - ../configmaps
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: dspo-parameters
     envs:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -15,6 +15,7 @@ IMAGESV2_ARGO_MLMDGRPC=quay.io/opendatahub/ds-pipelines-metadata-grpc:latest
 IMAGESV2_ARGO_MLMDWRITER=quay.io/opendatahub/ds-pipelines-metadata-writer:latest
 IMAGESV2_ARGO_WORKFLOWCONTROLLER=quay.io/opendatahub/ds-pipelines-argo-workflowcontroller:3.3.10-upstream
 IMAGESV2_ARGO_ARGOEXEC=quay.io/opendatahub/ds-pipelines-argo-argoexec:3.3.10-upstream
+IMAGES_ARGO_SERVER=quay.io/opendatahub/ds-pipelines-argo-server:3.3.10-upstream
 V2_LAUNCHER_IMAGE=quay.io/opendatahub/ds-pipelines-launcher:latest
 V2_DRIVER_IMAGE=quay.io/opendatahub/ds-pipelines-driver:latest
 IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal:8.8

--- a/config/configmaps/kustomization.yaml
+++ b/config/configmaps/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
   - name: dspo-config
     files:

--- a/config/overlays/make-argodeploy/argo-server-image-patch.yaml
+++ b/config/overlays/make-argodeploy/argo-server-image-patch.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+  namespace: argo
+spec:
+  template:
+    spec:
+      containers:
+      - name: argo-server
+        image: quay.io/argoproj/argocli

--- a/config/overlays/make-argodeploy/kustomization.yaml
+++ b/config/overlays/make-argodeploy/kustomization.yaml
@@ -4,6 +4,11 @@ namespace: opendatahub
 resources:
 - ../../argo
 
+# This patch is to override the `$(IMAGES_ARGO_SERVER)` param in config/argo
+# It is then overwridden by the `images` field further down, allowing us patch
+# the image from this overlays root kustomization `images` field.
+patchesStrategicMerge:
+- argo-server-image-patch.yaml
 images:
 - name: quay.io/argoproj/argocli
   newName: quay.io/opendatahub/ds-pipelines-argo-server

--- a/config/overlays/rhoai/kustomization.yaml
+++ b/config/overlays/rhoai/kustomization.yaml
@@ -1,9 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../make-argodeploy
-- ../make-deploy
-namespace: opendatahub
+- ../../base
+- ../../argo
+namespace: redhat-ods-applications
+
 vars:
   - name: IMAGES_ARGO_SERVER
     objref:


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Related: https://issues.redhat.com/browse/RHOAIENG-2877

## Description of your changes:
Provide a rhoai overlay alongside an odh overlay
This will allow us to patch any rhoai specific changes in the future
Also add argo server image to params.env so odh operator can sub this in for downstream.

One change here to watch out is the change to the configmapGenerator suffix, this makes it so that the 2 configmaps created for the DSPO deployment no longer have the hash suffix.

## Testing instructions
* confirm kustomize builds in the overlay directories build as expected, and that argo image is subbed in
* `make deployODH` behavior should not have changed other than the configmap name change, the output should be otherwise the same 
* currently the rhoai overlay should function identically to the odh overlay


## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
