### PR TITLE
chore: add ssl env to functest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 .PHONY: all
 all: build
 
@@ -123,7 +125,7 @@ unittest: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: functest
 functest: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... --tags=test_functional -coverprofile cover.out
+	export SSL_CERT_FILE=${ROOT_DIR}/controllers/testdata/tls/ca-bundle.crt && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... --tags=test_functional -coverprofile cover.out
 
 .PHONY: integrationtest
 integrationtest: ## Run integration tests


### PR DESCRIPTION
Have functest make command set the custom SSL_CERT_FILE path to leverage dummy cabundles