### PR TITLE
RHOAIENG-1669 - Modified the Request Size for Manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -105,8 +105,8 @@ spec:
             cpu: 1
             memory: 4Gi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 200m
+            memory: 400Mi
         volumeMounts:
           - mountPath: /home/config
             name: config


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-1669](https://issues.redhat.com/browse/RHOAIENG-1669)

## Description of your changes:
Leveraging **Vertical Pod Autoscaling recommender** , I got values suggested for the request size to be a bit more when I had a single DSPA deployed along with DSPO. 
I took the safe route of taking the minimum suggested values to modify the request size for manager by the Jira Reporter instead as it is recommended to leverage **Vertical Pod Autoscaling** for atleast a week before considering the suggested values.
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
1. Deploy DSPO
2. Deploy DSPA and see if the sample pipeline works as it should.
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
