### PR TITLE
FIX - Update metadata envoy service name in mlpipelines-ui deployment file

### DIFF
--- a/config/internal/ml-metadata/metadata-envoy.serviceaccount.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-envoy.serviceaccount.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: ds-pipeline-metadata-envoy-{{.Name}}
   namespace: {{.Namespace}}
   annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"ds-pipeline-metadata-envoy-{{.Name}}"}}'
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"ds-pipeline-md-{{.Name}}"}}'
   labels:
     app: ds-pipeline-metadata-envoy-{{.Name}}
     component: data-science-pipelines

--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
             - name: METADATA_ENVOY_SERVICE_SERVICE_HOST
-              value: ds-pipeline-metadata-envoy-{{.Name}}
+              value: ds-pipeline-md-{{.Name}}
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
             - name: AWS_ACCESS_KEY_ID

--- a/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
             - name: METADATA_ENVOY_SERVICE_SERVICE_HOST
-              value: ds-pipeline-metadata-envoy-testdsp2
+              value: ds-pipeline-md-testdsp2
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
             - name: AWS_ACCESS_KEY_ID

--- a/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
             - name: METADATA_ENVOY_SERVICE_SERVICE_HOST
-              value: ds-pipeline-metadata-envoy-testdsp4
+              value: ds-pipeline-md-testdsp4
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
             - name: AWS_ACCESS_KEY_ID

--- a/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
             - name: METADATA_ENVOY_SERVICE_SERVICE_HOST
-              value: ds-pipeline-metadata-envoy-testdsp5
+              value: ds-pipeline-md-testdsp5
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
             - name: AWS_ACCESS_KEY_ID

--- a/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT
               value: '8888'
             - name: METADATA_ENVOY_SERVICE_SERVICE_HOST
-              value: ds-pipeline-metadata-envoy-testdsp7
+              value: ds-pipeline-md-testdsp7
             - name: METADATA_ENVOY_SERVICE_SERVICE_PORT
               value: "9090"
             - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-5348](https://issues.redhat.com/browse/RHOAIENG-5348)

## Description of your changes:

- Updated mlpipelines-ui deployment file with the updated metadata-envoy service host . 
- Updated metadata-envoy-serviceaccount with the new service name.


## Testing instructions
Created this PR to fix the below error in kfp-ui which was caused by the changes done with this PR-https://github.com/opendatahub-io/data-science-pipelines-operator/pull/650-

Error occurred while trying to proxy request /ml_metadata.MetadataStoreService/GetContextByTypeAndName from ds-pipeline-ui-sample-dspa1.apps.rosa.hukhan.wrh7.p3.openshiftapps.com to http://ds-pipeline-metadata-envoy-sample:9090/ (ENOTFOUND) (https://nodejs.org/api/errors.html#errors_common_system_errors)

Deploy DSPO and create a DSPA instance. Create a pipeline run and make sure there are no errors in the UI and should be able to see the pipeline status.

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
