### PR TITLE
Allow DSPO test suite be running with RHOAI

### DIFF
--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -28,13 +28,11 @@ RESOURCES_DIR_CRD="${GIT_WORKSPACE}/.github/resources"
 OPENDATAHUB_NAMESPACE="opendatahub"
 RESOURCES_DIR_PYPI="${GIT_WORKSPACE}/.github/resources/pypiserver/base"
 
-# Functions
 get_dspo_image() {
   if [ "$REGISTRY_ADDRESS" = "" ]; then
       echo "REGISTRY_ADDRESS variable not defined." && exit 1
   fi
   local image="${REGISTRY_ADDRESS}/data-science-pipelines-operator"
-  echo "Using $image for DSPO image"
   echo $image
 }
 
@@ -47,10 +45,10 @@ apply_crd() {
 }
 
 build_image() {
-  echo "---------------------------------"
-  echo "Build image"
-  echo "---------------------------------"
   IMG=$(get_dspo_image)
+  echo "---------------------------------"
+  echo "Building image: $IMG"
+  echo "---------------------------------"
   ( cd $GIT_WORKSPACE && make podman-build -e IMG="$IMG" )
 }
 
@@ -69,10 +67,10 @@ deploy_argo_lite() {
 }
 
 deploy_dspo() {
-  echo "---------------------------------"
-  echo "Deploy DSPO"
-  echo "---------------------------------"
   IMG=$(get_dspo_image)
+  echo "---------------------------------"
+  echo "Deploying DSPO: $IMG"
+  echo "---------------------------------"
   ( cd $GIT_WORKSPACE && make podman-push -e IMG="$IMG" )
   ( cd $GIT_WORKSPACE && make deploy-kind -e IMG="$IMG" )
 }

--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -8,15 +8,11 @@ set -e
 
 # ------------------------------------
 # Env vars
+echo "GIT_WORKSPACE=$GIT_WORKSPACE"
 if [ "$GIT_WORKSPACE" = "" ]; then
-    echo "GIT_WORKSPACE variable not defined. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit
+    echo "GIT_WORKSPACE variable not defined. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit 1
 fi
 
-if [ "$REGISTRY_ADDRESS" = "" ]; then
-    echo "REGISTRY_ADDRESS variable not defined." && exit
-fi
-
-IMAGE_REPO_DSPO="data-science-pipelines-operator"
 DSPA_NAMESPACE="test-dspa"
 DSPA_EXTERNAL_NAMESPACE="dspa-ext"
 MINIO_NAMESPACE="test-minio"
@@ -30,13 +26,19 @@ DSPA_PATH="${GIT_WORKSPACE}/tests/resources/dspa-lite.yaml"
 DSPA_EXTERNAL_PATH="${GIT_WORKSPACE}/tests/resources/dspa-external-lite.yaml"
 CONFIG_DIR="${GIT_WORKSPACE}/config"
 RESOURCES_DIR_CRD="${GIT_WORKSPACE}/.github/resources"
-DSPO_IMAGE="${REGISTRY_ADDRESS}/data-science-pipelines-operator"
 OPENDATAHUB_NAMESPACE="opendatahub"
 RESOURCES_DIR_PYPI="${GIT_WORKSPACE}/.github/resources/pypiserver/base"
 # ------------------------------------
 
 # ------------------------------------
 # Functions
