### PR TITLE
make mlmd grpc NP more permissive

### DIFF
--- a/config/internal/ml-metadata/metadata-grpc.networkpolicy.yaml.tmpl
+++ b/config/internal/ml-metadata/metadata-grpc.networkpolicy.yaml.tmpl
@@ -18,7 +18,6 @@ spec:
               pipelines.kubeflow.org/v2_component: 'true'
         - podSelector:
            matchLabels:
-             app: ds-pipeline-metadata-envoy-{{.Name}}
              component: data-science-pipelines
   policyTypes:
     - Ingress


### PR DESCRIPTION
pipeline server also needs to be able to communicate with mlmd, making this NP more permissible to avoid any other unforseen issues, this will allow all dsp component pods to communicate with mlmd grpc server