### PR TITLE
chore: use pipelines default pipeline store path

### DIFF
--- a/config/internal/apiserver/default/server-config.yaml.tmpl
+++ b/config/internal/apiserver/default/server-config.yaml.tmpl
@@ -1,33 +1,41 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: pipeline-server-config-{{.Name}}
-    namespace: {{.Namespace}}
-    labels:
-        app: {{.APIServerDefaultResourceName}}
-        component: data-science-pipelines
+  name: pipeline-server-config-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: {{.APIServerDefaultResourceName}}
+    component: data-science-pipelines
 data:
-    config.json: |
+  config.json: |
 {{ if eq .DSPVersion "v2" }}
-      {
-        "DBConfig": {
-          "MySQLConfig": {
-            "ExtraParams": {{ .DBConnection.ExtraParams }},
-            "GroupConcatMaxLen": "4194304"
-           },
-          "PostgreSQLConfig": {},
-          "ConMaxLifeTime": "120s"
-        },
-        "DBDriverName": "mysql",
-        "InitConnectionTimeout": "6m"
-      }
+    {
+      "DBConfig": {
+        "MySQLConfig": {
+          "ExtraParams": {{ .DBConnection.ExtraParams }},
+          "GroupConcatMaxLen": "4194304"
+         },
+        "PostgreSQLConfig": {},
+        "ConMaxLifeTime": "120s"
+      },
+      "ObjectStoreConfig": {
+        "PipelinePath": "pipelines"
+      },
+      "DBDriverName": "mysql",
+      "ARCHIVE_CONFIG_LOG_FILE_NAME": "main.log",
+      "ARCHIVE_CONFIG_LOG_PATH_PREFIX": "/artifacts",
+      "InitConnectionTimeout": "6m"
+    }
 {{ else }}
-      {
-        "DBConfig": {
-          "DriverName": "mysql",
-          "ConMaxLifeTime": "120s",
-          "ExtraParams": {{ .DBConnection.ExtraParams }}
-        },
-        "InitConnectionTimeout": "6m"
-      }
+    {
+      "DBConfig": {
+        "DriverName": "mysql",
+        "ConMaxLifeTime": "120s",
+        "ExtraParams": {{ .DBConnection.ExtraParams }}
+      },
+      "ObjectStoreConfig": {
+        "PipelinePath": "pipelines"
+      },
+      "InitConnectionTimeout": "6m"
+    }
 {{ end }}

--- a/controllers/testdata/declarative/case_0/expected/created/configmap_server_config.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/configmap_server_config.yaml
@@ -15,5 +15,8 @@ data:
           "ConMaxLifeTime": "120s",
           "ExtraParams": {"tls":"false"}
         },
+        "ObjectStoreConfig": {
+          "PipelinePath": "pipelines"
+        },
         "InitConnectionTimeout": "6m"
       }

--- a/controllers/testdata/declarative/case_6/expected/created/configmap_server_config.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/configmap_server_config.yaml
@@ -18,6 +18,11 @@ data:
         "PostgreSQLConfig": {},
         "ConMaxLifeTime": "120s"
       },
+      "ObjectStoreConfig": {
+        "PipelinePath": "pipelines"
+      },
       "DBDriverName": "mysql",
+      "ARCHIVE_CONFIG_LOG_FILE_NAME": "main.log",
+      "ARCHIVE_CONFIG_LOG_PATH_PREFIX": "/artifacts",
       "InitConnectionTimeout": "6m"
     }


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHOAIENG-4509
for v2

## Description of your changes:
Use the defaults provided via kfp for pipelines store path, also use the same log archive defaults.

For the pipelines, this setting ensure pipelines in obj store are organized under the `pipelines` folder in obj store, instead of the root (which would get messy). 

## Testing instructions

Confirm for both v1 and v2. 

1. Deploy a v1 dspa, upload a pipeline, confirm this pipeline is stored in the `/pipelines` folder in the object store
  2.  you can do this by using the default minio, creating a route to minio, logging in (creds are in secrets) to the ui
3. Do the same for v2 (in a new namespace, or clean up the existing one)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
