### PR TITLE
chore: update mlpipelines ui liveness/readiness to use http.

### DIFF
--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -73,30 +73,22 @@ spec:
           image: {{.MlPipelineUI.Image}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            exec:
-              command:
-                - wget
-                - -q
-                - -S
-                - -O
-                - '-'
-                - http://localhost:3000/apis/v1beta1/healthz
-            initialDelaySeconds: 3
+            httpGet:
+              port: 3000
+              path: /apis/v1beta1/healthz
+              scheme: HTTP
+            initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 2
           name: ds-pipeline-ui
           ports:
             - containerPort: 3000
           readinessProbe:
-            exec:
-              command:
-                - wget
-                - -q
-                - -S
-                - -O
-                - '-'
-                - http://localhost:3000/apis/v1beta1/healthz
-            initialDelaySeconds: 3
+            httpGet:
+              port: 3000
+              path: /apis/v1beta1/healthz
+              scheme: HTTP
+            initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 2
           resources:


### PR DESCRIPTION
Livness probe via exec / wget seems flakey and seems to result in kfp ui crashing: 


![image](https://github.com/opendatahub-io/data-science-pipelines-operator/assets/10904967/73a00b1a-4fdf-426e-b072-fe8820180e97)

Despite the kfp UI working fine, this ends up restarting the pod and causing it to sporadically go into crashloop.


