### PR TITLE
chore: fix serving cert annotations

### DIFF
--- a/config/internal/apiserver/default/service.yaml.tmpl
+++ b/config/internal/apiserver/default/service.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: {{.APIServerServiceName}}
   namespace: {{.Namespace}}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: ds-pipelines-proxy-tls-{{.Name}}
+    service.beta.openshift.io/serving-cert-secret-name: ds-pipelines-proxy-tls-{{.Name}}
   labels:
     app: {{.APIServerDefaultResourceName}}
     component: data-science-pipelines

--- a/config/internal/mlpipelines-ui/service.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/service.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: ds-pipeline-ui-{{.Name}}
   namespace: {{.Namespace}}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: ds-pipelines-ui-proxy-tls-{{.Name}}
+    service.beta.openshift.io/serving-cert-secret-name: ds-pipelines-ui-proxy-tls-{{.Name}}
   labels:
     app: ds-pipeline-ui-{{.Name}}
     component: data-science-pipelines


### PR DESCRIPTION
Service serving certificate annotations were changed from `alpha` to `beta` 3 years ago. Fixing.

Ref: https://github.com/openshift/openshift-docs/commit/847d4dcbd7934bf6b20040231b5b607c1065c73b

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
