### PR TITLE
Updated mariadb to serve over tls

### DIFF
--- a/config/internal/mariadb/default/service.yaml.tmpl
+++ b/config/internal/mariadb/default/service.yaml.tmpl
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: mariadb-{{.Name}}
   namespace: {{.Namespace}}
+  {{ if .PodToPodTLS }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ds-pipelines-mariadb-tls-{{.Name}}
+  {{ end }}
   labels:
     app: mariadb-{{.Name}}
     component: data-science-pipelines

--- a/config/internal/mariadb/default/tls-config.yaml.tmpl
+++ b/config/internal/mariadb/default/tls-config.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ds-pipelines-mariadb-tls-config-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: mariadb-{{.Name}}
+    component: data-science-pipelines
+data:
+  mariadb-tls-config.cnf: |
+    [mariadb]
+    ssl_cert = /.mariadb/certs/tls.crt
+    ssl_key = /.mariadb/certs/tls.key

--- a/controllers/database.go
+++ b/controllers/database.go
@@ -44,6 +44,7 @@ var mariadbTemplates = []string{
 	"mariadb/default/service.yaml.tmpl",
 	"mariadb/default/mariadb-sa.yaml.tmpl",
 	"mariadb/default/networkpolicy.yaml.tmpl",
+	"mariadb/default/tls-config.yaml.tmpl",
 }
 
 func tLSClientConfig(pems [][]byte) (*cryptoTls.Config, error) {

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -325,6 +325,9 @@ func (p *DSPAParams) SetupDBParams(ctx context.Context, dsp *dspa.DataSciencePip
 		tlsParams := config.DBExtraParams{
 			"tls": "false",
 		}
+		if p.PodToPodTLS {
+			tlsParams["tls"] = "true"
+		}
 		dbExtraParams, err := config.GetDefaultDBExtraParams(tlsParams, log)
 		if err != nil {
 			log.Error(err, "Unexpected error encountered while retrieving DBExtraparams")

--- a/controllers/testdata/declarative/case_8/expected/created/mariadb_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/mariadb_deployment.yaml
@@ -2,36 +2,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mariadb-{{.Name}}
-  namespace: {{.Namespace}}
+  name: mariadb-testdsp8
+  namespace: default
   labels:
-    app: mariadb-{{.Name}}
+    app: mariadb-testdsp8
     component: data-science-pipelines
-    dspa: {{.Name}}
+    dspa: testdsp8
 spec:
   strategy:
-    # Need this since backing PVC is ReadWriteOnce,
-    # which creates resource lock condition in default
-    # Rolling strategy
-    type: Recreate
+    type: Recreate  # Need this since backing PVC is ReadWriteOnce, which creates resource lock condition in default Rolling strategy
   selector:
     matchLabels:
-      app: mariadb-{{.Name}}
+      app: mariadb-testdsp8
       component: data-science-pipelines
-      dspa: {{.Name}}
+      dspa: testdsp8
   template:
     metadata:
       labels:
-        app: mariadb-{{.Name}}
+        app: mariadb-testdsp8
         component: data-science-pipelines
-        dspa: {{.Name}}
+        dspa: testdsp8
     spec:
-      serviceAccountName: ds-pipelines-mariadb-sa-{{.Name}}
       containers:
         - name: mariadb
-          image: {{.MariaDB.Image}}
+          image: mariadb:test8
           ports:
             - containerPort: 3306
+              protocol: TCP
           readinessProbe:
             exec:
               command:
@@ -56,59 +53,45 @@ spec:
             timeoutSeconds: 1
           env:
             - name: MYSQL_USER
-              value: "{{.DBConnection.Username}}"
+              value: "mlpipeline"
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: "{{.DBConnection.CredentialsSecret.Key}}"
-                  name: "{{.DBConnection.CredentialsSecret.Name}}"
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp8"
             - name: MYSQL_DATABASE
-              value: "{{.DBConnection.DBName}}"
+              value: "mlpipeline"
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
           resources:
-            {{ if .MariaDB.Resources.Requests }}
             requests:
-              {{ if .MariaDB.Resources.Requests.CPU }}
-              cpu: {{.MariaDB.Resources.Requests.CPU}}
-              {{ end }}
-              {{ if .MariaDB.Resources.Requests.Memory }}
-              memory: {{.MariaDB.Resources.Requests.Memory}}
-              {{ end }}
-            {{ end }}
-            {{ if .MariaDB.Resources.Limits }}
+              cpu: 300m
+              memory: 800Mi
             limits:
-              {{ if .MariaDB.Resources.Limits.CPU }}
-              cpu: {{.MariaDB.Resources.Limits.CPU}}
-              {{ end }}
-              {{ if .MariaDB.Resources.Limits.Memory }}
-              memory: {{.MariaDB.Resources.Limits.Memory}}
-              {{ end }}
-            {{ end }}
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: mariadb-persistent-storage
               mountPath: /var/lib/mysql
-            {{ if .PodToPodTLS }}
             - name: mariadb-tls
               mountPath: /.mariadb/certs
             - name: mariadb-tls-config
               mountPath: /etc/my.cnf.d/mariadb-tls-config.cnf
               subPath: mariadb-tls-config.cnf
-            {{ end }}
       volumes:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
-            claimName: mariadb-{{.Name}}
-        {{ if .PodToPodTLS }}
+            claimName: mariadb-testdsp8
         - name: mariadb-tls
           secret:
-            secretName: ds-pipelines-mariadb-tls-{{.Name}}
+            secretName: ds-pipelines-mariadb-tls-testdsp8
             items:
               - key: tls.crt
                 path: tls.crt
               - key: tls.key
                 path: tls.key
+            defaultMode: 420
         - name: mariadb-tls-config
           configMap:
-            name: ds-pipelines-mariadb-tls-config-{{.Name}}
-        {{ end }}
+            name: ds-pipelines-mariadb-tls-config-testdsp8
+            defaultMode: 420


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #[RHOAIENG-4972](https://issues.redhat.com//browse/RHOAIENG-4972)

## Description of your changes:

- Updated MariaDB config to server over TLS.
- Added the oc annotation to generate the certs.
- Added a config map with the ssl info.

## Testing instructions

- Deploy DSPO and the dspa using the below yaml file for two scenarios. After deployment, verify that the health 
checks are successful.
- Create a pipeline run and ensure that it completes successfully.
- Execute the following command inside the MariaDB pod terminal to verify that the TLS setup is correctly configured.
 ```
 mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h 127.0.0.1 -D $MYSQL_DATABASE
    
 MariaDB [mlpipeline]> SHOW GLOBAL VARIABLES LIKE 'have_ssl';
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| have_ssl      | YES   |
+---------------+-------+
1 row in set (0.001 sec)
```
<details>
  <summary>TLS Enabled</summary>

1. Deploy the following DSPA
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  podToPodTLS: true
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  objectStorage:   
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'  
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```
</details>

<details>
  <summary>TLS Disabled</summary>

1. Deploy the following DSPA
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  podToPodTLS: false
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  objectStorage:  
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'  
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```
</details>

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
