### PR TITLE
increase default expiry for signed url

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -150,8 +150,8 @@ type APIServer struct {
 
 	// The expiry time (seconds) for artifact download links when
 	// querying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true
-	// Default: 15
-	// +kubebuilder:default:=15
+	// Default: 60
+	// +kubebuilder:default:=60
 	// +kubebuilder:validation:Optional
 	ArtifactSignedURLExpirySeconds *int `json:"artifactSignedURLExpirySeconds"`
 }

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -68,10 +68,10 @@ spec:
                         type: string
                     type: object
                   artifactSignedURLExpirySeconds:
-                    default: 15
+                    default: 60
                     description: 'The expiry time (seconds) for artifact download
                       links when querying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true
-                      Default: 15'
+                      Default: 60'
                     type: integer
                   autoUpdatePipelineDefaultVersion:
                     default: true

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -60,7 +60,7 @@ const (
 	DefaultDBSecretKey        = "password"
 	GeneratedDBPasswordLength = 12
 
-	DefaultSignedUrlExpiryTimeSeconds = 15
+	DefaultSignedUrlExpiryTimeSeconds = 60
 
 	MariaDBName        = "mlpipeline"
 	MariaDBHostPrefix  = "mariadb"

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: PipelineRun
             - name: CACHE_IMAGE

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: PipelineRun
             - name: CACHE_IMAGE

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: PipelineRun
             - name: CACHE_IMAGE

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: PipelineRun
             - name: CACHE_IMAGE

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: PipelineRun
             - name: CACHE_IMAGE

--- a/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: Workflow
             - name: DB_DRIVER_NAME

--- a/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
@@ -92,7 +92,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: ML_PIPELINE_TLS_ENABLED
               value: "true"
             - name: EXECUTIONTYPE

--- a/controllers/testdata/declarative/case_9/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_9/expected/created/apiserver_deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - name: ML_PIPELINE_SERVICE_PORT_GRPC
               value: "8887"
             - name: SIGNED_URL_EXPIRY_TIME_SECONDS
-              value: "15"
+              value: "60"
             - name: EXECUTIONTYPE
               value: Workflow
             - name: DB_DRIVER_NAME


### PR DESCRIPTION
Increase expiry for signed url to recommended minimum from aws s3