### PR TITLE
chore: allow make deploy to fully deploy v2 stack

### DIFF
--- a/.github/resources/argo-lite/kustomization.yaml
+++ b/.github/resources/argo-lite/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opendatahub
 resources:
-  - ../../../config/overlays/make-argodeploy
+  - ../../../config/argo

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,11 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 		&& $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
 	$(KUSTOMIZE) build config/overlays/make-deploy | kubectl apply -f -
 
+.PHONY: undeploy
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	cd config/overlays/make-deploy && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
+	$(KUSTOMIZE) build config/overlays/make-deploy | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
 .PHONY: deploy-kind
 deploy-kind:
 	cd config/overlays/kind-tests \
@@ -176,39 +181,11 @@ deploy-kind:
 		&& kustomize edit set namespace ${OPERATOR_NS}
 	kustomize build config/overlays/kind-tests | kubectl apply -f -
 
-.PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	cd config/overlays/make-deploy && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/overlays/make-deploy | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: argodeploy
-argodeploy: manifests kustomize
-	cd config/overlays/make-argodeploy \
-		&& $(KUSTOMIZE) edit set namespace ${ARGO_NS}
-	$(KUSTOMIZE) build config/overlays/make-argodeploy | kubectl apply -f -
-
-.PHONY: argoundeploy
-argoundeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	cd config/overlays/make-argodeploy \
-	    && $(KUSTOMIZE) edit set namespace ${ARGO_NS}
-	$(KUSTOMIZE) build config/overlays/make-argodeploy | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
 .PHONY: undeploy-kind
 undeploy-kind: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	cd config/overlays/kind-tests \
 		&& kustomize edit set namespace ${OPERATOR_NS}
 	kustomize build config/overlays/kind-tests | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: deployODH
-deployODH: manifests kustomize
-	cd config/overlays/make-deploy && $(KUSTOMIZE) edit set image controller=${IMG} && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/overlays/odh | kubectl apply -f -
-
-.PHONY: undeployODH
-undeployODH:
-	cd config/overlays/odh && $(KUSTOMIZE) edit set namespace ${OPERATOR_NS}
-	$(KUSTOMIZE) build config/overlays/odh | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
 
 ##@ Build Dependencies
 

--- a/README.md
+++ b/README.md
@@ -154,13 +154,7 @@ oc new-project ${ODH_NS}
 
 Now we will navigate to the DSPO manifests then build and deploy them to this namespace.
 
-If you wish to deploy Argo Workflows, run the following commands:
-```bash
-cd ${WORKING_DIR}
-make argodeploy OPERATOR_NS=${ODH_NS}
-```
-
-If not, build DSPO manifests directly:
+Run the following to deploy the ful DSPO v2 stack.
 ```bash
 cd ${WORKING_DIR}
 make deploy OPERATOR_NS=${ODH_NS}

--- a/config/overlays/make-argodeploy/kustomization.yaml
+++ b/config/overlays/make-argodeploy/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: opendatahub
-resources:
-- ../../argo

--- a/config/overlays/make-deploy/img_patch.yaml
+++ b/config/overlays/make-deploy/img_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-science-pipelines-operator-controller-manager
+  namespace: opendatahub
+spec:
+  template:
+    spec:
+      containers:
+        - image: controller
+          name: manager

--- a/config/overlays/make-deploy/kustomization.yaml
+++ b/config/overlays/make-deploy/kustomization.yaml
@@ -3,3 +3,10 @@ kind: Kustomization
 namespace: opendatahub
 resources:
 - ../../base
+- ../../argo
+patchesStrategicMerge:
+- img_patch.yaml
+images:
+- name: controller
+  newName: quay.io/opendatahub/data-science-pipelines-operator
+  newTag: main


### PR DESCRIPTION
## Description of your changes:

This pr fixes the broken `make deploy IMG=` option, and it also allows `make deploy` to deploy the full v2 stack, including argo, eliminating the need for `deployODH` and `argoDeploy` options.

## Testing instructions

run `make deploy`, and `make deploy IMG=<custom-image>`, and make sure they work as intended. 

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
