### PR TITLE
Disable DSPO Debug Logs by Default and modify the "DSPA resource was not found" message to Debug

### DIFF
--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -17,11 +17,11 @@ package controllers
 
 import (
 	"context"
-
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	v1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"log/slog"
 )
 
 var apiServerTemplatesDir = "apiserver/default"
@@ -40,10 +40,11 @@ var samplePipelineTemplates = map[string]string{
 }
 
 func (r *DSPAReconciler) ReconcileAPIServer(ctx context.Context, dsp *dspav1alpha1.DataSciencePipelinesApplication, params *DSPAParams) error {
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if !dsp.Spec.APIServer.Deploy {
-		r.Log.Info("Skipping Application of APIServer Resources")
+		log.Info("Skipping Application of APIServer Resources")
 		return nil
 	}
 

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package controllers
 
 import (
-	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
+	"log/slog"
 	"testing"
+
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -58,9 +60,12 @@ func TestDeployAPIServer(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert APIServer Deployment doesn't yet exist

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 var commonTemplatesDir = "common/default"
@@ -26,7 +27,8 @@ var tektonOnlyCommonTemplatesDir = "common/tekton"
 const commonCusterRolebindingTemplate = "common/no-owner/clusterrolebinding.yaml.tmpl"
 
 func (r *DSPAReconciler) ReconcileCommon(dsp *dspav1alpha1.DataSciencePipelinesApplication, params *DSPAParams) error {
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	log.Info("Applying Common Resources")
 	err := r.ApplyDir(dsp, params, commonTemplatesDir)

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package controllers
 
 import (
+	"log/slog"
 	"testing"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
@@ -54,9 +55,12 @@ func TestDeployCommonPolicies(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert Common NetworkPolicies don't yet exist

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -19,9 +19,9 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
-	"github.com/go-logr/logr"
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -243,7 +243,7 @@ func GetCABundleFileMountPath() string {
 	return fmt.Sprintf("%s/%s", CustomCABundleRootMountPath, CustomDSPTrustedCAConfigMapKey)
 }
 
-func GetDefaultDBExtraParams(params DBExtraParams, log logr.Logger) (string, error) {
+func GetDefaultDBExtraParams(params DBExtraParams, log *slog.Logger) (string, error) {
 	extraParamsJson, err := json.Marshal(params)
 	if err != nil {
 		log.Info(fmt.Sprintf("Error marshaling TLS configuration to JSON: %v", err))

--- a/controllers/database_test.go
+++ b/controllers/database_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package controllers
 
 import (
+	"log/slog"
 	"testing"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
@@ -53,9 +54,12 @@ func TestDeployDatabase(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert Database Deployment doesn't yet exist
@@ -103,9 +107,12 @@ func TestDontDeployDatabase(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert Database Deployment doesn't yet exist

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -177,7 +177,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	dspa := &dspav1alpha1.DataSciencePipelinesApplication{}
 	err := r.Get(ctx, req.NamespacedName, dspa)
 	if err != nil && apierrs.IsNotFound(err) {
-		log.Info("DSPA resource was not found")
+		log.Debug("DSPA resource was not found, assuming it was recently deleted, nothing to do here")
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error("Encountered error when fetching DSPA", err)

--- a/controllers/dspipeline_fake_controller.go
+++ b/controllers/dspipeline_fake_controller.go
@@ -19,9 +19,9 @@ package controllers
 
 import (
 	"context"
+	"log/slog"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -54,7 +54,7 @@ func NewFakeController() *DSPAReconciler {
 	// Generate DSPAReconciler using Fake Client
 	r := &DSPAReconciler{
 		Client:        FakeClient,
-		Log:           ctrl.Log.WithName("controllers").WithName("ds-pipelines-controller"),
+		Log:           slog.Logger{},
 		Scheme:        FakeScheme,
 		TemplatesPath: "../config/internal/",
 	}

--- a/controllers/dspipeline_params_test.go
+++ b/controllers/dspipeline_params_test.go
@@ -18,13 +18,15 @@ limitations under the License.
 package controllers
 
 import (
+	"log/slog"
+	"testing"
+
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/testutil"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"testing"
 )
 
 type Client struct {
@@ -33,8 +35,12 @@ type Client struct {
 
 func TestExtractParams_WithEmptyDSPA(t *testing.T) {
 	dspa := testutil.CreateEmptyDSPA()
+
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 }
 
@@ -223,7 +229,11 @@ func TestExtractParams_CABundle(t *testing.T) {
 			}
 
 			actualParams := &DSPAParams{}
-			extractError := actualParams.ExtractParams(ctx, test.dsp, client.Client, client.Log)
+
+			//Create Logging using slog
+			log := slog.With("namespace", actualParams.Namespace).With("dspa_name", actualParams.Name)
+
+			extractError := actualParams.ExtractParams(ctx, test.dsp, client.Client, log)
 			if test.errorMsg != "" {
 				assert.Contains(t, extractError.Error(), test.errorMsg)
 			} else {

--- a/controllers/mlmd.go
+++ b/controllers/mlmd.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 const (
@@ -27,10 +28,10 @@ const (
 func (r *DSPAReconciler) ReconcileMLMD(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if (params.MLMD == nil || !params.MLMD.Deploy) && (dsp.Spec.MLMD == nil || !dsp.Spec.MLMD.Deploy) {
-		r.Log.Info("Skipping Application of ML-Metadata (MLMD) Resources")
+		log.Info("Skipping Application of ML-Metadata (MLMD) Resources")
 		return nil
 	}
 

--- a/controllers/mlmd_test.go
+++ b/controllers/mlmd_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package controllers
 
 import (
-	v1 "github.com/openshift/api/route/v1"
+	"log/slog"
 	"testing"
+
+	v1 "github.com/openshift/api/route/v1"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -62,9 +64,12 @@ func TestDeployMLMDV1(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -157,9 +162,12 @@ func TestDeployMLMDV2(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -251,9 +259,12 @@ func TestDontDeployMLMDV1(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -342,9 +353,12 @@ func TestDontDeployMLMDV2(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.EqualError(t, err, MlmdIsRequiredInV2Msg)
 }
 
@@ -381,9 +395,12 @@ func TestDefaultDeployBehaviorMLMDV1(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -473,9 +490,12 @@ func TestDefaultDeployBehaviorMLMDV2(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -568,9 +588,12 @@ func TestDeployEnvoyRouteV1(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -640,9 +663,12 @@ func TestDeployEnvoyRouteV2(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -711,9 +737,12 @@ func TestDontDeployEnvoyRouteV1(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist
@@ -783,9 +812,12 @@ func TestDontDeployEnvoyRouteV2(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure MLMD-Envoy resources doesn't yet exist

--- a/controllers/mlpipeline_ui.go
+++ b/controllers/mlpipeline_ui.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 var mlPipelineUITemplatesDir = "mlpipelines-ui"
@@ -25,7 +26,7 @@ var mlPipelineUITemplatesDir = "mlpipelines-ui"
 func (r *DSPAReconciler) ReconcileUI(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if dsp.Spec.MlPipelineUI == nil || !dsp.Spec.MlPipelineUI.Deploy {
 		log.Info("Skipping Application of MlPipelineUI Resources")

--- a/controllers/mlpipeline_ui_test.go
+++ b/controllers/mlpipeline_ui_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package controllers
 
 import (
+	"log/slog"
 	"testing"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
@@ -57,9 +58,12 @@ func TestDeployUI(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure UI Deployement doesn't yet exist
@@ -111,9 +115,12 @@ func TestDontDeployUI(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure UI Deployment doesn't yet exist
@@ -161,9 +168,12 @@ func TestDefaultDeployBehaviorUI(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	params.ExtractParams(ctx, dspa, reconciler.Client, log)
 
 	// Ensure UI Deployment doesn't yet exist
 	deployment := &appsv1.Deployment{}

--- a/controllers/persistence_agent.go
+++ b/controllers/persistence_agent.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 var persistenceAgentTemplatesDir = "persistence-agent"
@@ -27,7 +28,7 @@ const persistenceAgentDefaultResourceNamePrefix = "ds-pipeline-persistenceagent-
 func (r *DSPAReconciler) ReconcilePersistenceAgent(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if !dsp.Spec.PersistenceAgent.Deploy {
 		log.Info("Skipping Application of PersistenceAgent Resources")

--- a/controllers/persistence_agent_test.go
+++ b/controllers/persistence_agent_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package controllers
 
 import (
-	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
+	"log/slog"
 	"testing"
+
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -57,9 +59,12 @@ func TestDeployPersistenceAgent(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure PersistenceAgent Deployment doesn't yet exist

--- a/controllers/scheduled_workflow.go
+++ b/controllers/scheduled_workflow.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 var scheduledWorkflowTemplatesDir = "scheduled-workflow"
@@ -27,7 +28,7 @@ const scheduledWorkflowDefaultResourceNamePrefix = "ds-pipeline-scheduledworkflo
 func (r *DSPAReconciler) ReconcileScheduledWorkflow(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if !dsp.Spec.ScheduledWorkflow.Deploy {
 		log.Info("Skipping Application of ScheduledWorkflow Resources")

--- a/controllers/scheduled_workflow_test.go
+++ b/controllers/scheduled_workflow_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package controllers
 
 import (
-	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
+	"log/slog"
 	"testing"
+
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -57,9 +59,12 @@ func TestDeployScheduledWorkflow(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure ScheduledWorkflow Deployment doesn't yet exist

--- a/controllers/storage_test.go
+++ b/controllers/storage_test.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 
@@ -72,9 +72,12 @@ func TestDeployStorage(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert ObjectStorage Deployment doesn't yet exist
@@ -139,9 +142,12 @@ func TestDeployStorageWithExternalRouteEnabled(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert ObjectStorage Deployment doesn't yet exist
@@ -201,9 +207,12 @@ func TestDontDeployStorage(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Assert ObjectStorage Deployment doesn't yet exist
@@ -247,9 +256,12 @@ func TestDefaultDeployBehaviorStorage(t *testing.T) {
 	dspa.Name = testDSPAName
 	dspa.Namespace = testNamespace
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.NotNil(t, err) // DSPAParams should throw an error if no objstore is provided
 
 	// Assert ObjectStorage Deployment doesn't yet exist
@@ -271,7 +283,7 @@ func TestDefaultDeployBehaviorStorage(t *testing.T) {
 
 func TestIsDatabaseAccessibleTrue(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+	ConnectAndQueryObjStore = func(ctx context.Context, log *slog.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
@@ -309,7 +321,7 @@ func TestIsDatabaseAccessibleTrue(t *testing.T) {
 
 func TestIsDatabaseNotAccessibleFalse(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+	ConnectAndQueryObjStore = func(ctx context.Context, log *slog.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 		return false, errors.New("Object Store is not Accessible")
 	}
 
@@ -347,7 +359,7 @@ func TestIsDatabaseNotAccessibleFalse(t *testing.T) {
 
 func TestDisabledHealthCheckReturnsTrue(t *testing.T) {
 	// Override the live connection function with a mock version that would always return false if called
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+	ConnectAndQueryObjStore = func(ctx context.Context, log *slog.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 		return false, errors.New("Object Store is not Accessible")
 	}
 
@@ -387,7 +399,7 @@ func TestDisabledHealthCheckReturnsTrue(t *testing.T) {
 
 func TestIsDatabaseAccessibleBadAccessKey(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+	ConnectAndQueryObjStore = func(ctx context.Context, log *slog.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
@@ -425,7 +437,7 @@ func TestIsDatabaseAccessibleBadAccessKey(t *testing.T) {
 
 func TestIsDatabaseAccessibleBadSecretKey(t *testing.T) {
 	// Override the live connection function with a mock version
-	ConnectAndQueryObjStore = func(ctx context.Context, log logr.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
+	ConnectAndQueryObjStore = func(ctx context.Context, log *slog.Logger, endpoint, bucket string, accesskey, secretkey []byte, secure bool, pemCerts [][]byte, objStoreConnectionTimeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
@@ -547,16 +559,20 @@ Em/2fyF49JL+vAPFMWRFpaExUr3gMbELo4YABQGg024d623LK0ienEF0p4jMVNbP
 S9IA40yOaVHMI51Fr1i1EIWvP8oJY8rAPWq45JnfFen3tOqKfw==
 -----END CERTIFICATE-----
 `
-	_, _, reconciler := CreateNewTestObjects()
+	//Create Logging using slog
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+
+	log := slog.With("namespace", testNamespace).With("dspa_name", testDSPAName)
 
 	validCerts := [][]byte{[]byte(validCert)}
-	transport, err := getHttpsTransportWithCACert(reconciler.Log, validCerts)
+	transport, err := getHttpsTransportWithCACert(log, validCerts)
 	assert.Nil(t, err)
 	assert.NotNil(t, transport)
 
 	invalidCert := "invalidCert"
 	invalidCerts := [][]byte{[]byte(invalidCert)}
-	transport, err = getHttpsTransportWithCACert(reconciler.Log, invalidCerts)
+	transport, err = getHttpsTransportWithCACert(log, invalidCerts)
 	assert.NotNil(t, err)
 	assert.Nil(t, transport)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,7 +20,12 @@ package controllers
 
 import (
 	"context"
-	"github.com/go-logr/logr"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -31,13 +36,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"os"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
-	"time"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,7 +74,7 @@ func (s *ControllerSuite) SetupTest() {
 	logf.Log.Info("Overriding the Database and Object Store live connection functions with trivial stubs")
 	ConnectAndQueryDatabase = func(
 		host string,
-		log logr.Logger,
+		log *slog.Logger,
 		port, username, password, dbname, tls string,
 		dbConnectionTimeout time.Duration,
 		pemCerts [][]byte,
@@ -82,7 +83,7 @@ func (s *ControllerSuite) SetupTest() {
 	}
 	ConnectAndQueryObjStore = func(
 		ctx context.Context,
-		log logr.Logger,
+		log *slog.Logger,
 		endpoint, bucket string,
 		accesskey, secretkey []byte,
 		secure bool,
@@ -138,7 +139,7 @@ func (s *ControllerSuite) SetupSuite() {
 
 	err = (&DSPAReconciler{
 		Client:        k8sClient,
-		Log:           ctrl.Log.WithName("controllers").WithName("ds-pipelines-controller"),
+		Log:           slog.Logger{},
 		Scheme:        scheme.Scheme,
 		TemplatesPath: "../config/internal/",
 	}).SetupWithManager(mgr)

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
+	"log/slog"
 )
 
 var workflowControllerTemplatesDir = "workflow-controller"
@@ -25,7 +26,7 @@ var workflowControllerTemplatesDir = "workflow-controller"
 func (r *DSPAReconciler) ReconcileWorkflowController(dsp *dspav1alpha1.DataSciencePipelinesApplication,
 	params *DSPAParams) error {
 
-	log := r.Log.WithValues("namespace", dsp.Namespace).WithValues("dspa_name", dsp.Name)
+	log := slog.With("namespace", dsp.Namespace).With("dspa_name", dsp.Name)
 
 	if dsp.Spec.WorkflowController == nil || !dsp.Spec.WorkflowController.Deploy {
 		log.Info("Skipping Application of WorkflowController Resources")

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package controllers
 
 import (
+	"log/slog"
 	"testing"
 
 	dspav1alpha1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1alpha1"
@@ -57,9 +58,12 @@ func TestDeployWorkflowController(t *testing.T) {
 	dspa.Namespace = testNamespace
 	dspa.Name = testDSPAName
 
+	//Create Logging using slog
+	log := slog.With("namespace", dspa.Namespace).With("dspa_name", dspa.Name)
+
 	// Create Context, Fake Controller and Params
 	ctx, params, reconciler := CreateNewTestObjects()
-	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, log)
 	assert.Nil(t, err)
 
 	// Ensure WorkflowController Deployment doesn't yet exist

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 	"github.com/spf13/viper"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -104,6 +105,7 @@ func main() {
 	var probeAddr string
 	var configPath string
 	var maxConcurrentReconciles int
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&configPath, "config", "", "Path to JSON file containing config")
@@ -141,7 +143,7 @@ func main() {
 	if err = (&controllers.DSPAReconciler{
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
-		Log:                     ctrl.Log,
+		Log:                     slog.Logger{},
 		TemplatesPath:           "config/internal/",
 		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-1650](https://issues.redhat.com/browse/RHOAIENG-1650)

## Description of your changes:
When deleting a DSPA we continue to see these types of logs:
```
2023-08-23T17:17:40Z DEBUG Reconcile event triggered by [Pod: mariadb-pipelines-definition-6d848d8d75-hg6hq] {"namespace": "my-ds-project"}
2023-08-23T17:17:40Z DEBUG Reconcile event triggered by [Pod: mariadb-pipelines-definition-6d848d8d75-hg6hq] {"namespace": "my-ds-project"}
2023-08-23T17:17:40Z DEBUG DataSciencePipelinesApplication Reconciler called. {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"}
2023-08-23T17:17:40Z INFO DSPA resource was not found {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"}
2023-08-23T17:17:40Z DEBUG Reconcile event triggered by [Pod: mariadb-pipelines-definition-6d848d8d75-hg6hq] {"namespace": "my-ds-project"}
2023-08-23T17:17:40Z DEBUG DataSciencePipelinesApplication Reconciler called. {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"}
2023-08-23T17:17:40Z INFO DSPA resource was not found {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"}
2023-08-23T17:17:40Z DEBUG DataSciencePipelinesApplication Reconciler called. {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"}
2023-08-23T17:17:40Z INFO DSPA resource was not found {"namespace": "my-ds-project", "dspa_name": "pipelines-definition"
```
This PR resolves this by ensuring DSPO logs default to Debug logs with the first commit.
The second commit modifies the "DSPA resources was not found" message to a Debug instead of an Info.
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
1. Deploy the DSPO created by Github
2. Deploy [DSPA](https://github.com/opendatahub-io/data-science-pipelines-operator/blob/main/config/samples/v2/dspa-simple/dspa_simple.yaml)
3. (Optional) Deploy additional [DSPA](https://github.com/opendatahub-io/data-science-pipelines-operator/blob/main/config/samples/v2/dspa-simple/dspa_simple.yaml) in another namespace
4. Delete the original DSPA
5. Observe the DSPO logs to ensure that `"DEBUG DSPA resource was not found"`  **does not appear**
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
