### PR TITLE
Added new Network Policy to access Mariadb from DSPO

### DIFF
--- a/config/internal/common/default/mariadb-access-policy.yaml.tmpl
+++ b/config/internal/common/default/mariadb-access-policy.yaml.tmpl
@@ -1,0 +1,32 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mariadb-{{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app: mariadb-{{.Name}}
+      component: data-science-pipelines
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 3306
+      from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: data-science-pipelines-operator
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{.DSPONamespace}}
+        - podSelector:
+           matchLabels:
+             app: {{.APIServerDefaultResourceName}}
+             component: data-science-pipelines
+        - podSelector:
+            matchLabels:
+              app: ds-pipeline-metadata-grpc-{{.Name}}
+              component: data-science-pipelines
+
+  policyTypes:
+    - Ingress

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,10 @@ spec:
             value: $(MAX_CONCURRENT_RECONCILES)
           - name: DSPO_REQUEUE_TIME
             value: $(DSPO_REQUEUE_TIME)
+          - name: DSPO_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -78,6 +79,7 @@ type DSPAParams struct {
 	// we need to leverage for tls connections within dsp apiserver
 	// pipeline pods
 	CustomCABundle *dspa.CABundle
+	DSPONamespace  string
 }
 
 type DBConnection struct {
@@ -553,6 +555,7 @@ func setResourcesDefault(defaultValue dspa.ResourceRequirements, value **dspa.Re
 func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePipelinesApplication, client client.Client, loggr logr.Logger) error {
 	p.Name = dsp.Name
 	p.Namespace = dsp.Namespace
+	p.DSPONamespace = os.Getenv("DSPO_NAMESPACE")
 	p.DSPVersion = dsp.Spec.DSPVersion
 	p.Owner = dsp
 	p.APIServer = dsp.Spec.APIServer.DeepCopy()


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-5314](https://issues.redhat.com/browse/RHOAIENG-5314)

## Description of your changes:
Added new Network policy which allows DSPO  to resolve connections to  mariadb deployed in the user namespace.

## Testing instructions
1. Deploy DSPO and create a DSPA. Run a pipeline and it should complete successfully.
2. Verify  the Network Policies in DSPA namespace, to see a new NWP for mariadb. Eg. mariadb-simple

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
