### PR TITLE
Added routes permissions to pipeline runner

### DIFF
--- a/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
+++ b/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
@@ -139,3 +139,10 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-7346

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Adds route.openshift.io->routes->get, list permissions
## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
No testing should be necessary here, but these permissions fixed the codeflare-sdk running using pipelines

For DW verification:
```
cd $(mktemp -d)
git clone git@github.com:opendatahub-io/data-science-pipelines-operator.git
cd data-science-pipelines-operator/
git fetch origin pull/654/head
git checkout -b pullrequest c025c7243bb58166df4471d5b416ddf83cedfd98
oc new-project opendatahub
make deploy IMG="quay.io/opendatahub/data-science-pipelines-operator:pr-654"
```

Configure the pipeline server and create default `LocalQueue` in the opendatahub.

Upload this https://issues.redhat.com/secure/attachment/13193837/pipeline.yaml and run the pipeline.

Should not get credential errors from here https://issues.redhat.com/browse/RHOAIENG-7346, and pipeline should finish successfully.




## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