+get_dspo_image() {
+  if [ "$REGISTRY_ADDRESS" = "" ]; then
+      echo "REGISTRY_ADDRESS variable not defined." && exit 1
+  fi
+  echo "${REGISTRY_ADDRESS}/data-science-pipelines-operator"
+}
+
 apply_crd() {
   echo "---------------------------------"
   echo "# Apply OCP CRDs"
@@ -49,7 +51,8 @@ build_image() {
   echo "---------------------------------"
   echo "Build image"
   echo "---------------------------------"
-  ( cd $GIT_WORKSPACE && make podman-build -e IMG="${DSPO_IMAGE}" )
+  IMG=$(get_dspo_image)
+  ( cd $GIT_WORKSPACE && make podman-build -e IMG="$IMG" )
 }
 
 create_opendatahub_namespace() {
@@ -70,57 +73,55 @@ deploy_dspo() {
   echo "---------------------------------"
   echo "Deploy DSPO"
   echo "---------------------------------"
-  ( cd $GIT_WORKSPACE && make podman-push -e IMG="${DSPO_IMAGE}" )
-  ( cd $GIT_WORKSPACE && make deploy-kind -e IMG="${DSPO_IMAGE}" )
+  IMG=$(get_dspo_image)
+  ( cd $GIT_WORKSPACE && make podman-push -e IMG="$IMG" )
+  ( cd $GIT_WORKSPACE && make deploy-kind -e IMG="$IMG" )
 }
 
-create_minio_namespace() {
+deploy_minio() {
   echo "---------------------------------"
   echo "Create Minio Namespace"
   echo "---------------------------------"
   kubectl create namespace $MINIO_NAMESPACE
-}
-
-deploy_minio() {
   echo "---------------------------------"
   echo "Deploy Minio"
   echo "---------------------------------"
   ( cd "${GIT_WORKSPACE}/.github/resources/minio" && kustomize build . | kubectl -n $MINIO_NAMESPACE apply -f - )
 }
 
-create_mariadb_namespace() {
+deploy_mariadb() {
   echo "---------------------------------"
   echo "Create MariaDB Namespace"
   echo "---------------------------------"
   kubectl create namespace $MARIADB_NAMESPACE
-}
-
-deploy_mariadb() {
   echo "---------------------------------"
   echo "Deploy MariaDB"
   echo "---------------------------------"
   ( cd "${GIT_WORKSPACE}/.github/resources/mariadb" && kustomize build . | kubectl -n $MARIADB_NAMESPACE apply -f - )
 }
 
-create_pypiserver_namespace() {
+deploy_pypi_server() {
   echo "---------------------------------"
   echo "Create Pypiserver Namespace"
   echo "---------------------------------"
   kubectl create namespace $PYPISERVER_NAMESPACE
-}
-
-deploy_pypi_server() {
   echo "---------------------------------"
   echo "Deploy pypi-server"
   echo "---------------------------------"
   ( cd "${GIT_WORKSPACE}/.github/resources/pypiserver/base" && kustomize build . | kubectl -n $PYPISERVER_NAMESPACE apply -f - )
 }
 
-wait_for_dependencies() {
+wait_for_dspo_dependencies() {
   echo "---------------------------------"
-  echo "Wait for Dependencies (DSPO, Minio, Mariadb, Pypi server)"
+  echo "Wait for DSPO Dependencies"
   echo "---------------------------------"
   kubectl wait -n $OPENDATAHUB_NAMESPACE --timeout=60s --for=condition=Available=true deployment data-science-pipelines-operator-controller-manager
+}
+
+wait_for_dependencies() {
+  echo "---------------------------------"
+  echo "Wait for Dependencies (Minio, Mariadb, Pypi server)"
+  echo "---------------------------------"
   kubectl wait -n $MARIADB_NAMESPACE --timeout=60s --for=condition=Available=true deployment mariadb
   kubectl wait -n $MINIO_NAMESPACE --timeout=60s --for=condition=Available=true deployment minio
   kubectl wait -n $PYPISERVER_NAMESPACE --timeout=60s --for=condition=Available=true deployment pypi-server
@@ -151,7 +152,7 @@ apply_mariadb_minio_secrets_configmaps_external_namespace() {
   echo "---------------------------------"
   echo "Apply MariaDB and Minio Secrets and Configmaps in the External Namespace"
   echo "---------------------------------"
-  ( cd "${GIT_WORKSPACE}/.github/resources/external-pre-reqs" && kustomize build . |  oc -n $DSPA_EXTERNAL_NAMESPACE apply -f - )
+  ( cd "${GIT_WORKSPACE}/.github/resources/external-pre-reqs" && kustomize build . |  kubectl -n $DSPA_EXTERNAL_NAMESPACE apply -f - )
 }
 
 apply_pip_server_configmap() {
@@ -165,21 +166,27 @@ run_tests() {
   echo "---------------------------------"
   echo "Run tests"
   echo "---------------------------------"
-  ( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${DSPA_NAMESPACE} DSPAPATH=${DSPA_PATH} )
+  ( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(kubectl whoami --show-server) DSPANAMESPACE=${DSPA_NAMESPACE} DSPAPATH=${DSPA_PATH} )
 }
 
 run_tests_dspa_external_connections() {
   echo "---------------------------------"
   echo "Run tests for DSPA with External Connections"
   echo "---------------------------------"
-  ( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(oc whoami --show-server) DSPANAMESPACE=${DSPA_EXTERNAL_NAMESPACE} DSPAPATH=${DSPA_EXTERNAL_PATH} )
+  ( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=$(kubectl whoami --show-server) DSPANAMESPACE=${DSPA_EXTERNAL_NAMESPACE} DSPAPATH=${DSPA_EXTERNAL_PATH} )
 }
 
-clean_up() {
+undeploy_kind_resources() {
   echo "---------------------------------"
   echo "Clean up"
   echo "---------------------------------"
   ( cd $GIT_WORKSPACE && make undeploy-kind )
+}
+
+remove_namespace_created_for_rhoai() {
+  kubectl delete projects $MINIO_NAMESPACE --now || true
+  kubectl delete projects $MARIADB_NAMESPACE --now || true
+  kubectl delete projects $PYPISERVER_NAMESPACE --now || true
 }
 
 run_kind_tests() {
@@ -188,11 +195,25 @@ run_kind_tests() {
   create_opendatahub_namespace
   deploy_argo_lite
   deploy_dspo
-  create_minio_namespace
   deploy_minio
-  create_mariadb_namespace
   deploy_mariadb
-  create_pypiserver_namespace
+  deploy_pypi_server
+  wait_for_dspo_dependencies
+  wait_for_dependencies
+  upload_python_packages_to_pypi_server
+  create_dspa_namespace
+  create_namespace_dspa_external_connections
+  apply_mariadb_minio_secrets_configmaps_external_namespace
+  apply_pip_server_configmap
+  run_tests
+  run_tests_dspa_external_connections
+  undeploy_kind_resources
+}
+
+run_rhoai_tests() {
+  remove_namespace_created_for_rhoai
+  deploy_minio
+  deploy_mariadb
   deploy_pypi_server
   wait_for_dependencies
   upload_python_packages_to_pypi_server
@@ -202,7 +223,6 @@ run_kind_tests() {
   apply_pip_server_configmap
   run_tests
   run_tests_dspa_external_connections
-  clean_up
 }
 # ------------------------------------
 
@@ -211,6 +231,9 @@ run_kind_tests() {
 case "$1" in
     --kind)
         run_kind_tests
+        ;;
+    --rhoai)
+        run_rhoai_tests
         ;;
     *)
         echo "Usage: $0 [--kind]"

--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -6,7 +6,6 @@
 
 set -e
 
-# ------------------------------------
 # Env vars
 echo "GIT_WORKSPACE=$GIT_WORKSPACE"
 if [ "$GIT_WORKSPACE" = "" ]; then
@@ -28,15 +27,15 @@ CONFIG_DIR="${GIT_WORKSPACE}/config"
 RESOURCES_DIR_CRD="${GIT_WORKSPACE}/.github/resources"
 OPENDATAHUB_NAMESPACE="opendatahub"
 RESOURCES_DIR_PYPI="${GIT_WORKSPACE}/.github/resources/pypiserver/base"
-# ------------------------------------
 
-# ------------------------------------
 # Functions
 get_dspo_image() {
   if [ "$REGISTRY_ADDRESS" = "" ]; then
       echo "REGISTRY_ADDRESS variable not defined." && exit 1
   fi
-  echo "${REGISTRY_ADDRESS}/data-science-pipelines-operator"
+  local image="${REGISTRY_ADDRESS}/data-science-pipelines-operator"
+  echo "Using $image for DSPO image"
+  echo $image
 }
 
 apply_crd() {
@@ -178,12 +177,15 @@ run_tests_dspa_external_connections() {
 
 undeploy_kind_resources() {
   echo "---------------------------------"
-  echo "Clean up"
+  echo "Clean up resources created for testing on kind"
   echo "---------------------------------"
   ( cd $GIT_WORKSPACE && make undeploy-kind )
 }
 
 remove_namespace_created_for_rhoai() {
+  echo "---------------------------------"
+  echo "Clean up resources created for testing on RHOAI"
+  echo "---------------------------------"
   kubectl delete projects $MINIO_NAMESPACE --now || true
   kubectl delete projects $MARIADB_NAMESPACE --now || true
   kubectl delete projects $PYPISERVER_NAMESPACE --now || true
@@ -224,9 +226,7 @@ run_rhoai_tests() {
   run_tests
   run_tests_dspa_external_connections
 }
-# ------------------------------------
 
-# ------------------------------------
 # Run
 case "$1" in
     --kind)
@@ -240,4 +240,3 @@ case "$1" in
         exit 1
         ;;
 esac
-# ------------------------------------

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -12,6 +12,7 @@ on:
       - tests/**
       - .github/resources/**
       - '.github/workflows/kind-integration.yml'
+      - '.github/scripts/tests/tests.sh'
       - Makefile
     types:
       - opened

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Dockerfile.cross
 __pycache__/
 *.py[cod]
 *$py.class
+.github/scripts/python_package_upload/


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Break down the solution for #[RHOAIENG-10212](https://issues.redhat.com//browse/RHOAIENG-10212) into smaller PRs to facilitate review.

## Description of your changes:
The goal of `test.sh --rhoai` is to be to run the DSPO test suite with a previous RHOAI installed.

## Testing instructions
* Have an OpenShift cluster with RHOAI installed and in the terminal do the following
* oc login ...
* export GIT_WORKSPACE=.....
* test.sh --rhoai

The output must be

```
--- PASS: TestIntegrationTestSuite (350.21s)
    --- PASS: TestIntegrationTestSuite/TestAPIServerDeployment (1.89s)
        --- PASS: TestIntegrationTestSuite/TestAPIServerDeployment/Should_successfully_fetch_pipelines (0.47s)
        --- PASS: TestIntegrationTestSuite/TestAPIServerDeployment/Should_successfully_upload_a_pipeline (0.91s)
        --- PASS: TestIntegrationTestSuite/TestAPIServerDeployment/Should_successfully_upload_a_pipeline_with_custom_pip_server (0.50s)
    --- PASS: TestIntegrationTestSuite/TestDSPADeployment (1.05s)
        --- PASS: TestIntegrationTestSuite/TestDSPADeployment/with_default_MariaDB_and_Minio (1.05s)
            --- PASS: TestIntegrationTestSuite/TestDSPADeployment/with_default_MariaDB_and_Minio/should_have_6_pods (0.45s)
            --- PASS: TestIntegrationTestSuite/TestDSPADeployment/with_default_MariaDB_and_Minio/should_have_a_ready_ds-pipeline-dspa-ext_deployment (0.30s)
            --- PASS: TestIntegrationTestSuite/TestDSPADeployment/with_default_MariaDB_and_Minio/should_have_a_ready_ds-pipeline-persistenceagent-dspa-ext_deployment (0.15s)
            --- PASS: TestIntegrationTestSuite/TestDSPADeployment/with_default_MariaDB_and_Minio/should_have_a_ready_ds-pipeline-scheduledworkflow-dspa-ext_deployment (0.15s)
    --- PASS: TestIntegrationTestSuite/TestFetchExperiments (0.15s)
        --- PASS: TestIntegrationTestSuite/TestFetchExperiments/Should_successfully_fetch_experiments (0.15s)
    --- PASS: TestIntegrationTestSuite/TestPipelineSuccessfulRun (327.14s)
        --- PASS: TestIntegrationTestSuite/TestPipelineSuccessfulRun/Should_create_a_Pipeline_Run (248.24s)
        --- PASS: TestIntegrationTestSuite/TestPipelineSuccessfulRun/Should_create_a_Pipeline_Run_using_custom_pip_server (78.90s)
PASS
ok  	github.com/opendatahub-io/data-science-pipelines-operator/tests	350.219s

```
## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
