### PR TITLE
Simplify sample pipeline input parameters

### DIFF
--- a/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
@@ -12,11 +12,8 @@ data:
       # PIPELINE DEFINITION
       # Name: iris-training-pipeline
       # Inputs:
-      #    min_max_scaler: bool
-      #    neighbors: int
-      #    standard_scaler: bool
-      # Outputs:
-      #    train-model-metrics: system.ClassificationMetrics
+      #    neighbors: int [Default: 3.0]
+      #    standard_scaler: bool [Default: True]
       components:
         comp-create-dataset:
           executorLabel: exec-create-dataset
@@ -35,8 +32,6 @@ data:
                   schemaTitle: system.Dataset
                   schemaVersion: 0.0.1
             parameters:
-              min_max_scaler:
-                parameterType: BOOLEAN
               standard_scaler:
                 parameterType: BOOLEAN
           outputDefinitions:
@@ -58,10 +53,6 @@ data:
                 parameterType: NUMBER_INTEGER
           outputDefinitions:
             artifacts:
-              metrics:
-                artifactType:
-                  schemaTitle: system.ClassificationMetrics
-                  schemaVersion: 0.0.1
               model:
                 artifactType:
                   schemaTitle: system.Model
@@ -72,7 +63,7 @@ data:
             container:
               args:
               - --executor_input
-              - '{{"{{"}}${{"}}"}}'
+              - '{{$}}'
               - --function_to_execute
               - create_dataset
               command:
@@ -80,15 +71,18 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
                 \ && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
