### PR TITLE
Parameterize CABundle mountpath in dspa

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -133,6 +133,14 @@ type APIServer struct {
 	// +kubebuilder:default:=true
 	// +kubebuilder:validation:Optional
 	AutoUpdatePipelineDefaultVersion bool `json:"autoUpdatePipelineDefaultVersion"`
+	// This is the path where the ca bundle will be mounted in the
+	// pipeline server and user executor pods
+	// +kubebuilder:validation:Optional
+	CABundleFileMountPath string `json:"caBundleFileMountPath"`
+	// This is the filename of the ca bundle that will be created in the
+	// pipeline server and user executor pods
+	// +kubebuilder:validation:Optional
+	CABundleFileName string `json:"caBundleFileName"`
 }
 
 type CABundle struct {

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -89,6 +89,14 @@ spec:
                     - configMapKey
                     - configMapName
                     type: object
+                  caBundleFileMountPath:
+                    description: This is the path where the ca bundle will be mounted
+                      in the pipeline server and user executor pods
+                    type: string
+                  caBundleFileName:
+                    description: This is the folder where the ca bundle will be created
+                      in the pipeline server and user executor pods
+                    type: string
                   cacheImage:
                     description: 'Deprecated: DSP V1 only, will be removed in the
                       future.'

--- a/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
+++ b/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
@@ -22,6 +22,8 @@ spec:
       limits:
         cpu: 500m
         memory: 1Gi
+    CABundleFileMountPath: /your/certbundle/path.crt
+    CABundleFileName: certbundlefilename.crt
     # requires this configmap to be created beforehand,
     cABundle:
       configMapKey: keyname

--- a/controllers/testdata/declarative/case_6/deploy/03_cr.yaml
+++ b/controllers/testdata/declarative/case_6/deploy/03_cr.yaml
@@ -3,6 +3,8 @@
 # When a user provides a cABundle in the DSPA, it is also included in the concatenated dsp custom ca cert configmap
 # When external db is used the server config created for api server uses tls=true
 # MLMD grpc server mounts the dspa cert and passes it into grpc server
+# When a user provides a caBundleFileMountPath, it will be used to mount the ca bundle
+# When a user provides ca bundle configmapkey, it will be used instead of default one
 apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
 kind: DataSciencePipelinesApplication
 metadata:
@@ -12,6 +14,8 @@ spec:
   apiServer:
     deploy: true
     enableSamplePipeline: false
+    caBundleFileMountPath: /dspa/custom-certs
+    caBundleFileName: user-ca-bundle.crt
     cABundle:
       configMapKey: user-ca-bundle.crt
       configMapName: user-ca-bundle

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -40,11 +40,11 @@ spec:
             - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_NAME
               value: dsp-trusted-ca-testdsp6
             - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_KEY
-              value: dsp-ca.crt
+              value: user-ca-bundle.crt
             - name: ARTIFACT_COPY_STEP_CABUNDLE_MOUNTPATH
-              value: /dsp-custom-certs
+              value: /dspa/custom-certs
             - name: SSL_CERT_DIR
-              value: "/dsp-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs"
+              value: "/dspa/custom-certs:/etc/ssl/certs:/etc/pki/tls/certs"
             - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
               value: "true"
             - name: DBCONFIG_CONMAXLIFETIMESEC
@@ -158,7 +158,7 @@ spec:
               mountPath: /config/config.json
               subPath: config.json
             - name: ca-bundle
-              mountPath: /dsp-custom-certs
+              mountPath: /dspa/custom-certs
         - name: oauth-proxy
           args:
             - --https-address=:8443

--- a/controllers/testdata/declarative/case_6/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/configmap_artifact_script.yaml
@@ -9,7 +9,7 @@ data:
 
         aws_cp() {
 
-          aws s3 --endpoint http://minio-testdsp6.default.svc.cluster.local:9000 --ca-bundle /dsp-custom-certs/dsp-ca.crt cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+          aws s3 --endpoint http://minio-testdsp6.default.svc.cluster.local:9000 --ca-bundle /dspa/custom-certs/user-ca-bundle.crt cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
 
         }
 

--- a/controllers/testdata/declarative/case_6/expected/created/configmap_dspa_trusted_ca.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/configmap_dspa_trusted_ca.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: dsp-trusted-ca-testdsp6
 data:
-  dsp-ca.crt: |
+  user-ca-bundle.crt: |
     -----BEGIN CERTIFICATE-----
     MIIFLTCCAxWgAwIBAgIUIvY4jV0212P/ddjuCZhcUyJfoocwDQYJKoZIhvcNAQEL
     BQAwJjELMAkGA1UEBhMCWFgxFzAVBgNVBAMMDnJoLWRzcC1kZXZzLmlvMB4XDTI0

--- a/controllers/testdata/declarative/case_6/expected/created/metadata_grpc_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/metadata_grpc_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - --mysql_config_user=$(DBCONFIG_USER)
             - --mysql_config_password=$(DBCONFIG_PASSWORD)
             - --enable_database_upgrade=true
-            - --mysql_config_sslrootcert=/dsp-custom-certs/dsp-ca.crt
+            - --mysql_config_sslrootcert=/dspa/custom-certs/user-ca-bundle.crt
           command:
             - /bin/metadata_store_server
           env:
@@ -73,7 +73,7 @@ spec:
               cpu: 100m
               memory: 256Mi
           volumeMounts:
-            - mountPath: /dsp-custom-certs
+            - mountPath: /dspa/custom-certs
               name: ca-bundle
       serviceAccountName: ds-pipeline-metadata-grpc-testdsp6
       volumes:

--- a/controllers/testdata/declarative/case_8/deploy/02_cr.yaml
+++ b/controllers/testdata/declarative/case_8/deploy/02_cr.yaml
@@ -15,6 +15,7 @@ spec:
   apiServer:
     deploy: true
     enableSamplePipeline: false
+    caBundleFileName: testcabundleconfigmapkey8.crt
     cABundle:
       configMapName: testcabundleconfigmap8
       configMapKey: testcabundleconfigmapkey8.crt

--- a/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_NAME
               value: dsp-trusted-ca-testdsp8
             - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_KEY
-              value: dsp-ca.crt
+              value: testcabundleconfigmapkey8.crt
             - name: ARTIFACT_COPY_STEP_CABUNDLE_MOUNTPATH
               value: /dsp-custom-certs
             - name: SSL_CERT_DIR

--- a/controllers/testdata/declarative/case_8/expected/created/configmap_artifact_script.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/configmap_artifact_script.yaml
@@ -9,7 +9,7 @@ data:
 
         aws_cp() {
 
-          aws s3 --endpoint http://minio-testdsp8.default.svc.cluster.local:9000 --ca-bundle /dsp-custom-certs/dsp-ca.crt cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+          aws s3 --endpoint http://minio-testdsp8.default.svc.cluster.local:9000 --ca-bundle /dsp-custom-certs/testcabundleconfigmapkey8.crt cp $1.tgz s3://mlpipeline/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
 
         }
 

--- a/controllers/testdata/declarative/case_8/expected/created/configmap_dspa_trusted_ca.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/configmap_dspa_trusted_ca.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: dsp-trusted-ca-testdsp8
 data:
-  dsp-ca.crt: |-
+  testcabundleconfigmapkey8.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIFLTCCAxWgAwIBAgIUIvY4jV0212P/ddjuCZhcUyJfoocwDQYJKoZIhvcNAQEL
     BQAwJjELMAkGA1UEBhMCWFgxFzAVBgNVBAMMDnJoLWRzcC1kZXZzLmlvMB4XDTI0


### PR DESCRIPTION
## The issue resolved by this Pull Request:

Resolves [RHOAIENG-3780](https://issues.redhat.com/browse/RHOAIENG-3780)

## Description of your changes:

- Added new parameter for caBundleFileMountPath which can be set by users in dspa. 
- Overrides the values of default values of CustomCABundleRootMountPath and customDSPTrustedCAConfigMapKey, if the values are provided in dspa.

## Testing instructions
Deploy a self-signed  cert minio and provide these configs to the DSPA as external storage connection.
Deploy dspa using the below yaml file (with your updated details for minio).Create a pipeline run and verify the mount paths in kfp-launcher pod and pipeline server to see the ca-bundle mountpath that we provided in the dspa.
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    deploy: true
    enableSamplePipeline: true
    caBundleFileMountPath: /dspa/custom-certs
caBundleFileName: ca.crt
    cABundle:
      configMapName: kube-root-ca.crt
      configMapKey: ca.crt      
  objectStorage:
    externalStorage:
      bucket: mlpipeline
      host: minio-secure-test-minio.apps.vmudadla.dev.datahub.redhat.com
      region: us-east-2
      s3CredentialsSecret:
        accessKey: accesskey
        secretKey: secretkey
        secretName: minio
      scheme: https
  # Optional
  mlpipelineUI:
    # Image field is required
    image: gcr.io/ml-pipeline/frontend:2.0.2

```
## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
