### PR TITLE
Removed imagePullPolicy: IfNotPresent

### DIFF
--- a/.github/resources/minio/deployment.yaml
+++ b/.github/resources/minio/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           ports:
             - containerPort: 9000
               protocol: TCP
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           volumeMounts:
             - name: data
               mountPath: /data

--- a/.github/resources/pypiserver/base/pypiserver.yaml
+++ b/.github/resources/pypiserver/base/pypiserver.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - image: "quay.io/harshad16/pypi-server"
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: pypi-server
           command:
             - pypi-server

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -176,7 +176,7 @@ spec:
               value: "{{.APIServer.TerminateStatus}}"
             {{ end }}
           image: {{.APIServer.Image}}
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/config/internal/mlpipelines-ui/deployment.yaml.tmpl
+++ b/config/internal/mlpipelines-ui/deployment.yaml.tmpl
@@ -79,7 +79,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: {{.MlPipelineUI.Image}}
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             httpGet:
               port: 3000

--- a/config/internal/persistence-agent/deployment.yaml.tmpl
+++ b/config/internal/persistence-agent/deployment.yaml.tmpl
@@ -45,7 +45,7 @@ spec:
               value: "/etc/pki/tls/certs:/var/run/secrets/kubernetes.io/serviceaccount/"
             {{ end }}
           image: "{{.PersistenceAgent.Image}}"
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/config/internal/scheduled-workflow/deployment.yaml.tmpl
+++ b/config/internal/scheduled-workflow/deployment.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: "{{.ScheduledWorkflow.Image}}"
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/config/internal/workflow-controller/configmap.yaml.tmpl
+++ b/config/internal/workflow-controller/configmap.yaml.tmpl
@@ -38,4 +38,4 @@ data:
         key: "{{.ObjectStorageConnection.CredentialsSecret.SecretKey}}"
   containerRuntimeExecutor: emissary  # TODO
   executor: |
-    imagePullPolicy: IfNotPresent  # TODO
+    # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting  # TODO

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
         - /home/config
         image: $(IMAGES_DSPO)
         name: manager
-        imagePullPolicy: Always
+        # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
         env:
           # Env vars are prioritized over --config
           - name: IMAGES_APISERVER

--- a/config/samples/v2/custom-workflow-controller-config/custom-workflow-controller-configmap.yaml
+++ b/config/samples/v2/custom-workflow-controller-config/custom-workflow-controller-configmap.yaml
@@ -27,7 +27,7 @@ data:
         key: "secretkey"
   containerRuntimeExecutor: emissary
   executor: |
-    imagePullPolicy: IfNotPresent  # TODO
+    # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting  # TODO
 kind: ConfigMap
 metadata:
   name: custom-workflow-controller-configmap

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TERMINATE_STATUS
               value: "Cancelled"
           image: api-server:test0
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_0/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: persistenceagent:test0
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/controllers/testdata/declarative/case_0/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/scheduled-workflow_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: scheduledworkflow:test0
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TERMINATE_STATUS
               value: "Cancelled"
           image: api-server:test2
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/mlpipelines-ui_deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: frontend:test2
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             exec:
               command:

--- a/controllers/testdata/declarative/case_2/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: persistenceagent:test2
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/controllers/testdata/declarative/case_2/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/scheduled-workflow_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: scheduledworkflow:test2
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TERMINATE_STATUS
               value: "Cancelled"
           image: api-server:test3
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TERMINATE_STATUS
               value: "Cancelled"
           image: this-apiserver-image-from-cr-should-be-used:test4
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           volumeMounts:

--- a/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/mlpipelines-ui_deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: this-frontend-image-from-cr-should-be-used:test4
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             exec:
               command:

--- a/controllers/testdata/declarative/case_4/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: this-persistenceagent-image-from-cr-should-be-used:test4
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/controllers/testdata/declarative/case_4/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/scheduled-workflow_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: this-scheduledworkflow-image-from-cr-should-be-used:test4
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -117,7 +117,7 @@ spec:
             - name: TERMINATE_STATUS
               value: "Cancelled"
           image: api-server:test5
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/mlpipelines-ui_deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: frontend:test5
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             exec:
               command:

--- a/controllers/testdata/declarative/case_5/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: persistenceagent:test5
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/controllers/testdata/declarative/case_5/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/scheduled-workflow_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: scheduledworkflow:test5
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "test6"
           image: api-server:test6
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/apiserver_deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
           image: api-server:test7
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/mlpipelines-ui_deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: frontend:test7
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             exec:
               command:

--- a/controllers/testdata/declarative/case_7/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: Workflow
           image: persistenceagent:test7
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent

--- a/controllers/testdata/declarative/case_7/expected/created/scheduled-workflow_deployment.yaml
+++ b/controllers/testdata/declarative/case_7/expected/created/scheduled-workflow_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: EXECUTIONTYPE
               value: PipelineRun
           image: scheduledworkflow:test7
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-scheduledworkflow
           command:
             - controller

--- a/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
           image: api-server:test8
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_9/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_9/expected/created/apiserver_deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
           image: api-server:test9
-          imagePullPolicy: Always
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server
           command: ['/bin/apiserver']
           args:

--- a/controllers/testdata/declarative/case_9/expected/created/mlpipelines-ui_deployment.yaml
+++ b/controllers/testdata/declarative/case_9/expected/created/mlpipelines-ui_deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DISABLE_GKE_METADATA
               value: 'true'
           image: frontend:test9
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           livenessProbe:
             exec:
               command:

--- a/controllers/testdata/declarative/case_9/expected/created/persistence-agent_deployment.yaml
+++ b/controllers/testdata/declarative/case_9/expected/created/persistence-agent_deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: EXECUTIONTYPE
               value: Workflow
           image: persistenceagent:test9
-          imagePullPolicy: IfNotPresent
+          # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-persistenceagent
           command:
             - persistence_agent


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHOAIENG-12336

This PR changes `imagePullPolicy` for [default](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting) instead of `IfNotPresent`.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
Deploy the `simple-dspa` sample and run the pipeline. The run must succeed.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
