### PR TITLE
add ability to customize `kfp-launcher` ConfigMap data contents

### DIFF
--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -86,6 +86,19 @@ type APIServer struct {
 	// for the api server to use instead.
 	CustomServerConfig *ScriptConfigMap `json:"customServerConfigMap,omitempty"`
 
+	// When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes
+	// will be fully replaced with the `data` contents of the ConfigMap specified here.
+	// This allows the user to fully replace the `data` contents of the kfp-launcher ConfigMap.
+	// The `kfp-launcher` component requires a ConfigMap to exist in the namespace
+	// where it runs (i.e. the namespace where pipelines run). This ConfigMap contains
+	// object storage configuration, as well as pipeline root (object store root path
+	// where artifacts will be uploaded) configuration. Currently this ConfigMap *must*
+	// be named "kfp-launcher". We currently deploy a default copy of the kfp-launcher
+	// ConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration,
+	// so that they can specify multiple object storage sources and paths.
+	// +kubebuilder:validation:Optional
+	CustomKfpLauncherConfigMap string `json:"customKfpLauncherConfigMap,omitempty"`
+
 	// Default: true
 	// Deprecated: DSP V1 only, will be removed in the future.
 	// +kubebuilder:default:=true

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -112,6 +112,21 @@ spec:
                     description: 'Default: true Deprecated: DSP V1 only, will be removed
                       in the future.'
                     type: boolean
+                  customKfpLauncherConfigMap:
+                    description: When specified, the `data` contents of the `kfp-launcher`
+                      ConfigMap that DSPO writes will be fully replaced with the `data`
+                      contents of the ConfigMap specified here. This allows the user
+                      to fully replace the `data` contents of the kfp-launcher ConfigMap.
+                      The `kfp-launcher` component requires a ConfigMap to exist in
+                      the namespace where it runs (i.e. the namespace where pipelines
+                      run). This ConfigMap contains object storage configuration,
+                      as well as pipeline root (object store root path where artifacts
+                      will be uploaded) configuration. Currently this ConfigMap *must*
+                      be named "kfp-launcher". We currently deploy a default copy
+                      of the kfp-launcher ConfigMap via DSPO, but a user may want
+                      to provide their own ConfigMap configuration, so that they can
+                      specify multiple object storage sources and paths.
+                    type: string
                   customServerConfigMap:
                     description: CustomServerConfig is a custom config file that you
                       can provide for the api server to use instead.

--- a/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
+++ b/config/internal/apiserver/default/kfp_launcher_config.yaml.tmpl
@@ -1,5 +1,8 @@
 apiVersion: v1
 data:
+  {{ if .APIServer.CustomKfpLauncherConfigMap }}
+  {{.CustomKfpLauncherConfigMapData}}
+  {{ else }}
   {{ if .ObjectStorageConnection.BasePath }}
   defaultPipelineRoot: s3://{{.ObjectStorageConnection.Bucket}}/{{.ObjectStorageConnection.BasePath}}
   {{ else }}
@@ -13,6 +16,7 @@ data:
         secretName: {{.ObjectStorageConnection.CredentialsSecret.SecretName}}
         accessKeyKey: {{.ObjectStorageConnection.CredentialsSecret.AccessKey}}
         secretKeyKey: {{.ObjectStorageConnection.CredentialsSecret.SecretKey}}
+  {{ end }}
 kind: ConfigMap
 metadata:
   name: kfp-launcher

--- a/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
+++ b/config/samples/v2/dspa-all-fields/dspa_all_fields.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   dspVersion: v2
   apiServer:
+    customKfpLauncherConfigMap: configmapname
     deploy: true
     enableSamplePipeline: true
     image: quay.io/opendatahub/ds-pipelines-api-server:latest

--- a/controllers/testutil/util.go
+++ b/controllers/testutil/util.go
@@ -256,3 +256,17 @@ func CreateDSPAWithAPIServerPodtoPodTlsEnabled() *dspav1alpha1.DataSciencePipeli
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+func CreateDSPAWithCustomKfpLauncherConfigMap(configMapName string) *dspav1alpha1.DataSciencePipelinesApplication {
+	dspa := CreateEmptyDSPA()
+	dspa.Spec.DSPVersion = "v2"
+	// required, or we get an error because OCP certs aren't found
+	dspa.Spec.PodToPodTLS = boolPtr(false)
+	// required, or we get an error because this is required in v2
+	dspa.Spec.MLMD.Deploy = true
+	dspa.Spec.APIServer = &dspav1alpha1.APIServer{
+		Deploy:                     true,
+		CustomKfpLauncherConfigMap: configMapName,
+	}
+	return dspa
+}


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-4528

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Allow the user to fully replace the `data` contents of the kfp-launcher ConfigMap. The `kfp-launcher` component requires a ConfigMap to exist in the namespace where it runs (i.e. the namespace where pipelines run). This ConfigMap contains object storage configuration, as well as pipeline root (object store root path where artifacts will be uploaded) configuration. Currently this ConfigMap *must* be named "kfp-launcher". We currently deploy a default copy of the kfp-launcher ConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration, so that they can specify multiple object storage sources and paths.

Add a `CustomKfpLauncherConfigMap` parameter to DSPA.ApiServer. When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes will be fully replaced with the `data` contents of the ConfigMap specified here.

Fixes: https://issues.redhat.com/browse/RHOAIENG-4528


## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

login to openshift
$ oc login --token=sha256~jMYSUPERSECRETTOKEN --server=https://api.greg-1234.bd9q.p3.openshiftapps.com:443

make a new project for dspo to be deployed
$ oc new-project dspo

check out the PR
$ gh pr checkout 681

deploy it using the pre-built image
$ make deploy IMG="quay.io/opendatahub/data-science-pipelines-operator:pr-681" OPERATOR_NS=dspo

wait a bit for the deployment to finish, and make sure it's up

![Screenshot from 2024-08-05 16-36-18](https://github.com/user-attachments/assets/059cb442-9d44-4bcd-8dfd-e5b94e26c1c6)

make a new project to deploy a DSPA into
![Screenshot from 2024-08-05 16-37-32](https://github.com/user-attachments/assets/42ae49aa-4fed-4625-9382-ae39de5f11c4)

first, create a ConfigMap to copy data from (click the plus button at the top). 
![Screenshot from 2024-08-05 16-38-10](https://github.com/user-attachments/assets/6144a70a-2ec0-48fc-8edc-07c1db615dd9)

Example: 

```
kind: ConfigMap
apiVersion: v1
metadata:
  name: my-custom-kfp-launcher
  namespace: dspa1
data:
  defaultPipelineRoot: 's3://some-path'
  greg: isCool
  hey: |
    - what: isUp
```

Here's another more complex example (don't have screenshots for this one, but it should work the same)
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: my-custom-kfp-launcher
  namespace: dspa1
data:
  defaultPipelineRoot: s3://mlpipeline/special/location
  providers: |-
    s3:
      default:
        endpoint: s3.amazonaws.com
        disableSSL: false
        region: us-east-2
        credentials:
          fromEnv: true
    gs:
      default:
        credentials:
          fromEnv: false
          secretRef:
            secretName: your-k8s-secret
            tokenKey: some-key-1
```

![Screenshot from 2024-08-05 16-39-19](https://github.com/user-attachments/assets/673e2812-31f9-40fb-b63f-99d9ddec6104)

deploy the DSPA, also using the plus button. Don't forget to tell it about your new ConfigMap --

notice the `customKfpLauncherConfigMap: my-custom-kfp-launcher` line!

```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: dspa1
spec:
  dspVersion: v2
  apiServer:
    image: "quay.io/opendatahub/ds-pipelines-api-server:latest"
    argoDriverImage: "quay.io/opendatahub/ds-pipelines-driver:latest"
    argoLauncherImage: "quay.io/opendatahub/ds-pipelines-launcher:latest"
    customKfpLauncherConfigMap: my-custom-kfp-launcher
  persistenceAgent:
    image: "quay.io/opendatahub/ds-pipelines-persistenceagent:latest"
  scheduledWorkflow:
    image: "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest"
  mlmd:  
    deploy: true  # Optional component
    grpc:
      image: "quay.io/opendatahub/mlmd-grpc-server:latest"
    envoy:
      image: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.9-2"
  mlpipelineUI:
    deploy: true  # Optional component 
    image: "quay.io/opendatahub/ds-pipelines-frontend:latest"
  objectStorage:
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
```

![Screenshot from 2024-08-05 16-40-54](https://github.com/user-attachments/assets/894cd788-b296-4b72-8a0b-b71eabe6bda3)

wait a bit for DSPO to reconcile the new DSPA … once you start to see pods come up, should be good

![Screenshot from 2024-08-05 16-41-25](https://github.com/user-attachments/assets/857cf26b-570c-4c5a-a81d-9ec6f27ba040)

then check the kfp-launcher ConfigMap. It's data section should look like what you put in the my-custom-kfp-launcher ConfigMap

![Screenshot from 2024-08-05 16-42-11](https://github.com/user-attachments/assets/1e64471f-5a05-4a15-881d-6688ca57078e)

![Screenshot from 2024-08-05 16-42-25](https://github.com/user-attachments/assets/74526d9a-31ab-46b2-9375-7983396ddb2b)

Now delete the DSPA and redeploy it, but this time leave out the `customKfpLauncherConfigMap: my-custom-kfp-launcher` line from the DSPA. The kfp-launcher ConfigMap should now look how it usually does.

![Screenshot from 2024-08-05 16-55-07](https://github.com/user-attachments/assets/5c235d2e-23b8-47cd-9549-0fa767f3d8ac)

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
