### PR TITLE
Added the additional permissions in the pipeline runner file for Ray

### DIFF
--- a/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
+++ b/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
@@ -132,3 +132,10 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -176,6 +176,13 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - networkpolicies
   verbs:
   - create

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -150,6 +150,7 @@ func (r *DSPAReconciler) buildCondition(conditionType string, dspa *dspav1alpha1
 //+kubebuilder:rbac:groups=datasciencepipelinesapplications.opendatahub.io,resources=datasciencepipelinesapplications/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list
 //+kubebuilder:rbac:groups=*,resources=deployments;services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets;configmaps;services;serviceaccounts;persistentvolumes;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=persistentvolumes;persistentvolumeclaims,verbs=*


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-880](https://issues.redhat.com/browse/RHOAIENG-880)

## Description of your changes:
Added the additional permissions which was missing and is required to create ray clusters. 
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
1. Create a Data Science project with namespace "pipelineskfptekton1"
2. Create a valid pipeline server
3. Import the pipeline mentioned below
4. Run the pipeline
5. It should work without any errors.

<details>
<summary>pipeline.yaml</summary>

```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: ray-integration-test
  annotations:
    tekton.dev/output_artifacts: '{"ray-fn": [{"key": "artifacts/$PIPELINERUN/ray-fn/Output.tgz",
      "name": "ray-fn-Output", "path": "/tmp/outputs/Output/data"}]}'
    tekton.dev/input_artifacts: '{}'
    tekton.dev/artifact_bucket: mlpipeline
    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
    tekton.dev/artifact_endpoint_scheme: http://
    tekton.dev/artifact_items: '{"ray-fn": [["Output", "$(results.Output.path)"]]}'
    sidecar.istio.io/inject: "false"
    tekton.dev/template: ''
    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
    pipelines.kubeflow.org/pipeline_spec: '{"description": "Ray Integration Test",
      "name": "Ray Integration Test"}'
  labels:
    pipelines.kubeflow.org/pipelinename: ''
    pipelines.kubeflow.org/generation: ''
spec:
  pipelineSpec:
    tasks:
    - name: ray-fn
      taskSpec:
        steps:
        - name: main
          args:
          - '----output-paths'
          - $(results.Output.path)
          command:
          - sh
          - -c
          - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
            'codeflare-sdk' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install
            --quiet --no-warn-script-location 'codeflare-sdk' --user) && "$0" "$@"
          - sh
          - -ec
          - |
            program_path=$(mktemp)
            printf "%s" "$0" > "$program_path"
            python3 -u "$program_path" "$@"
          - |
            def ray_fn():
                from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
                import ray

                cluster = Cluster(ClusterConfiguration(
                    name='raytest',
                    # namespace must exist, and it is the same from 432__data-science-pipelines-tekton.robot
                    namespace='pipelineskfptekton1',
                    num_workers=1,
                    head_cpus='500m',
                    min_memory=1,
                    max_memory=1,
                    num_gpus=0,
                    image="quay.io/project-codeflare/ray:latest-py39-cu118",
                    instascale=False,
                    ingress_domain='apps.upaptest-n-pool-ds2m8.rhods.ccitredhat.com'
                ))
                # workaround for https://github.com/project-codeflare/codeflare-sdk/pull/412
                cluster_file_name = '/opt/app-root/src/.codeflare/appwrapper/raytest.yaml'
                # Read in the file
                with open(cluster_file_name, 'r') as file:
                    filedata = file.read()

                # Replace the target string
                filedata = filedata.replace('busybox:1.28', 'quay.io/project-codeflare/busybox:latest')

                # Write the file out again
                with open(cluster_file_name, 'w') as file:
                    file.write(filedata)
                # end workaround

                # always clean the resources
                cluster.down()
                print(cluster.status())
                cluster.up()
                cluster.wait_ready()
                print(cluster.status())
                print(cluster.details())

                ray_dashboard_uri = cluster.cluster_dashboard_uri()
                ray_cluster_uri = cluster.cluster_uri()
                print(ray_dashboard_uri)
                print(ray_cluster_uri)

                # before proceeding make sure the cluster exists and the uri is not empty
                assert ray_cluster_uri, "Ray cluster needs to be started and set before proceeding"

                # reset the ray context in case there's already one.
                ray.shutdown()
                # establish connection to ray cluster
                ray.init(address=ray_cluster_uri)
                print("Ray cluster is up and running: ", ray.is_initialized())

                @ray.remote
                def train_fn():
                    return 100

                result = ray.get(train_fn.remote())
                assert 100 == result
                ray.shutdown()
                cluster.down()
                auth.logout()
                return result

            def _serialize_int(int_value: int) -> str:
                if isinstance(int_value, str):
                    return int_value
                if not isinstance(int_value, int):
                    raise TypeError('Value "{}" has type "{}" instead of int.'.format(
                        str(int_value), str(type(int_value))))
                return str(int_value)

            import argparse
            _parser = argparse.ArgumentParser(prog='Ray fn', description='')
            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
            _parsed_args = vars(_parser.parse_args())
            _output_files = _parsed_args.pop("_output_paths", [])

            _outputs = ray_fn(**_parsed_args)

            _outputs = [_outputs]

            _output_serializers = [
                _serialize_int,

            ]

            import os
            for idx, output_file in enumerate(_output_files):
                try:
                    os.makedirs(os.path.dirname(output_file))
                except OSError:
                    pass
                with open(output_file, 'w') as f:
                    f.write(_output_serializers[idx](_outputs[idx]))
          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
        results:
        - name: Output
          type: string
          description: /tmp/outputs/Output/data
        metadata:
          labels:
            pipelines.kubeflow.org/cache_enabled: "true"
          annotations:
            pipelines.kubeflow.org/component_spec_digest: '{"name": "Ray fn", "outputs":
              [{"name": "Output", "type": "Integer"}], "version": "Ray fn@sha256=e224348a70f708acdcee6dc324d56466087027edc04954a409c66a602978e1c7"}'
```
</details>

<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
