### PR TITLE
Disable samples by default

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -100,7 +100,7 @@ type APIServer struct {
 	// +kubebuilder:validation:Optional
 	EnableRoute bool `json:"enableOauth"`
 	// Include sample pipelines with the deployment of this DSP API Server. Default: true
-	// +kubebuilder:default:=true
+	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
 	EnableSamplePipeline bool `json:"enableSamplePipeline"`
 	// Default: true

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -104,7 +104,7 @@ spec:
                       Default: true'
                     type: boolean
                   enableSamplePipeline:
-                    default: true
+                    default: false
                     description: 'Include sample pipelines with the deployment of
                       this DSP API Server. Default: true'
                     type: boolean

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -162,6 +162,13 @@ spec:
           image: {{.APIServer.Image}}
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
+            {{ if .APIServer.EnableSamplePipeline }}
+            - --sampleconfig=/config/sample_config.json
+            {{ end }}
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_0/deploy/cr.yaml
+++ b/controllers/testdata/declarative/case_0/deploy/cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: testdsp0
 spec:
   apiServer:
+    enableSamplePipeline: true
     argoLauncherImage: argolauncherimage:test0
     argoDriverImage: argodriverimage:test0
   objectStorage:

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -113,6 +113,11 @@ spec:
           image: api-server:test0
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
+            - --sampleconfig=/config/sample_config.json
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -113,6 +113,11 @@ spec:
           image: api-server:test2
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
+            - --sampleconfig=/config/sample_config.json
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -113,6 +113,10 @@ spec:
           image: api-server:test3
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -113,6 +113,10 @@ spec:
           image: this-apiserver-image-from-cr-should-be-used:test4
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -117,6 +117,10 @@ spec:
           image: api-server:test5
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
           ports:
             - containerPort: 8888
               name: http
@@ -155,15 +159,6 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
-          volumeMounts:
-            - name: server-config
-              mountPath: /config/config.json
-              subPath: config.json
-            - mountPath: /config/sample_config.json
-              name: sample-config
-              subPath: sample_config.json
-            - mountPath: /samples/
-              name: sample-pipeline
         - name: oauth-proxy
           args:
             - --https-address=:8443
@@ -220,13 +215,4 @@ spec:
             defaultMode: 420
             name: pipeline-server-config-testdsp5
           name: server-config
-        - configMap:
-            defaultMode: 420
-            name: sample-config-testdsp5
-          name: sample-config
-        - configMap:
-            defaultMode: 420
-            name: sample-pipeline-testdsp5
-          name: sample-pipeline
-
       serviceAccountName: ds-pipeline-testdsp5

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -111,6 +111,10 @@ spec:
           image: api-server:test6
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
@@ -103,6 +103,11 @@ spec:
           image: api-server:test7
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
+            - --sampleconfig=/config/sample_config.json
           ports:
             - containerPort: 8888
               name: http

--- a/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
@@ -111,6 +111,10 @@ spec:
           image: api-server:test8
           imagePullPolicy: Always
           name: ds-pipeline-api-server
+          command: ['/bin/apiserver']
+          args:
+            - --config=/config
+            - -logtostderr=true
           ports:
             - containerPort: 8888
               name: http


### PR DESCRIPTION
Resolve: https://issues.redhat.com/browse/RHOAIENG-4382

Merge after this is merged: https://github.com/opendatahub-io/data-science-pipelines/pull/23

# Description 

enableSamplePipeline should be off by default, and users should opt in to use it 


# Testing instructions 

* Deploy DSPO with changes 
* deploy DSPA without `spec.apiServer.enableSamplePipeline` set and ensure no pipeline shows up: 

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest

```

* then deploy another dspa with enable `spec.apiServer.enableSamplePipeline=true`, and ensure a default pipeline (iris) shows up. 