### PR TITLE
Move embedded binary and bash calls from YAML to a single script

### DIFF
--- a/.github/scripts/tests/kind-integration.sh
+++ b/.github/scripts/tests/kind-integration.sh
@@ -2,11 +2,11 @@
 set -e
 
 if [ "$GIT_WORKSPACE" = "" ]; then
-    echo "GIT_WORKSPACE variable not definied. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit
+    echo "GIT_WORKSPACE variable not defined. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit
 fi
 
 if [ "$REGISTRY_ADDRESS" = "" ]; then
-    echo "REGISTRY_ADDRESS variable not definied." && exit
+    echo "REGISTRY_ADDRESS variable not defined." && exit
 fi
 
 # Env vars

--- a/.github/scripts/tests/kind-integration.sh
+++ b/.github/scripts/tests/kind-integration.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -e
+
+if [ "$GIT_WORKSPACE" = "" ]; then
+    echo "GIT_WORKSPACE variable not definied. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit
+fi
+
+if [ "$REGISTRY_ADDRESS" = "" ]; then
+    echo "REGISTRY_ADDRESS variable not definied." && exit
+fi
+
+# Env vars
+IMAGE_REPO_DSPO="data-science-pipelines-operator"
+DSPA_NAMESPACE="test-dspa"
+DSPA_EXTERNAL_NAMESPACE="dspa-ext"
+MINIO_NAMESPACE="test-minio"
+MARIADB_NAMESPACE="test-mariadb"
+PYPISERVER_NAMESPACE="test-pypiserver"
+DSPA_NAME="test-dspa"
+DSPA_EXTERNAL_NAME="dspa-ext"
+DSPA_DEPLOY_WAIT_TIMEOUT="300"
+INTEGRATION_TESTS_DIR="${GIT_WORKSPACE}/tests"
+DSPA_PATH="${GIT_WORKSPACE}/tests/resources/dspa-lite.yaml"
+DSPA_EXTERNAL_PATH="${GIT_WORKSPACE}/tests/resources/dspa-external-lite.yaml"
+CONFIG_DIR="${GIT_WORKSPACE}/config"
+RESOURCES_DIR_CRD="${GIT_WORKSPACE}/.github/resources"
+DSPO_IMAGE="${REGISTRY_ADDRESS}/data-science-pipelines-operator"
+OPENDATAHUB_NAMESPACE="opendatahub"
+RESOURCES_DIR_PYPI="${GIT_WORKSPACE}/.github/resources/pypiserver/base"
+
+# TODO: Consolidate testing CRDS (2 locations)
+# Apply OCP CRDs
+kubectl apply -f ${RESOURCES_DIR_CRD}/crds
+kubectl apply -f "${CONFIG_DIR}/crd/external/route.openshift.io_routes.yaml"
+
+# Build image
+( cd $GIT_WORKSPACE && make podman-build -e IMG="${DSPO_IMAGE}" )
+
+# Create opendatahub namespace
+kubectl create namespace $OPENDATAHUB_NAMESPACE
+
+# Deploy Argo Lite
+( cd "${GIT_WORKSPACE}/.github/resources/argo-lite" && kustomize build . | kubectl -n $OPENDATAHUB_NAMESPACE apply -f - )
+
+# Deploy DSPO
+( cd $GIT_WORKSPACE && make podman-push -e IMG="${DSPO_IMAGE}" )
+( cd $GIT_WORKSPACE && make deploy-kind -e IMG="${DSPO_IMAGE}" )
+
+# Create Minio Namespace
+kubectl create namespace $MINIO_NAMESPACE
+
+# Deploy Minio
+( cd "${GIT_WORKSPACE}/.github/resources/minio" && kustomize build . | kubectl -n $MINIO_NAMESPACE apply -f - )
+
+# Create MariaDB Namespace
+kubectl create namespace $MARIADB_NAMESPACE
+
+# Deploy MariaDB
+( cd "${GIT_WORKSPACE}/.github/resources/mariadb" && kustomize build . | kubectl -n $MARIADB_NAMESPACE apply -f - )
+
+# Create Pypiserver Namespace
+kubectl create namespace $PYPISERVER_NAMESPACE
+
+# Deploy pypi-server
+( cd "${GIT_WORKSPACE}/.github/resources/pypiserver/base" && kustomize build . | kubectl -n $PYPISERVER_NAMESPACE apply -f - )
+
+# Wait for Dependencies (DSPO, Minio, Mariadb, Pypi server)
+kubectl wait -n $OPENDATAHUB_NAMESPACE --timeout=60s --for=condition=Available=true deployment data-science-pipelines-operator-controller-manager
+kubectl wait -n $MARIADB_NAMESPACE --timeout=60s --for=condition=Available=true deployment mariadb
+kubectl wait -n $MINIO_NAMESPACE --timeout=60s --for=condition=Available=true deployment minio
+kubectl wait -n $PYPISERVER_NAMESPACE --timeout=60s --for=condition=Available=true deployment pypi-server
+
+# Upload Python Packages to pypi-server
+( cd "${GIT_WORKSPACE}/.github/scripts/python_package_upload" && sh package_upload.sh )
+
+# Create DSPA Namespace
+kubectl create namespace $DSPA_NAMESPACE
+
+# Create Namespace for DSPA with External connections
+kubectl create namespace $DSPA_EXTERNAL_NAMESPACE
+
+# Apply MariaDB and Minio Secrets and Configmaps in the External Namespace
+( cd "${GIT_WORKSPACE}/.github/resources/external-pre-reqs" && kustomize build . |  oc -n $DSPA_EXTERNAL_NAMESPACE apply -f - )
+
+# Apply PIP Server ConfigMap
+( cd "${GIT_WORKSPACE}/.github/resources/pypiserver/base" && kubectl apply -f $RESOURCES_DIR_PYPI/nginx-tls-config.yaml -n $DSPA_NAMESPACE )
+
+# Run tests
+( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${DSPA_NAMESPACE} DSPAPATH=${DSPA_PATH} )
+
+# Run tests for DSPA with External Connections
+( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${DSPA_EXTERNAL_NAMESPACE} DSPAPATH=${DSPA_EXTERNAL_PATH} )
+
+# Clean up
+( cd $GIT_WORKSPACE && make undeploy-kind )

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -11,6 +11,7 @@ on:
       - config/**
       - tests/**
       - .github/resources/**
+      - '.github/workflows/kind-integration.yml'
     types:
       - opened
       - reopened
@@ -22,18 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_REPO_DSPO: data-science-pipelines-operator
-  DSPA_NAMESPACE: test-dspa
-  DSPA_EXTERNAL_NAMESPACE: dspa-ext
-  MINIO_NAMESPACE: test-minio
-  MARIADB_NAMESPACE: test-mariadb
-  PYPISERVER_NAMESPACE: test-pypiserver
-  DSPA_NAME: test-dspa
-  DSPA_EXTERNAL_NAME: dspa-ext
-  DSPA_DEPLOY_WAIT_TIMEOUT: 300
-  INTEGRATION_TESTS_DIR: ${{ github.workspace }}/tests
-  DSPA_PATH: ${{ github.workspace }}/tests/resources/dspa-lite.yaml
-  DSPA_EXTERNAL_PATH: ${{ github.workspace }}/tests/resources/dspa-external-lite.yaml
+  GIT_WORKSPACE: ${{ github.workspace }}
+
 jobs:
   dspo-tests:
     runs-on: ubuntu-20.04
@@ -53,113 +44,7 @@ jobs:
       - name: Setup and start KinD cluster
         uses: ./.github/actions/kind
 
-      # TODO: Consolidate testing CRDS (2 locations)
-      - name: Apply OCP CRDs
-        env:
-          RESOURCES_DIR: ${{ github.workspace }}/.github/resources
-          CONFIG_DIR: ${{ github.workspace }}/config
+      - name: Run test
+        working-directory: ${{ github.workspace }}/.github/scripts/tests
         run: |
-          kubectl apply -f ${{ env.RESOURCES_DIR }}/crds
-          kubectl apply -f ${{ env.CONFIG_DIR }}/crd/external/route.openshift.io_routes.yaml
-
-      - name: Build image
-        env:
-          DSPO_IMAGE: ${{env.REGISTRY_ADDRESS}}/data-science-pipelines-operator
-        run: |
-          make podman-build -e IMG="${DSPO_IMAGE}"
-
-      - name: Create opendatahub namespace
-        run: |
-          kubectl create namespace opendatahub
-
-      - name: Deploy Argo Lite
-        working-directory: ${{ github.workspace }}/.github/resources/argo-lite
-        run: |
-          kustomize build . | kubectl apply -f -
-
-      - name: Deploy DSPO
-        env:
-          DSPO_IMAGE: ${{env.REGISTRY_ADDRESS}}/data-science-pipelines-operator
-        run: |
-          make podman-push -e IMG="${DSPO_IMAGE}"
-          make deploy-kind -e IMG="${DSPO_IMAGE}"
-
-      - name: Create Minio Namespace
-        run: |
-          kubectl create namespace ${{ env.MINIO_NAMESPACE }}
-
-      - name: Deploy Minio
-        working-directory: ${{ github.workspace }}/.github/resources/minio
-        run: |
-          kustomize build . |  oc -n ${{ env.MINIO_NAMESPACE }} apply -f -
-
-      - name: Create MariaDB Namespace
-        run: |
-          kubectl create namespace ${{ env.MARIADB_NAMESPACE }}
-
-      - name: Deploy MariaDB
-        working-directory: ${{ github.workspace }}/.github/resources/mariadb
-        run: |
-          kustomize build . |  oc -n ${{ env.MARIADB_NAMESPACE }} apply -f -
-
-      - name: Create Pypiserver Namespace
-        run: |
-          kubectl create namespace ${{ env.PYPISERVER_NAMESPACE }}
-
-      - name: Deploy pypi-server
-        working-directory: ${{ github.workspace }}/.github/resources/pypiserver/base
-        run: |
-          kustomize build . | oc -n ${{ env.PYPISERVER_NAMESPACE }} apply -f -
-
-      - name: Wait for Dependencies (DSPO, Minio, Mariadb, Pypi server)
-        run: |
-          kubectl wait -n opendatahub --timeout=60s --for=condition=Available=true deployment data-science-pipelines-operator-controller-manager
-          kubectl wait -n ${{ env.MARIADB_NAMESPACE }} --timeout=60s --for=condition=Available=true deployment mariadb
-          kubectl wait -n ${{ env.MINIO_NAMESPACE }} --timeout=60s --for=condition=Available=true deployment minio
-          kubectl wait -n ${{ env.PYPISERVER_NAMESPACE }} --timeout=60s --for=condition=Available=true deployment pypi-server
-
-      - name: Upload Python Packages to pypi-server
-        working-directory: ${{ github.workspace }}/.github/scripts/python_package_upload
-        run: |
-          sh package_upload.sh
-
-      - name: Create DSPA Namespace
-        run: |
-          kubectl create namespace ${{ env.DSPA_NAMESPACE }}
-
-      - name: Create Namespace for DSPA with External connections
-        run: |
-          kubectl create namespace ${{ env.DSPA_EXTERNAL_NAMESPACE }}
-
-      - name: Apply MariaDB and Minio Secrets and Configmaps in the External Namespace
-        working-directory: ${{ github.workspace }}/.github/resources/external-pre-reqs
-        run: |
-          kustomize build . |  oc -n ${{ env.DSPA_EXTERNAL_NAMESPACE }} apply -f -
-
-      - name: Apply PIP Server ConfigMap
-        env:
-          RESOURCES_DIR: ${{ github.workspace }}/.github/resources/pypiserver/base
-        run: |
-          kubectl apply -f $RESOURCES_DIR/nginx-tls-config.yaml -n ${{ env.DSPA_NAMESPACE }}
-
-      - name: Run tests
-        working-directory: ${{ github.workspace }}
-        env:
-          NAMESPACE: ${{ env.DSPA_NAMESPACE }}
-          DSPA_NAME: ${{ env.DSPA_NAME }}
-          DSPA_PATH: ${{ env.DSPA_PATH }}
-        run: |
-            make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${NAMESPACE} DSPAPATH=${DSPA_PATH}
-
-      - name: Run tests for DSPA with External Connections
-        working-directory: ${{ github.workspace }}
-        env:
-          NAMESPACE: ${{ env.DSPA_EXTERNAL_NAMESPACE }}
-          DSPA_NAME: ${{ env.DSPA_EXTERNAL_NAME }}
-          DSPA_EXTERNAL_PATH: ${{ env.DSPA_EXTERNAL_PATH }}
-        run: |
-            make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${NAMESPACE} DSPAPATH=${DSPA_EXTERNAL_PATH}
-
-      - name: Clean up
-        run: |
-          make undeploy-kind
+          sh kind-integration.sh


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-9518](https://issues.redhat.com/browse/RHOAIENG-9518)
Create a shared testing artifact for DSPO infrastructure

## Description of your changes:
* Add `- '.github/workflows/kind-integration.yml'` as part of this PR because changing the yaml must also run the steps
* All environment variables are defined in the script. The script requires two environment variables `GIT_WORKSPACE` and `REGISTRY_ADDRESS`. They can change based on the host. While running in GHA they have a value while running locally they have other value.
* The job has a lot of steps. The `name` was translated to a comment. The `env` were defined early in the script. The `working-directory` is translated to ( cd ... && ... )
* We can now use the script locally and on Jenkins

## Testing instructions
Have a kind cluster and execute the bash with the two required variables. How to setup the kind cluster you will need to read and understand the yaml|bash scripts.

## Checklist
- [ X ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ X ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ X ] The developer has manually tested the changes and verified that the changes work
