### PR TITLE
disable gke metadata in kfp ui

### DIFF
--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -70,6 +70,8 @@ spec:
             - name: AWS_SSL
               value: "false"
             {{ end }}
+            - name: DISABLE_GKE_METADATA
+              value: 'true'
           image: {{.MlPipelineUI.Image}}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "minio-testdsp2.default.svc.cluster.local"
             - name: AWS_SSL
               value: "false"
+            - name: DISABLE_GKE_METADATA
+              value: 'true'
           image: frontend:test2
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "minio-testdsp4.default.svc.cluster.local"
             - name: AWS_SSL
               value: "false"
+            - name: DISABLE_GKE_METADATA
+              value: 'true'
           image: this-frontend-image-from-cr-should-be-used:test4
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "minio-testdsp5.default.svc.cluster.local"
             - name: AWS_SSL
               value: "false"
+            - name: DISABLE_GKE_METADATA
+              value: 'true'
           image: frontend:test5
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "minio-testdsp7.default.svc.cluster.local"
             - name: AWS_SSL
               value: "false"
+            - name: DISABLE_GKE_METADATA
+              value: 'true'
           image: frontend:test7
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
this disables the gke ui bits from loading in the kfp ui 