### PR TITLE
Added MLMD GRPC Server Network Policy

### DIFF
--- a/config/internal/ml-metadata/metadata-grpc.networkpolicy.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-grpc.networkpolicy.yaml.tmpl
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ds-pipeline-metadata-grpc-{{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: ds-pipeline-metadata-grpc-{{ .Name }}
+      component: data-science-pipelines
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+      from:
+        - podSelector:
+            matchLabels:
+              pipelines.kubeflow.org/v2_component: 'true'
+        - podSelector:
+           matchLabels:
+             app: ds-pipeline-metadata-envoy-{{.Name}}
+             component: data-science-pipelines
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-10994](https://issues.redhat.com/browse/RHOAIENG-10994)

## Description of your changes:
 Added a network policy for MLMD GRPC Server.

## Testing instructions

-  Deploy DSPO, create a dspa instance and verify if a network policy gets created for GRPC , eg. ds-pipeline-metadata-grpc-myproject.
-  Create a pipeline run to verify if it works properly.
-  Execute the below curl command from ds-pipeline-metadata-envoy-sample-myproject , it should connect successfully.
    ```curl -v ds-pipeline-metadata-grpc-myproject.<namespace>.svc.cluster.local:8080 ```
- Execution of  the same curl command from any other pod other than ds-pipeline-metadata-grpc or the driver/launcher pods should time out.
## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
