### PR TITLE
fix: fail templating gracefully

### DIFF
--- a/controllers/config/manifest.go
+++ b/controllers/config/manifest.go
@@ -23,7 +23,12 @@ import (
 )
 
 func Manifest(cl client.Client, templatePath string, context interface{}) (mf.Manifest, error) {
-	m, err := mf.ManifestFrom(PathTemplateSource(templatePath, context))
+	pathTmplSrc, err := PathTemplateSource(templatePath, context)
+	if err != nil {
+		return mf.Manifest{}, err
+	}
+
+	m, err := mf.ManifestFrom(pathTmplSrc)
 	if err != nil {
 		return mf.Manifest{}, err
 	}


### PR DESCRIPTION
Currently we panic and crash the operator if templating fails, this is not ideal., the controller should be resilient to errors and forward them up the call stack and log them. 