### PR TITLE
Fixed the DSPA status update on reconciliation

### DIFF
--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -80,7 +80,7 @@ func TestDeployAPIServer(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Ensure readiness is handled
-	apiServerReady, err := reconciler.handleReadyCondition(ctx, dspa, params.APIServerDefaultResourceName, config.APIServerReady)
+	apiServerReady, err := reconciler.evaluateCondition(ctx, dspa, params.APIServerDefaultResourceName, config.APIServerReady)
 	assert.Equal(t, "Deploying", apiServerReady.Reason)
 	assert.Nil(t, err)
 }

--- a/controllers/dspastatus/dspa_status.go
+++ b/controllers/dspastatus/dspa_status.go
@@ -1,0 +1,191 @@
+package dspastatus
+
+import (
+	"fmt"
+	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DSPAStatus interface {
+	SetDatabaseReady()
+	SetDatabaseNotReady(err error)
+
+	SetObjStoreReady()
+	SetObjStoreNotReady(err error)
+
+	SetApiServerStatus(apiServerReady metav1.Condition)
+
+	SetPersistenceAgentStatus(persistenceAgentReady metav1.Condition)
+
+	SetScheduledWorkflowStatus(scheduledWorkflowReady metav1.Condition)
+
+	GetConditions() []metav1.Condition
+}
+
+func NewDSPAStatus(dspa *dspav1alpha1.DataSciencePipelinesApplication) DSPAStatus {
+	databaseCondition := BuildUnknownCondition(config.DatabaseAvailable)
+	objStoreCondition := BuildUnknownCondition(config.ObjectStoreAvailable)
+	apiServerCondition := BuildUnknownCondition(config.APIServerReady)
+	persistenceAgentCondition := BuildUnknownCondition(config.PersistenceAgentReady)
+	scheduledWorkflowReadyCondition := BuildUnknownCondition(config.ScheduledWorkflowReady)
+
+	return &dspaStatus{
+		dspa:                   dspa,
+		databaseAvailable:      &databaseCondition,
+		objStoreAvailable:      &objStoreCondition,
+		apiServerReady:         &apiServerCondition,
+		persistenceAgentReady:  &persistenceAgentCondition,
+		scheduledWorkflowReady: &scheduledWorkflowReadyCondition,
+	}
+}
+
+type dspaStatus struct {
+	dspa                   *dspav1alpha1.DataSciencePipelinesApplication
+	databaseAvailable      *metav1.Condition
+	objStoreAvailable      *metav1.Condition
+	apiServerReady         *metav1.Condition
+	persistenceAgentReady  *metav1.Condition
+	scheduledWorkflowReady *metav1.Condition
+}
+
+func (s *dspaStatus) SetDatabaseNotReady(err error) {
+	condition := BuildFalseCondition(config.DatabaseAvailable, config.FailingToDeploy, err.Error())
+	s.databaseAvailable = &condition
+}
+
+func (s *dspaStatus) SetDatabaseReady() {
+	condition := buildTrueCondition(config.DatabaseAvailable, "Database connectivity successfully verified")
+	s.databaseAvailable = &condition
+}
+
+func (s *dspaStatus) SetObjStoreReady() {
+	condition := buildTrueCondition(config.ObjectStoreAvailable, "Object Store connectivity successfully verified")
+	s.objStoreAvailable = &condition
+}
+
+func (s *dspaStatus) SetObjStoreNotReady(err error) {
+	condition := BuildFalseCondition(config.ObjectStoreAvailable, config.FailingToDeploy, err.Error())
+	s.objStoreAvailable = &condition
+}
+
+func (s *dspaStatus) SetApiServerStatus(apiServerReady metav1.Condition) {
+	s.apiServerReady = &apiServerReady
+}
+
+func (s *dspaStatus) SetPersistenceAgentStatus(persistenceAgentReady metav1.Condition) {
+	s.persistenceAgentReady = &persistenceAgentReady
+}
+
+func (s *dspaStatus) SetScheduledWorkflowStatus(scheduledWorkflowReady metav1.Condition) {
+	s.scheduledWorkflowReady = &scheduledWorkflowReady
+}
+
+func (s *dspaStatus) GetConditions() []metav1.Condition {
+	componentConditions := []metav1.Condition{
+		*s.getDatabaseAvailableCondition(),
+		*s.getObjStoreAvailableCondition(),
+		*s.getApiServerReadyCondition(),
+		*s.getPersistenceAgentReadyCondition(),
+		*s.getScheduledWorkflowReadyCondition(),
+	}
+
+	allReady := true
+	failureMessages := ""
+	for _, c := range componentConditions {
+		if c.Status == metav1.ConditionFalse || c.Status == metav1.ConditionUnknown {
+			allReady = false
+			failureMessages += fmt.Sprintf("%s \n", c.Message)
+		}
+	}
+
+	var crReady metav1.Condition
+
+	if allReady {
+		crReady = metav1.Condition{
+			Type:               config.CrReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             config.MinimumReplicasAvailable,
+			Message:            "All components are ready.",
+			LastTransitionTime: metav1.Now(),
+		}
+	} else {
+		crReady = metav1.Condition{
+			Type:               config.CrReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             config.MinimumReplicasAvailable,
+			Message:            failureMessages,
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+
+	conditions := []metav1.Condition{
+		*s.databaseAvailable,
+		*s.objStoreAvailable,
+		*s.apiServerReady,
+		*s.persistenceAgentReady,
+		*s.scheduledWorkflowReady,
+		crReady,
+	}
+
+	for i, condition := range s.dspa.Status.Conditions {
+		if condition.Status == conditions[i].Status {
+			conditions[i].LastTransitionTime = condition.LastTransitionTime
+		}
+		condition.ObservedGeneration = s.dspa.Generation
+	}
+
+	return conditions
+}
+
+func (s *dspaStatus) getDatabaseAvailableCondition() *metav1.Condition {
+	return s.databaseAvailable
+}
+
+func (s *dspaStatus) getObjStoreAvailableCondition() *metav1.Condition {
+	return s.objStoreAvailable
+}
+
+func (s *dspaStatus) getApiServerReadyCondition() *metav1.Condition {
+	return s.apiServerReady
+}
+
+func (s *dspaStatus) getPersistenceAgentReadyCondition() *metav1.Condition {
+	return s.persistenceAgentReady
+}
+
+func (s *dspaStatus) getScheduledWorkflowReadyCondition() *metav1.Condition {
+	return s.scheduledWorkflowReady
+}
+
+func buildTrueCondition(conditionType string, message string) metav1.Condition {
+	condition := metav1.Condition{}
+	condition.Type = conditionType
+	condition.Status = metav1.ConditionTrue
+	condition.Reason = conditionType
+	condition.Message = message
+	condition.LastTransitionTime = metav1.Now()
+
+	return condition
+}
+
+func BuildFalseCondition(conditionType string, reason string, message string) metav1.Condition {
+	condition := metav1.Condition{}
+	condition.Type = conditionType
+	condition.Status = metav1.ConditionFalse
+	condition.Reason = reason
+	condition.Message = message
+	condition.LastTransitionTime = metav1.Now()
+
+	return condition
+}
+
+func BuildUnknownCondition(conditionType string) metav1.Condition {
+	condition := metav1.Condition{}
+	condition.Type = conditionType
+	condition.Status = metav1.ConditionUnknown
+	condition.Reason = "Unknown"
+	condition.LastTransitionTime = metav1.Now()
+
+	return condition
+}

--- a/controllers/dspastatus/dspa_status.go
+++ b/controllers/dspastatus/dspa_status.go
@@ -9,10 +9,10 @@ import (
 
 type DSPAStatus interface {
 	SetDatabaseReady()
-	SetDatabaseNotReady(err error)
+	SetDatabaseNotReady(err error, reason string)
 
 	SetObjStoreReady()
-	SetObjStoreNotReady(err error)
+	SetObjStoreNotReady(err error, reason string)
 
 	SetApiServerStatus(apiServerReady metav1.Condition)
 
@@ -49,8 +49,12 @@ type dspaStatus struct {
 	scheduledWorkflowReady *metav1.Condition
 }
 
-func (s *dspaStatus) SetDatabaseNotReady(err error) {
-	condition := BuildFalseCondition(config.DatabaseAvailable, config.FailingToDeploy, err.Error())
+func (s *dspaStatus) SetDatabaseNotReady(err error, reason string) {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	condition := BuildFalseCondition(config.DatabaseAvailable, reason, message)
 	s.databaseAvailable = &condition
 }
 
@@ -64,8 +68,13 @@ func (s *dspaStatus) SetObjStoreReady() {
 	s.objStoreAvailable = &condition
 }
 
-func (s *dspaStatus) SetObjStoreNotReady(err error) {
-	condition := BuildFalseCondition(config.ObjectStoreAvailable, config.FailingToDeploy, err.Error())
+func (s *dspaStatus) SetObjStoreNotReady(err error, reason string) {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+
+	condition := BuildFalseCondition(config.ObjectStoreAvailable, reason, message)
 	s.objStoreAvailable = &condition
 }
 

--- a/controllers/dspastatus/dspa_status.go
+++ b/controllers/dspastatus/dspa_status.go
@@ -59,12 +59,12 @@ func (s *dspaStatus) SetDatabaseNotReady(err error, reason string) {
 }
 
 func (s *dspaStatus) SetDatabaseReady() {
-	condition := buildTrueCondition(config.DatabaseAvailable, "Database connectivity successfully verified")
+	condition := BuildTrueCondition(config.DatabaseAvailable, "Database connectivity successfully verified")
 	s.databaseAvailable = &condition
 }
 
 func (s *dspaStatus) SetObjStoreReady() {
-	condition := buildTrueCondition(config.ObjectStoreAvailable, "Object Store connectivity successfully verified")
+	condition := BuildTrueCondition(config.ObjectStoreAvailable, "Object Store connectivity successfully verified")
 	s.objStoreAvailable = &condition
 }
 
@@ -167,7 +167,7 @@ func (s *dspaStatus) getScheduledWorkflowReadyCondition() *metav1.Condition {
 	return s.scheduledWorkflowReady
 }
 
-func buildTrueCondition(conditionType string, message string) metav1.Condition {
+func BuildTrueCondition(conditionType string, message string) metav1.Condition {
 	condition := metav1.Condition{}
 	condition.Type = conditionType
 	condition.Status = metav1.ConditionTrue

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -231,7 +231,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	err = r.ReconcileDatabase(ctx, dspa, params)
 	if err != nil {
-		dspaStatus.SetDatabaseNotReady(err)
+		dspaStatus.SetDatabaseNotReady(err, config.FailingToDeploy)
 		return ctrl.Result{}, err
 	} else {
 		dspaStatus.SetDatabaseReady()
@@ -239,7 +239,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	err = r.ReconcileStorage(ctx, dspa, params)
 	if err != nil {
-		dspaStatus.SetObjStoreNotReady(err)
+		dspaStatus.SetObjStoreNotReady(err, config.FailingToDeploy)
 		return ctrl.Result{}, err
 	} else {
 		dspaStatus.SetObjStoreReady()
@@ -249,14 +249,14 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	dbAvailable, err := r.isDatabaseAccessible(dspa, params)
 
 	if err != nil {
-		dspaStatus.SetDatabaseNotReady(err)
+		dspaStatus.SetDatabaseNotReady(err, config.FailingToDeploy)
 	} else {
 		dspaStatus.SetDatabaseReady()
 	}
 
 	objStoreAvailable, err := r.isObjectStorageAccessible(ctx, dspa, params)
 	if err != nil {
-		dspaStatus.SetObjStoreNotReady(err)
+		dspaStatus.SetObjStoreNotReady(err, config.FailingToDeploy)
 	} else {
 		dspaStatus.SetObjStoreReady()
 	}

--- a/controllers/persistence_agent_test.go
+++ b/controllers/persistence_agent_test.go
@@ -79,7 +79,7 @@ func TestDeployPersistenceAgent(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Ensure readiness is handled
-	persistenceAgentReady, err := reconciler.handleReadyCondition(ctx, dspa, params.PersistentAgentDefaultResourceName, config.PersistenceAgentReady)
+	persistenceAgentReady, err := reconciler.evaluateCondition(ctx, dspa, params.PersistentAgentDefaultResourceName, config.PersistenceAgentReady)
 	assert.Equal(t, "Deploying", persistenceAgentReady.Reason)
 	assert.Nil(t, err)
 }

--- a/controllers/scheduled_workflow_test.go
+++ b/controllers/scheduled_workflow_test.go
@@ -79,7 +79,7 @@ func TestDeployScheduledWorkflow(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Ensure readiness is handled
-	scheduledWorkflowReady, err := reconciler.handleReadyCondition(ctx, dspa, params.ScheduledWorkflowDefaultResourceName, config.ScheduledWorkflowReady)
+	scheduledWorkflowReady, err := reconciler.evaluateCondition(ctx, dspa, params.ScheduledWorkflowDefaultResourceName, config.ScheduledWorkflowReady)
 	assert.Equal(t, "Deploying", scheduledWorkflowReady.Reason)
 	assert.Nil(t, err)
 }

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -27,7 +27,7 @@ func (r *DSPAReconciler) ReconcileWorkflowController(dsp *dspav1alpha1.DataScien
 
 	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
 
-	if !dsp.Spec.WorkflowController.Deploy {
+	if dsp.Spec.WorkflowController == nil || !dsp.Spec.WorkflowController.Deploy {
 		log.Info("Skipping Application of WorkflowController Resources")
 		return nil
 	}


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-6287

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
This PR refactors `controllers.DSPAReconciler#Reconcile` so it updates the DSPA status correctly.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

### Scenario 1 - Successful deployment

- Deploy `config/samples/v2/dspa-simple` to the `kubeflow` namespace.

- Wait until all the pods get started.

```
oc get pods -n kubeflow
NAME                                                      READY   STATUS    RESTARTS   AGE
ds-pipeline-metadata-envoy-sample-5857b74974-psjcd        2/2     Running   0          49s
ds-pipeline-metadata-grpc-sample-79995d8b76-8rg8c         1/1     Running   0          49s
ds-pipeline-persistenceagent-sample-69c64c4cf-8bgvl       1/1     Running   0          50s
ds-pipeline-sample-7975c7f99-b5fl5                        2/2     Running   0          50s
ds-pipeline-scheduledworkflow-sample-bc6f4c55d-prfbz      1/1     Running   0          50s
ds-pipeline-ui-sample-867bf74ff9-kp8f2                    2/2     Running   0          49s
ds-pipeline-workflow-controller-sample-757696fcff-4864z   1/1     Running   0          49s
mariadb-sample-5455fd4c74-plnl9                           1/1     Running   0          69s
minio-sample-5d58bf78f9-4mcnr                             1/1     Running   0          69s
```

- Check the DSPA status:

```bash
oc get datasciencepipelinesapplication.datasciencepipelinesapplications.opendatahub.io/sample -o yaml -n kubeflow | yq .status
```

- You should see a status similar to the following:

```yaml
conditions:
  - lastTransitionTime: "2024-05-16T18:22:36Z"
    message: Database connectivity successfully verified
    reason: DatabaseAvailable
    status: "True"
    type: DatabaseAvailable
  - lastTransitionTime: "2024-05-16T18:22:36Z"
    message: Object Store connectivity successfully verified
    reason: ObjectStoreAvailable
    status: "True"
    type: ObjectStoreAvailable
  - lastTransitionTime: "2024-05-16T18:22:48Z"
    message: Component [ds-pipeline-sample] is minimally available.
    reason: MinimumReplicasAvailable
    status: "True"
    type: APIServerReady
  - lastTransitionTime: "2024-05-16T18:22:43Z"
    message: Component [ds-pipeline-persistenceagent-sample] is minimally available.
    reason: MinimumReplicasAvailable
    status: "True"
    type: PersistenceAgentReady
  - lastTransitionTime: "2024-05-16T18:22:41Z"
    message: Component [ds-pipeline-scheduledworkflow-sample] is minimally available.
    reason: MinimumReplicasAvailable
    status: "True"
    type: ScheduledWorkflowReady
  - lastTransitionTime: "2024-05-16T18:22:48Z"
    message: All components are ready.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Ready
```

### Scenario 2 - Deployment failure

- Deploy `config/samples/v2/dspa-simple` to the `an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project` namespace.

- Wait until the deployment fails with the following message:

```
ERROR	Reconciler error	{"controller": "datasciencepipelinesapplication", "controllerGroup": "datasciencepipelinesapplications.opendatahub.io", "controllerKind": "DataSciencePipelinesApplication", "DataSciencePipelinesApplication": {"name":"sample","namespace":"an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project"}, "namespace": "an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project", "name": "sample", "reconcileID": "30ac4943-f7ca-464c-9e42-7a729bb89b30", "error": "Route.route.openshift.io \"ds-pipeline-sample\" is invalid: spec.host: Invalid value: \"ds-pipeline-sample-an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project.apps.hbelmiro-10.dev.datahub.redhat.com\": must be no more than 63 characters"}
```

- Check the DSPA status:

```bash
oc get datasciencepipelinesapplication.datasciencepipelinesapplications.opendatahub.io/sample -o yaml -n an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project | yq .status
```

- You should see a status similar to the following:

```yaml
conditions:
  - lastTransitionTime: "2024-05-16T17:59:15Z"
    message: Database connectivity successfully verified
    reason: DatabaseAvailable
    status: "True"
    type: DatabaseAvailable
  - lastTransitionTime: "2024-05-16T17:59:14Z"
    message: Object Store connectivity successfully verified
    reason: ObjectStoreAvailable
    status: "True"
    type: ObjectStoreAvailable
  - lastTransitionTime: "2024-05-16T17:59:15Z"
    message: 'Route.route.openshift.io "ds-pipeline-sample" is invalid: spec.host: Invalid value: "ds-pipeline-sample-an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project.apps.hbelmiro-10.dev.datahub.redhat.com": must be no more than 63 characters'
    reason: FailingToDeploy
    status: "False"
    type: APIServerReady
  - lastTransitionTime: "2024-05-16T17:58:54Z"
    message: ""
    reason: Unknown
    status: Unknown
    type: PersistenceAgentReady
  - lastTransitionTime: "2024-05-16T17:58:54Z"
    message: ""
    reason: Unknown
    status: Unknown
    type: ScheduledWorkflowReady
  - lastTransitionTime: "2024-05-16T17:58:54Z"
    message: "Route.route.openshift.io \"ds-pipeline-sample\" is invalid: spec.host: Invalid value: \"ds-pipeline-sample-an-even-longer-veeeeeeeeeeeeeeery-long-data-science-project.apps.hbelmiro-10.dev.datahub.redhat.com\": must be no more than 63 characters \n \n \n"
    reason: MinimumReplicasAvailable
    status: "False"
    type: Ready
```

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
