### PR TITLE
add kuberoot-ca to sample

### DIFF
--- a/config/samples/v2/dspa-simple/dspa_simple.yaml
+++ b/config/samples/v2/dspa-simple/dspa_simple.yaml
@@ -6,6 +6,9 @@ spec:
   dspVersion: v2
   apiServer:
     enableSamplePipeline: true
+    cABundle:
+      configMapKey: ca.crt
+      configMapName: kube-root-ca.crt
   objectStorage:
     # Need to enable this for artifact download links to work
     # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true


### PR DESCRIPTION
This is needed when `enableExternalRoute=true` because the dev minio is behind a re-encrypt route and, on a self-signed ocp cluster, will serve certs signed by ocp network operator, which requires the client to have the kuberoot ca trust