### PR TITLE
Bumped actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-prs-trigger.yaml
+++ b/.github/workflows/build-prs-trigger.yaml
@@ -2,6 +2,7 @@ name: Trigger build images for PRs
 on:
   pull_request:
     paths:
+      - .github/workflows/build-prs-trigger.yaml
       - go.mod
       - go.sum
       - controllers/**
@@ -28,7 +29,7 @@ jobs:
           echo ${{ github.event.pull_request.state }} >> ./pr/pr_state
           echo ${{ github.event.pull_request.head.sha }} >> ./pr/head_sha
           echo ${{ github.event.action }} >> ./pr/event_action
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/

--- a/.github/workflows/release_trigger.yaml
+++ b/.github/workflows/release_trigger.yaml
@@ -22,7 +22,7 @@ jobs:
           PR_STATE: ${{ github.event.pull_request.state }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./.github/scripts/release_trigger/upload-data.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
This PR updates `upload-artifact` action due to deprecation. The current version [is blocking PRs](https://github.com/opendatahub-io/data-science-pipelines-operator/actions/runs/10905399912/job/30264134931?pr=683).
Deprecation notice: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
The `Trigger build images for PRs / upload-data (pull_request)` workflow should pass.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
