### PR TITLE
Updated metadata envoy route name

### DIFF
--- a/config/internal/ml-metadata/metadata-envoy.route.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.route.yaml.tmpl
@@ -1,7 +1,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: ds-pipeline-metadata-envoy-{{.Name}}
+  name: ds-pipeline-md-{{.Name}}
   namespace: {{.Namespace}}
   labels:
     app: ds-pipeline-metadata-envoy-{{.Name}}

--- a/config/internal/ml-metadata/metadata-envoy.service.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.service.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: ds-pipeline-metadata-envoy-{{.Name}}
     component: data-science-pipelines
-  name: ds-pipeline-metadata-envoy-{{.Name}}
+  name: ds-pipeline-md-{{.Name}}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: ds-pipelines-envoy-proxy-tls-{{.Name}}
   namespace: {{.Namespace}}


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-5348](https://issues.redhat.com/browse/RHOAIENG-5348)

## Description of your changes:

1. Updated the metadata envoy route name to avoid the issue with creation of pipeline server when the project name is longer than 31 chars.
2. This is the route name before the change - https://ds-pipeline-metadata-envoy-dspa-MYPROJECT.apps.clustername.domain.com/  , when the project name is longer than 31 chars pipeline server fails to create. Updated the route to this format - https://ds-pipeline-md-myproject.apps.clustername.domain.com/ which allows the project name to have more chars.
## Testing instructions
Deploy DSPO and create a DSPA instance. The metadata envoy route should be as shown in the below format-
https://ds-pipeline-md-myproject.apps.clustername.domain.com/

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