@@ -97,12 +91,12 @@ data:
                 \    col_names = [\n        'Sepal_Length', 'Sepal_Width', 'Petal_Length',\
                 \ 'Petal_Width', 'Labels'\n    ]\n    df = pd.read_csv(csv_url, names=col_names)\n\
                 \n    with open(iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
           exec-normalize-dataset:
             container:
               args:
               - --executor_input
-              - '{{"{{"}}${{"}}"}}'
+              - '{{$}}'
               - --function_to_execute
               - normalize_dataset
               command:
@@ -110,37 +104,36 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
-                \ && \"$0\" \"$@\"\n"
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
+                \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
                 \ *\n\ndef normalize_dataset(\n    input_iris_dataset: Input[Dataset],\n\
                 \    normalized_iris_dataset: Output[Dataset],\n    standard_scaler: bool,\n\
-                \    min_max_scaler: bool,\n):\n    if standard_scaler is min_max_scaler:\n\
-                \        raise ValueError(\n            'Exactly one of standard_scaler\
-                \ or min_max_scaler must be True.')\n\n    import pandas as pd\n    from\
-                \ sklearn.preprocessing import MinMaxScaler\n    from sklearn.preprocessing\
-                \ import StandardScaler\n\n    with open(input_iris_dataset.path) as f:\n\
-                \        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n    if standard_scaler:\n\
-                \        scaler = StandardScaler()\n    if min_max_scaler:\n        scaler\
-                \ = MinMaxScaler()\n\n    df = pd.DataFrame(scaler.fit_transform(df))\n\
-                \    df['Labels'] = labels\n    normalized_iris_dataset.metadata['state']\
-                \ = \"Normalized\"\n    with open(normalized_iris_dataset.path, 'w') as\
-                \ f:\n        df.to_csv(f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+                ):\n\n    import pandas as pd\n    from sklearn.preprocessing import MinMaxScaler\n\
+                \    from sklearn.preprocessing import StandardScaler\n\n    with open(input_iris_dataset.path)\
+                \ as f:\n        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n\
+                \    scaler = StandardScaler() if standard_scaler else MinMaxScaler()\n\n\
+                \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
+                \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
+                \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
           exec-train-model:
             container:
               args:
               - --executor_input
-              - '{{"{{"}}${{"}}"}}'
+              - '{{$}}'
               - --function_to_execute
               - train_model
               command:
@@ -148,45 +141,35 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
-                \ && \"$0\" \"$@\"\n"
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
+                \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
                 \ *\n\ndef train_model(\n    normalized_iris_dataset: Input[Dataset],\n\
-                \    model: Output[Model],\n    metrics: Output[ClassificationMetrics],\n\
-                \    n_neighbors: int,\n):\n    import pickle\n\n    import pandas as pd\n\
-                \    from sklearn.neighbors import KNeighborsClassifier\n\n    from sklearn.metrics\
-                \ import roc_curve\n    from sklearn.model_selection import train_test_split,\
-                \ cross_val_predict\n    from sklearn.metrics import confusion_matrix\n\n\
-                \n    with open(normalized_iris_dataset.path) as f:\n        df = pd.read_csv(f)\n\
-                \n    y = df.pop('Labels')\n    X = df\n\n    X_train, X_test, y_train,\
-                \ y_test = train_test_split(X, y, random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
-                \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(\n\
-                \        clf, X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n\
-                \        ['Iris-Setosa', 'Iris-Versicolour', 'Iris-Virginica'],\n      \
-                \  confusion_matrix(\n            y_train,\n            predictions).tolist()\
-                \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
-                \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
-                \ f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+                \    model: Output[Model],\n    n_neighbors: int,\n):\n    import pickle\n\
+                \n    import pandas as pd\n    from sklearn.model_selection import train_test_split\n\
+                \    from sklearn.neighbors import KNeighborsClassifier\n\n    with open(normalized_iris_dataset.path)\
+                \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop('Labels')\n    X\
+                \ = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
+                \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
+                \    clf.fit(X_train, y_train)\n\n    model.metadata['framework'] = 'scikit-learn'\n\
+                \    with open(model.path, 'wb') as f:\n        pickle.dump(clf, f)\n\n"
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
       pipelineInfo:
         name: iris-training-pipeline
       root:
         dag:
-          outputs:
-            artifacts:
-              train-model-metrics:
-                artifactSelectors:
-                - outputArtifactKey: metrics
-                  producerSubtask: train-model
           tasks:
             create-dataset:
               cachingOptions:
@@ -209,9 +192,6 @@ data:
                       outputArtifactKey: iris_dataset
                       producerTask: create-dataset
                 parameters:
-                  min_max_scaler:
-                    runtimeValue:
-                      constant: false
                   standard_scaler:
                     runtimeValue:
                       constant: true
@@ -237,23 +217,16 @@ data:
                 name: train-model
         inputDefinitions:
           parameters:
-            min_max_scaler:
-              defaultValue: true
-              parameterType: BOOLEAN
             neighbors:
-              defaultValue: 3
+              defaultValue: 3.0
+              isOptional: true
               parameterType: NUMBER_INTEGER
             standard_scaler:
-              defaultValue: false
+              defaultValue: true
+              isOptional: true
               parameterType: BOOLEAN
-        outputDefinitions:
-          artifacts:
-            train-model-metrics:
-              artifactType:
-                schemaTitle: system.ClassificationMetrics
-                schemaVersion: 0.0.1
       schemaVersion: 2.1.0
-      sdkVersion: kfp-2.0.1
+      sdkVersion: kfp-2.7.0
 {{ else }}
 apiVersion: v1
 kind: ConfigMap

--- a/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
@@ -14,6 +14,8 @@ data:
       # Inputs:
       #    neighbors: int [Default: 3.0]
       #    standard_scaler: bool [Default: True]
+      # Outputs:
+      #    train-model-metrics: system.ClassificationMetrics
       components:
         comp-create-dataset:
           executorLabel: exec-create-dataset
@@ -53,6 +55,10 @@ data:
                 parameterType: NUMBER_INTEGER
           outputDefinitions:
             artifacts:
+              metrics:
+                artifactType:
+                  schemaTitle: system.ClassificationMetrics
+                  schemaVersion: 0.0.1
               model:
                 artifactType:
                   schemaTitle: system.Model
@@ -63,7 +69,7 @@ data:
             container:
               args:
               - --executor_input
-              - '{{$}}'
+              - '{{"{{"}}${{"}}"}}'
               - --function_to_execute
               - create_dataset
               command:
@@ -96,7 +102,7 @@ data:
             container:
               args:
               - --executor_input
-              - '{{$}}'
+              - '{{"{{"}}${{"}}"}}'
               - --function_to_execute
               - normalize_dataset
               command:
@@ -133,7 +139,7 @@ data:
             container:
               args:
               - --executor_input
-              - '{{$}}'
+              - '{{"{{"}}${{"}}"}}'
               - --function_to_execute
               - train_model
               command:
@@ -157,19 +163,33 @@ data:
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
                 \ *\n\ndef train_model(\n    normalized_iris_dataset: Input[Dataset],\n\
-                \    model: Output[Model],\n    n_neighbors: int,\n):\n    import pickle\n\
-                \n    import pandas as pd\n    from sklearn.model_selection import train_test_split\n\
-                \    from sklearn.neighbors import KNeighborsClassifier\n\n    with open(normalized_iris_dataset.path)\
+                \    model: Output[Model],\n    metrics: Output[ClassificationMetrics],\n\
+                \    n_neighbors: int,\n):\n    import pickle\n\n    import pandas as pd\n\
+                \    from sklearn.model_selection import train_test_split\n    from sklearn.neighbors\
+                \ import KNeighborsClassifier\n\n    from sklearn.metrics import roc_curve\n\
+                \    from sklearn.model_selection import train_test_split, cross_val_predict\n\
+                \    from sklearn.metrics import confusion_matrix\n\n\n    with open(normalized_iris_dataset.path)\
                 \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop('Labels')\n    X\
                 \ = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
                 \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
-                \    clf.fit(X_train, y_train)\n\n    model.metadata['framework'] = 'scikit-learn'\n\
-                \    with open(model.path, 'wb') as f:\n        pickle.dump(clf, f)\n\n"
+                \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(\n\
+                \        clf, X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n\
+                \        ['Iris-Setosa', 'Iris-Versicolour', 'Iris-Virginica'],\n      \
+                \  confusion_matrix(\n            y_train,\n            predictions).tolist()\
+                \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
+                \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
+                \ f)\n\n"
               image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
       pipelineInfo:
         name: iris-training-pipeline
       root:
         dag:
+          outputs:
+            artifacts:
+              train-model-metrics:
+                artifactSelectors:
+                - outputArtifactKey: metrics
+                  producerSubtask: train-model
           tasks:
             create-dataset:
               cachingOptions:
@@ -225,6 +245,12 @@ data:
               defaultValue: true
               isOptional: true
               parameterType: BOOLEAN
+        outputDefinitions:
+          artifacts:
+            train-model-metrics:
+              artifactType:
+                schemaTitle: system.ClassificationMetrics
+                schemaVersion: 0.0.1
       schemaVersion: 2.1.0
       sdkVersion: kfp-2.7.0
 {{ else }}

--- a/controllers/testdata/declarative/case_7/expected/created/sample-pipeline.yaml.tmpl
+++ b/controllers/testdata/declarative/case_7/expected/created/sample-pipeline.yaml.tmpl
@@ -11,9 +11,8 @@ data:
       # PIPELINE DEFINITION
       # Name: iris-training-pipeline
       # Inputs:
-      #    min_max_scaler: bool
-      #    neighbors: int
-      #    standard_scaler: bool
+      #    neighbors: int [Default: 3.0]
+      #    standard_scaler: bool [Default: True]
       # Outputs:
       #    train-model-metrics: system.ClassificationMetrics
       components:
@@ -34,8 +33,6 @@ data:
                   schemaTitle: system.Dataset
                   schemaVersion: 0.0.1
             parameters:
-              min_max_scaler:
-                parameterType: BOOLEAN
               standard_scaler:
                 parameterType: BOOLEAN
           outputDefinitions:
@@ -79,15 +76,18 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
                 \ && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
@@ -96,7 +96,7 @@ data:
                 \    col_names = [\n        'Sepal_Length', 'Sepal_Width', 'Petal_Length',\
                 \ 'Petal_Width', 'Labels'\n    ]\n    df = pd.read_csv(csv_url, names=col_names)\n\
                 \n    with open(iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
           exec-normalize-dataset:
             container:
               args:
@@ -109,32 +109,31 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
-                \ && \"$0\" \"$@\"\n"
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
+                \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
                 \ *\n\ndef normalize_dataset(\n    input_iris_dataset: Input[Dataset],\n\
                 \    normalized_iris_dataset: Output[Dataset],\n    standard_scaler: bool,\n\
-                \    min_max_scaler: bool,\n):\n    if standard_scaler is min_max_scaler:\n\
-                \        raise ValueError(\n            'Exactly one of standard_scaler\
-                \ or min_max_scaler must be True.')\n\n    import pandas as pd\n    from\
-                \ sklearn.preprocessing import MinMaxScaler\n    from sklearn.preprocessing\
-                \ import StandardScaler\n\n    with open(input_iris_dataset.path) as f:\n\
-                \        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n    if standard_scaler:\n\
-                \        scaler = StandardScaler()\n    if min_max_scaler:\n        scaler\
-                \ = MinMaxScaler()\n\n    df = pd.DataFrame(scaler.fit_transform(df))\n\
-                \    df['Labels'] = labels\n    normalized_iris_dataset.metadata['state']\
-                \ = \"Normalized\"\n    with open(normalized_iris_dataset.path, 'w') as\
-                \ f:\n        df.to_csv(f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+                ):\n\n    import pandas as pd\n    from sklearn.preprocessing import MinMaxScaler\n\
+                \    from sklearn.preprocessing import StandardScaler\n\n    with open(input_iris_dataset.path)\
+                \ as f:\n        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n\
+                \    scaler = StandardScaler() if standard_scaler else MinMaxScaler()\n\n\
+                \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
+                \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
+                \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
           exec-train-model:
             container:
               args:
@@ -147,27 +146,31 @@ data:
               - -c
               - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
                 \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-                \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.1'\
-                \ && \"$0\" \"$@\"\n"
+                \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+                \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+                \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
+                \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
               - sh
               - -ec
               - 'program_path=$(mktemp -d)
 
+
                 printf "%s" "$0" > "$program_path/ephemeral_component.py"
 
-                python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+                _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
 
                 '
               - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
                 \ *\n\ndef train_model(\n    normalized_iris_dataset: Input[Dataset],\n\
                 \    model: Output[Model],\n    metrics: Output[ClassificationMetrics],\n\
                 \    n_neighbors: int,\n):\n    import pickle\n\n    import pandas as pd\n\
-                \    from sklearn.neighbors import KNeighborsClassifier\n\n    from sklearn.metrics\
-                \ import roc_curve\n    from sklearn.model_selection import train_test_split,\
-                \ cross_val_predict\n    from sklearn.metrics import confusion_matrix\n\n\
-                \n    with open(normalized_iris_dataset.path) as f:\n        df = pd.read_csv(f)\n\
-                \n    y = df.pop('Labels')\n    X = df\n\n    X_train, X_test, y_train,\
-                \ y_test = train_test_split(X, y, random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
+                \    from sklearn.model_selection import train_test_split\n    from sklearn.neighbors\
+                \ import KNeighborsClassifier\n\n    from sklearn.metrics import roc_curve\n\
+                \    from sklearn.model_selection import train_test_split, cross_val_predict\n\
+                \    from sklearn.metrics import confusion_matrix\n\n\n    with open(normalized_iris_dataset.path)\
+                \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop('Labels')\n    X\
+                \ = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
+                \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
                 \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(\n\
                 \        clf, X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n\
                 \        ['Iris-Setosa', 'Iris-Versicolour', 'Iris-Virginica'],\n      \
@@ -175,7 +178,7 @@ data:
                 \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
                 \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
                 \ f)\n\n"
-              image: quay.io/hukhan/iris-base:1
+              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
       pipelineInfo:
         name: iris-training-pipeline
       root:
@@ -208,9 +211,6 @@ data:
                       outputArtifactKey: iris_dataset
                       producerTask: create-dataset
                 parameters:
-                  min_max_scaler:
-                    runtimeValue:
-                      constant: false
                   standard_scaler:
                     runtimeValue:
                       constant: true
@@ -236,14 +236,13 @@ data:
                 name: train-model
         inputDefinitions:
           parameters:
-            min_max_scaler:
-              defaultValue: true
-              parameterType: BOOLEAN
             neighbors:
-              defaultValue: 3
+              defaultValue: 3.0
+              isOptional: true
               parameterType: NUMBER_INTEGER
             standard_scaler:
-              defaultValue: false
+              defaultValue: true
+              isOptional: true
               parameterType: BOOLEAN
         outputDefinitions:
           artifacts:
@@ -252,4 +251,4 @@ data:
                 schemaTitle: system.ClassificationMetrics
                 schemaVersion: 0.0.1
       schemaVersion: 2.1.0
-      sdkVersion: kfp-2.0.1
+      sdkVersion: kfp-2.7.0

--- a/docs/example_pipelines/iris/iris-pipeline.py
+++ b/docs/example_pipelines/iris/iris-pipeline.py
@@ -33,11 +33,7 @@ def normalize_dataset(
     input_iris_dataset: Input[Dataset],
     normalized_iris_dataset: Output[Dataset],
     standard_scaler: bool,
-    min_max_scaler: bool,
 ):
-    if standard_scaler is min_max_scaler:
-        raise ValueError(
-            'Exactly one of standard_scaler or min_max_scaler must be True.')
 
     import pandas as pd
     from sklearn.preprocessing import MinMaxScaler
@@ -47,10 +43,7 @@ def normalize_dataset(
         df = pd.read_csv(f)
     labels = df.pop('Labels')
 
-    if standard_scaler:
-        scaler = StandardScaler()
-    if min_max_scaler:
-        scaler = MinMaxScaler()
+    scaler = StandardScaler() if standard_scaler else MinMaxScaler()
 
     df = pd.DataFrame(scaler.fit_transform(df))
     df['Labels'] = labels
@@ -92,16 +85,14 @@ def train_model(
 
 @dsl.pipeline(name='iris-training-pipeline')
 def my_pipeline(
-    standard_scaler: bool,
-    min_max_scaler: bool,
-    neighbors: int,
+    standard_scaler: bool = True,
+    neighbors: int = 3
 ):
     create_dataset_task = create_dataset()
 
     normalize_dataset_task = normalize_dataset(
         input_iris_dataset=create_dataset_task.outputs['iris_dataset'],
-        standard_scaler=True,
-        min_max_scaler=False)
+        standard_scaler=True)
 
     train_model(
         normalized_iris_dataset=normalize_dataset_task

--- a/docs/example_pipelines/iris/iris-pipeline.yaml
+++ b/docs/example_pipelines/iris/iris-pipeline.yaml
@@ -1,9 +1,8 @@
 # PIPELINE DEFINITION
 # Name: iris-training-pipeline
 # Inputs:
-#    min_max_scaler: bool
-#    neighbors: int
-#    standard_scaler: bool
+#    neighbors: int [Default: 3.0]
+#    standard_scaler: bool [Default: True]
 components:
   comp-create-dataset:
     executorLabel: exec-create-dataset
@@ -22,8 +21,6 @@ components:
             schemaTitle: system.Dataset
             schemaVersion: 0.0.1
       parameters:
-        min_max_scaler:
-          parameterType: BOOLEAN
         standard_scaler:
           parameterType: BOOLEAN
     outputDefinitions:
@@ -113,17 +110,13 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef normalize_dataset(\n    input_iris_dataset: Input[Dataset],\n\
           \    normalized_iris_dataset: Output[Dataset],\n    standard_scaler: bool,\n\
-          \    min_max_scaler: bool,\n):\n    if standard_scaler is min_max_scaler:\n\
-          \        raise ValueError(\n            'Exactly one of standard_scaler\
-          \ or min_max_scaler must be True.')\n\n    import pandas as pd\n    from\
-          \ sklearn.preprocessing import MinMaxScaler\n    from sklearn.preprocessing\
-          \ import StandardScaler\n\n    with open(input_iris_dataset.path) as f:\n\
-          \        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n    if standard_scaler:\n\
-          \        scaler = StandardScaler()\n    if min_max_scaler:\n        scaler\
-          \ = MinMaxScaler()\n\n    df = pd.DataFrame(scaler.fit_transform(df))\n\
-          \    df['Labels'] = labels\n    normalized_iris_dataset.metadata['state']\
-          \ = \"Normalized\"\n    with open(normalized_iris_dataset.path, 'w') as\
-          \ f:\n        df.to_csv(f)\n\n"
+          ):\n\n    import pandas as pd\n    from sklearn.preprocessing import MinMaxScaler\n\
+          \    from sklearn.preprocessing import StandardScaler\n\n    with open(input_iris_dataset.path)\
+          \ as f:\n        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n\
+          \    scaler = StandardScaler() if standard_scaler else MinMaxScaler()\n\n\
+          \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
+          \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
+          \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
         image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
     exec-train-model:
       container:
@@ -161,7 +154,6 @@ deploymentSpec:
           \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
           \    clf.fit(X_train, y_train)\n\n    model.metadata['framework'] = 'scikit-learn'\n\
           \    with open(model.path, 'wb') as f:\n        pickle.dump(clf, f)\n\n"
-
         image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
 pipelineInfo:
   name: iris-training-pipeline
@@ -189,9 +181,6 @@ root:
                 outputArtifactKey: iris_dataset
                 producerTask: create-dataset
           parameters:
-            min_max_scaler:
-              runtimeValue:
-                constant: false
             standard_scaler:
               runtimeValue:
                 constant: true
@@ -217,11 +206,13 @@ root:
           name: train-model
   inputDefinitions:
     parameters:
-      min_max_scaler:
-        parameterType: BOOLEAN
       neighbors:
+        defaultValue: 3.0
+        isOptional: true
         parameterType: NUMBER_INTEGER
       standard_scaler:
+        defaultValue: true
+        isOptional: true
         parameterType: BOOLEAN
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.7.0

--- a/docs/example_pipelines/iris/iris-pipeline.yaml
+++ b/docs/example_pipelines/iris/iris-pipeline.yaml
@@ -3,6 +3,8 @@
 # Inputs:
 #    neighbors: int [Default: 3.0]
 #    standard_scaler: bool [Default: True]
+# Outputs:
+#    train-model-metrics: system.ClassificationMetrics
 components:
   comp-create-dataset:
     executorLabel: exec-create-dataset
@@ -42,6 +44,10 @@ components:
           parameterType: NUMBER_INTEGER
     outputDefinitions:
       artifacts:
+        metrics:
+          artifactType:
+            schemaTitle: system.ClassificationMetrics
+            schemaVersion: 0.0.1
         model:
           artifactType:
             schemaTitle: system.Model
@@ -146,19 +152,33 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef train_model(\n    normalized_iris_dataset: Input[Dataset],\n\
-          \    model: Output[Model],\n    n_neighbors: int,\n):\n    import pickle\n\
-          \n    import pandas as pd\n    from sklearn.model_selection import train_test_split\n\
-          \    from sklearn.neighbors import KNeighborsClassifier\n\n    with open(normalized_iris_dataset.path)\
+          \    model: Output[Model],\n    metrics: Output[ClassificationMetrics],\n\
+          \    n_neighbors: int,\n):\n    import pickle\n\n    import pandas as pd\n\
+          \    from sklearn.model_selection import train_test_split\n    from sklearn.neighbors\
+          \ import KNeighborsClassifier\n\n    from sklearn.metrics import roc_curve\n\
+          \    from sklearn.model_selection import train_test_split, cross_val_predict\n\
+          \    from sklearn.metrics import confusion_matrix\n\n\n    with open(normalized_iris_dataset.path)\
           \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop('Labels')\n    X\
           \ = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
           \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
-          \    clf.fit(X_train, y_train)\n\n    model.metadata['framework'] = 'scikit-learn'\n\
-          \    with open(model.path, 'wb') as f:\n        pickle.dump(clf, f)\n\n"
+          \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(\n\
+          \        clf, X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n\
+          \        ['Iris-Setosa', 'Iris-Versicolour', 'Iris-Virginica'],\n      \
+          \  confusion_matrix(\n            y_train,\n            predictions).tolist()\
+          \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
+          \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
+          \ f)\n\n"
         image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
 pipelineInfo:
   name: iris-training-pipeline
 root:
   dag:
+    outputs:
+      artifacts:
+        train-model-metrics:
+          artifactSelectors:
+          - outputArtifactKey: metrics
+            producerSubtask: train-model
     tasks:
       create-dataset:
         cachingOptions:
@@ -214,5 +234,11 @@ root:
         defaultValue: true
         isOptional: true
         parameterType: BOOLEAN
+  outputDefinitions:
+    artifacts:
+      train-model-metrics:
+        artifactType:
+          schemaTitle: system.ClassificationMetrics
+          schemaVersion: 0.0.1
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.7.0


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #annoyance

## Description of your changes:
standard_scaler and min_max_scaler were effectivly mutually exclusive, so let's implement them as such to work around the issue with false-y default input params not parsing/instantiating correctly on the kfp UI.

## Testing instructions
Deploy DSPO, create a v2 DSPA with `spec.apiServer.enableSamplePipeline` = true.  Create a run of the sample pipeline and ensure that all input parameters are populated and you can simply click 'run' without specifying anything else.  Extra credit for also setting 'standard_scaler' to false and ensuring pipeline still runs with the MinMaxScaler instead of StandardScaler

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
