### PR TITLE
Add oauth2-proxy in mlmd envoy proxy pod

### DIFF
--- a/config/internal/common/default/mlmd-envoy-dashboard-access-policy.yaml.tmpl
+++ b/config/internal/common/default/mlmd-envoy-dashboard-access-policy.yaml.tmpl
@@ -11,12 +11,11 @@ spec:
   ingress:
     - ports:
         - protocol: TCP
+          port: 8443
+    - ports:
+        - protocol: TCP
           port: 9090
       from:
-        - podSelector:
-            matchLabels:
-              app: odh-dashboard
-          namespaceSelector: {}
         - podSelector:
             matchLabels:
               component: data-science-pipelines

--- a/config/internal/common/no-owner/clusterrolebinding.yaml.tmpl
+++ b/config/internal/common/no-owner/clusterrolebinding.yaml.tmpl
@@ -13,3 +13,6 @@ subjects:
   - kind: ServiceAccount
     namespace: {{.Namespace}}
     name: ds-pipeline-{{.Name}}
+  - kind: ServiceAccount
+    namespace: {{.Namespace}}
+    name: ds-pipeline-metadata-envoy-{{.Name}}

--- a/config/internal/ml-metadata/metadata-envoy.deployment.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.deployment.yaml.tmpl
@@ -71,7 +71,58 @@ spec:
             - mountPath: /etc/envoy.yaml
               name: envoy-config
               subPath: envoy.yaml
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-metadata-envoy-{{.Name}}
+            - --upstream=http://localhost:9090
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-metadata-envoy-{{.Name}}","namespace":"{{.Namespace}}"}}'
+            - '--openshift-sar={"namespace":"{{.Namespace}}","resource":"routes","resourceName":"ds-pipeline-metadata-envoy-{{.Name}}","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: {{.OAuthProxy}}
+          ports:
+            - containerPort: 8443
+              name: oauth2-proxy
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth2-proxy
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth2-proxy
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+      serviceAccountName: ds-pipeline-metadata-envoy-{{.Name}}
       volumes:
         - name: envoy-config
           configMap:
             name: ds-pipeline-metadata-envoy-config-{{.Name}}
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-envoy-proxy-tls-{{.Name}}

--- a/config/internal/ml-metadata/metadata-envoy.route.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.route.yaml.tmpl
@@ -1,0 +1,20 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: ds-pipeline-metadata-envoy-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: ds-pipeline-metadata-envoy-{{.Name}}
+    component: data-science-pipelines
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  to:
+    kind: Service
+    name: ds-pipeline-metadata-envoy-{{.Name}}
+    weight: 100
+  port:
+    targetPort: oauth2-proxy
+  tls:
+    termination: Reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/config/internal/ml-metadata/metadata-envoy.service.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.service.yaml.tmpl
@@ -5,11 +5,16 @@ metadata:
     app: ds-pipeline-metadata-envoy-{{.Name}}
     component: data-science-pipelines
   name: ds-pipeline-metadata-envoy-{{.Name}}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ds-pipelines-envoy-proxy-tls-{{.Name}}
   namespace: {{.Namespace}}
 spec:
   ports:
     - name: md-envoy
       port: 9090
+      protocol: TCP
+    - name: oauth2-proxy
+      port: 8443
       protocol: TCP
   selector:
     app: ds-pipeline-metadata-envoy-{{.Name}}

--- a/config/internal/ml-metadata/metadata-envoy.serviceaccount.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.serviceaccount.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ds-pipeline-metadata-envoy-{{.Name}}
+  namespace: {{.Namespace}}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"ds-pipeline-metadata-envoy-{{.Name}}"}}'
+  labels:
+    app: ds-pipeline-metadata-envoy-{{.Name}}
+    component: data-science-pipelines

--- a/controllers/testdata/declarative/case_5/expected/created/metadata-envoy_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/metadata-envoy_deployment.yaml
@@ -61,8 +61,59 @@ spec:
             - mountPath: /etc/envoy.yaml
               name: envoy-config
               subPath: envoy.yaml
+        - name: oauth-proxy
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=ds-pipeline-metadata-envoy-testdsp5
+            - --upstream=http://localhost:9090
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=SECRET
+            - '--openshift-delegate-urls={"/": {"group":"route.openshift.io","resource":"routes","verb":"get","name":"ds-pipeline-metadata-envoy-testdsp5","namespace":"default"}}'
+            - '--openshift-sar={"namespace":"default","resource":"routes","resourceName":"ds-pipeline-metadata-envoy-testdsp5","verb":"get","resourceAPIGroup":"route.openshift.io"}'
+            - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
+          image: oauth-proxy:test5
+          ports:
+            - containerPort: 8443
+              name: oauth2-proxy
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth2-proxy
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: oauth2-proxy
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
       volumes:
         - name: envoy-config
           configMap:
             name: ds-pipeline-metadata-envoy-config-testdsp5
+            defaultMode: 420
+        - name: proxy-tls
+          secret:
+            secretName: ds-pipelines-envoy-proxy-tls-testdsp5
             defaultMode: 420


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-4921](https://issues.redhat.com/browse/RHOAIENG-4921)

## Description of your changes:
To adhere to the security requirements, this PR adds OAuth2 proxy as sidecar to MLMD envoy proxy.

## Testing instructions
* Deploy DSPO
* Deploy DSPO from `config/samples/v2/dspa-simple/dspa_simple.yaml`
* Check if `ds-pipeline-metadata-envoy-sample` pod has both envoy and oauth2-proxy containers

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
