### PR TITLE
RHOAIENG-4528 - Customizable kfp-launcher with a config map

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -86,6 +86,10 @@ type APIServer struct {
 	// for the api server to use instead.
 	CustomServerConfig *ScriptConfigMap `json:"customServerConfigMap,omitempty"`
 
+	// CustomKfpLauncherConfig is a custom config file that you can provide
+	// for the api server to use instead of the one provided with DSPO.
+	CustomKfpLauncherConfig string `json:"customKfpLauncherConfigMap,omitempty"`
+
 	// Default: true
 	// Deprecated: DSP V1 only, will be removed in the future.
 	// +kubebuilder:default:=true

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -112,6 +112,11 @@ spec:
                     description: 'Default: true Deprecated: DSP V1 only, will be removed
                       in the future.'
                     type: boolean
+                  customKfpLauncherConfigMap:
+                    description: CustomKfpLauncherConfig is a custom config file that
+                      you can provide for the api server to use instead of the one
+                      provided with DSPO.
+                    type: string
                   customServerConfigMap:
                     description: CustomServerConfig is a custom config file that you
                       can provide for the api server to use instead.

--- a/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
+++ b/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
@@ -1,5 +1,9 @@
 apiVersion: v1
 data:
+  {{ if .APIServer.CustomKfpLauncherConfig }}
+  providers: |
+    {{.CustomKfpLauncherConfigMap.Data}}
+  {{ else }}
   {{ if .ObjectStorageConnection.BasePath }}
   defaultPipelineRoot: s3://{{.ObjectStorageConnection.Bucket}}/{{.ObjectStorageConnection.BasePath}}
   {{ else }}
@@ -13,10 +17,11 @@ data:
         secretName: {{.ObjectStorageConnection.CredentialsSecret.SecretName}}
         accessKeyKey: {{.ObjectStorageConnection.CredentialsSecret.AccessKey}}
         secretKeyKey: {{.ObjectStorageConnection.CredentialsSecret.SecretKey}}
+  {{ end }}
 kind: ConfigMap
 metadata:
-  name: kfp-launcher
-  namespace: {{.Namespace}}
-  labels:
-    app: ds-pipeline-{{.Name}}
-    component: data-science-pipelines
+    name: kfp-launcher
+    namespace: {{.Namespace}}
+    labels:
+        app: ds-pipeline-{{.Name}}
+        component: data-science-pipelines

--- a/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
+++ b/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   dspVersion: v2
   apiServer:
+    customKfpLauncherConfigMap: configmapname
     deploy: true
     enableSamplePipeline: true
     image: quay.io/opendatahub/ds-pipelines-api-server:latest


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-4528](https://issues.redhat.com/browse/RHOAIENG-4528)

## Description of your changes:
kfp-launcher is a KFP component that is responsible for fulfilling the "Executor wrapper" and "Publisher" roles as described in the [KFP v2 System Design document](https://docs.google.com/document/d/1fHU29oScMEKPttDA1Th1ibImAKsFVVt2Ynr4ZME05i0/edit):
> Executor: user container that runs user specified image with command and arguments.
> Publisher: publish MLMD metadata read from the executor to MLMD. The publisher is built in a statically compiled go binary and injected as an entrypoint of the executor Pod.

kfp-launcher requires a configmap to exist in the namespace where it runs. This configmap contains pipeline root and object storage configuration. This configmap must be named "kfp-launcher".

We currently deploy a default copy of the kfp-launcher configmap via DSPO, but we want the user to be able to provide their own configmap configuration as well, so that they can specify multiple object storage sources and paths (as described in https://issues.redhat.com/browse/RHOAIENG-4528). This PR adds this functionality.

We don't want to assume anything about the structure of the kfp-launcher configmap (and we know that it will likely change in the future), so this implementation simply copies the data contents of the user-provided configmap into the  kfp-launcher configmap.

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
1. Deploy DSPO 
2. Apply the config map mentioned below to the namespace where you will deploy the DSPA.
3. Deploy the DSPA mentioned below
4. After all the DSPA Pods are running, verify the `kfp-launcher` ConfigMap is the same as the config map we applied earlier. 
5. Deploy the `config/samples/v2/dspa-simple/` DSPA in another namespace
6. After all the DSPA Pods are running ,verify the `kfp-launcher` ConfigMap is created with autogenerated values as was always the case.
7. Run a Pipeline to verify that the simple-dspa runs as it should

Attachments:
<details>
<summary>config_map.yaml</summary>

```
kind: ConfigMap
apiVersion: v1
metadata:
  name: custom-config
  labels:
    app: ds-pipeline-test
    component: data-science-pipelines
data:
    s3: |
      defaultPipelineRoot: s3://rhods-dsp-dev endpoint: https://s3.amazonaws.com/ region: us-east-2 secretName: aws-artifact-secret accessKeyKey: accesskey secretKeyKey: secretkey
```
</details>

<details>
<summary> dspa.yaml </summary>

```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  apiServer:
    customKfpLauncherConfigMap: custom-config
  dspVersion: v2
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```

</details>
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
