### PR TITLE
Remove containerRuntimeExecutor key/value for WC ConfigMap

### DIFF
--- a/config/internal/workflow-controller/configmap.yaml.tmpl
+++ b/config/internal/workflow-controller/configmap.yaml.tmpl
@@ -36,6 +36,5 @@ data:
       secretKeySecret:
         name: "{{.ObjectStorageConnection.CredentialsSecret.SecretName}}"
         key: "{{.ObjectStorageConnection.CredentialsSecret.SecretKey}}"
-  containerRuntimeExecutor: emissary  # TODO
   executor: |
     imagePullPolicy: IfNotPresent  # TODO


### PR DESCRIPTION
- config option is deprecated as of Argo 3.4 and will break WC startup

## The issue resolved by this Pull Request:
Resolves [RHOAIENG-11816](https://issues.redhat.com/browse/RHOAIENG-11816)

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
- Deploy DSPO and a simple DSPA using a RHOAI v2.13+ image
- Ensure WorkflowController comes up
- Check the `ds-pipeline-workflow-controller-{{.Name}}` ConfigMap in DSPA namespace and ensure `containerRuntimeExecutor` key no longer exists

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
