### PR TITLE
Adding exclusive notebook pod label

### DIFF
--- a/config/internal/common/argo/policy.yaml.tmpl
+++ b/config/internal/common/argo/policy.yaml.tmpl
@@ -62,4 +62,4 @@ spec:
               pipelines.kubeflow.org/v2_component: 'true'
         - podSelector:
             matchLabels:
-              opendatahub.io/dashboard: 'true'
+              opendatahub.io/workbenches: 'true'

--- a/config/internal/common/tekton/policy.yaml.tmpl
+++ b/config/internal/common/tekton/policy.yaml.tmpl
@@ -66,7 +66,7 @@ spec:
               component: data-science-pipelines
         - podSelector:
             matchLabels:
-              opendatahub.io/dashboard: 'true'
+              opendatahub.io/workbenches: 'true'
       ports:
         - protocol: TCP
           port: 8888


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-4546

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Replace the existing generic dashboard label in the network policy's pod selector with [the new exclusive static notebook pod label.
](https://github.com/opendatahub-io/kubeflow/pull/265)
## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
Deploy DSPO + DSPA.
Deploy ODH Dashboard and Workbenches in the same namespace as that of the DSPA instance.
From the notebook pod, try this curl command:
`curl http://<data-science-pipelines-service-hostname>:8888/apis/v1beta1/runs`
This command should return a JSON response with details about the existing pipeline runs. If no runs exist, you'll still see the structure of the response, confirming that the API endpoint is accessible and functioning.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
