### PR TITLE
Add support for using route or service as target endpoints in the test suite

### DIFF
--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -12,7 +12,7 @@ if [ "$GIT_WORKSPACE" = "" ]; then
     echo "GIT_WORKSPACE variable not defined. Should be the root of the source code. Example GIT_WORKSPACE=/home/dev/git/data-science-pipelines-operator" && exit 1
 fi
 
-CLEANUP=false
+CLEAN_INFRA=false
 K8SAPISERVERHOST=""
 DSPA_NAMESPACE="test-dspa"
 DSPA_EXTERNAL_NAMESPACE="dspa-ext"
@@ -232,8 +232,11 @@ while [ "$#" -gt 0 ]; do
       TARGET="rhoai"
       shift
       ;;
-    --cleanup)
-      CLEANUP=true
+    # The clean-infra option is helpful when rerunning tests on the same target environment, as it eliminates
+    # the need to manually delete the necessary infrastructure. By default, this setting is set to false.
+    # If true, before running the test, it delete the necessary infrastructure.
+    --clean-infra)
+      CLEAN_INFRA=true
       shift
       ;;
     --k8s-api-server-host)
@@ -249,7 +252,7 @@ while [ "$#" -gt 0 ]; do
     --dspa-namespace)
       shift
       if [[ -n "$1" ]]; then
-        DSPANAMESPACE="$1"
+        DSPA_NAMESPACE="$1"
         shift
       else
         echo "Error: --dspa-namespace requires a value"
@@ -269,10 +272,20 @@ while [ "$#" -gt 0 ]; do
     --dspa-path)
       shift
       if [[ -n "$1" ]]; then
-        DSPAPATH="$1"
+        DSPA_PATH="$1"
         shift
       else
         echo "Error: --dspa-path requires a value"
+        exit 1
+      fi
+      ;;
+    --external-dspa-path)
+      shift
+      if [[ -n "$1" ]]; then
+        DSPA_EXTERNAL_PATH="$1"
+        shift
+      else
+        echo "Error: --external-dspa-path requires a value"
         exit 1
       fi
       ;;
@@ -299,12 +312,12 @@ if [ "$K8SAPISERVERHOST" = "" ]; then
 fi
 
 if [ "$TARGET" = "kind" ]; then
-  if [ "$CLEANUP" = true ] ; then
+  if [ "$CLEAN_INFRA" = true ] ; then
       undeploy_kind_resources
   fi
   setup_kind_requirements
 elif [ "$TARGET" = "rhoai" ]; then
-  if [ "$CLEANUP" = true ] ; then
+  if [ "$CLEAN_INFRA" = true ] ; then
       remove_namespace_created_for_rhoai
   fi
   setup_rhoai_requirements

--- a/tests/dspa_v2_test.go
+++ b/tests/dspa_v2_test.go
@@ -52,8 +52,10 @@ func (suite *IntegrationTestSuite) TestDSPADeployment() {
 	suite.T().Run("with default MariaDB and Minio", func(t *testing.T) {
 		t.Run(fmt.Sprintf("should have %d pods", podCount), func(t *testing.T) {
 			podList := &corev1.PodList{}
+			// retrieve the running pods only, to allow for multiple reruns of  the test suite
 			listOpts := []client.ListOption{
 				client.InNamespace(suite.DSPANamespace),
+				client.MatchingFields{"status.phase": string(corev1.PodRunning)},
 			}
 			err := suite.Clientmgr.k8sClient.List(suite.Ctx, podList, listOpts...)
 			require.NoError(t, err)

--- a/tests/experiments_test.go
+++ b/tests/experiments_test.go
@@ -21,7 +21,6 @@ package integration
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,7 +28,7 @@ import (
 
 func (suite *IntegrationTestSuite) TestFetchExperiments() {
 	suite.T().Run("Should successfully fetch experiments", func(t *testing.T) {
-		response, err := http.Get(fmt.Sprintf("%s/apis/v2beta1/experiments", APIServerURL))
+		response, err := suite.Clientmgr.httpClient.Get(fmt.Sprintf("%s/apis/v2beta1/experiments", APIServerURL))
 		require.NoError(t, err, "Error fetching experiments")
 
 		responseData, err := ioutil.ReadAll(response.Body)

--- a/tests/pipeline_runs_test.go
+++ b/tests/pipeline_runs_test.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"net/http"
 	"testing"
 
 	TestUtil "github.com/opendatahub-io/data-science-pipelines-operator/tests/util"
@@ -34,13 +33,13 @@ func (suite *IntegrationTestSuite) TestPipelineSuccessfulRun() {
 	suite.T().Run("Should create a Pipeline Run", func(t *testing.T) {
 		// Retrieve Pipeline ID to create a new run
 		pipelineDisplayName := "[Demo] iris-training"
-		pipelineID, err := TestUtil.RetrievePipelineId(t, APIServerURL, pipelineDisplayName)
+		pipelineID, err := TestUtil.RetrievePipelineId(t, suite.Clientmgr.httpClient, APIServerURL, pipelineDisplayName)
 		require.NoError(t, err)
 		postUrl := fmt.Sprintf("%s/apis/v2beta1/runs", APIServerURL)
 		body := TestUtil.FormatRequestBody(t, pipelineID, pipelineDisplayName)
 		contentType := "application/json"
 		// Create a new run
-		response, err := http.Post(postUrl, contentType, bytes.NewReader(body))
+		response, err := suite.Clientmgr.httpClient.Post(postUrl, contentType, bytes.NewReader(body))
 		require.NoError(t, err)
 		responseData, err := io.ReadAll(response.Body)
 		responseString := string(responseData)
@@ -48,20 +47,20 @@ func (suite *IntegrationTestSuite) TestPipelineSuccessfulRun() {
 		require.NoError(t, err)
 		require.Equal(t, 200, response.StatusCode)
 
-		err = TestUtil.WaitForPipelineRunCompletion(t, APIServerURL)
+		err = TestUtil.WaitForPipelineRunCompletion(t, suite.Clientmgr.httpClient, APIServerURL)
 		require.NoError(t, err)
 	})
 
 	suite.T().Run("Should create a Pipeline Run using custom pip server", func(t *testing.T) {
 		// Retrieve Pipeline ID to create a new run
 		pipelineDisplayName := "Test pipeline run with custom pip server"
-		pipelineID, err := TestUtil.RetrievePipelineId(t, APIServerURL, pipelineDisplayName)
+		pipelineID, err := TestUtil.RetrievePipelineId(t, suite.Clientmgr.httpClient, APIServerURL, pipelineDisplayName)
 		require.NoError(t, err)
 		postUrl := fmt.Sprintf("%s/apis/v2beta1/runs", APIServerURL)
 		body := TestUtil.FormatRequestBody(t, pipelineID, pipelineDisplayName)
 		contentType := "application/json"
 		// Create a new run
-		response, err := http.Post(postUrl, contentType, bytes.NewReader(body))
+		response, err := suite.Clientmgr.httpClient.Post(postUrl, contentType, bytes.NewReader(body))
 		require.NoError(t, err)
 		responseData, err := io.ReadAll(response.Body)
 		responseString := string(responseData)
@@ -69,7 +68,7 @@ func (suite *IntegrationTestSuite) TestPipelineSuccessfulRun() {
 		require.NoError(t, err)
 		require.Equal(t, 200, response.StatusCode)
 
-		err = TestUtil.WaitForPipelineRunCompletion(t, APIServerURL)
+		err = TestUtil.WaitForPipelineRunCompletion(t, suite.Clientmgr.httpClient, APIServerURL)
 		require.NoError(t, err)
 	})
 }

--- a/tests/pipeline_test.go
+++ b/tests/pipeline_test.go
@@ -21,7 +21,6 @@ package integration
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"testing"
 
@@ -32,7 +31,7 @@ import (
 
 func (suite *IntegrationTestSuite) TestAPIServerDeployment() {
 	suite.T().Run("Should successfully fetch pipelines", func(t *testing.T) {
-		response, err := http.Get(fmt.Sprintf("%s/apis/v2beta1/pipelines", APIServerURL))
+		response, err := suite.Clientmgr.httpClient.Get(fmt.Sprintf("%s/apis/v2beta1/pipelines", APIServerURL))
 		require.NoError(t, err)
 
 		responseData, err := io.ReadAll(response.Body)
@@ -50,7 +49,7 @@ func (suite *IntegrationTestSuite) TestAPIServerDeployment() {
 		}
 		body, contentType := TestUtil.FormFromFile(t, vals)
 
-		response, err := http.Post(postUrl, contentType, body)
+		response, err := suite.Clientmgr.httpClient.Post(postUrl, contentType, body)
 		require.NoError(t, err)
 		responseData, err := io.ReadAll(response.Body)
 		responseString := string(responseData)
@@ -68,7 +67,7 @@ func (suite *IntegrationTestSuite) TestAPIServerDeployment() {
 		}
 		body, contentType := TestUtil.FormFromFile(t, vals)
 
-		response, err := http.Post(postUrl, contentType, body)
+		response, err := suite.Clientmgr.httpClient.Post(postUrl, contentType, body)
 		require.NoError(t, err)
 		responseData, err := io.ReadAll(response.Body)
 		responseString := string(responseData)

--- a/tests/resources/dspa-external.yaml
+++ b/tests/resources/dspa-external.yaml
@@ -1,0 +1,41 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: dspa-ext
+spec:
+  dspVersion: v2
+  podToPodTLS: true
+  apiServer:
+    deploy: true
+    enableOauth: true
+    enableSamplePipeline: true
+    cABundle:
+      configMapName: root-ca
+      configMapKey: public.crt
+  scheduledWorkflow:
+    deploy: true
+  persistenceAgent:
+    deploy: true
+  mlmd:
+    deploy: true
+  database:
+    customExtraParams: '{"tls":"true"}'
+    externalDB:
+      host: mariadb.test-mariadb.svc.cluster.local
+      port: "3306"
+      username: mlpipeline
+      pipelineDBName: mlpipeline
+      passwordSecret:
+        name: ds-pipeline-db-test
+        key: password
+  objectStorage:
+    externalStorage:
+      bucket: mlpipeline
+      host: minio.test-minio.svc.cluster.local
+      port: "9000"
+      region: us-east-2
+      s3CredentialsSecret:
+        accessKey: accesskey
+        secretKey: secretkey
+        secretName: minio
+      scheme: https

--- a/tests/resources/dspa.yaml
+++ b/tests/resources/dspa.yaml
@@ -1,0 +1,26 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: test-dspa
+spec:
+  dspVersion: v2
+  podToPodTLS: true
+  apiServer:
+    deploy: true
+    enableOauth: true
+    enableSamplePipeline: true
+    cABundle:
+      configMapName: nginx-tls-config
+      configMapKey: rootCA.crt
+  objectStorage:
+    minio:
+      deploy: true
+      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
+      pvcSize: 500Mi
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100m

--- a/tests/util/rest.go
+++ b/tests/util/rest.go
@@ -71,8 +71,8 @@ func FormFromFile(t *testing.T, form map[string]string) (*bytes.Buffer, string) 
 	return body, mp.FormDataContentType()
 }
 
-func RetrievePipelineId(t *testing.T, APIServerURL string, PipelineDisplayName string) (string, error) {
-	response, err := http.Get(fmt.Sprintf("%s/apis/v2beta1/pipelines", APIServerURL))
+func RetrievePipelineId(t *testing.T, httpClient http.Client, APIServerURL string, PipelineDisplayName string) (string, error) {
+	response, err := httpClient.Get(fmt.Sprintf("%s/apis/v2beta1/pipelines", APIServerURL))
 	require.NoError(t, err)
 	responseData, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func FormatRequestBody(t *testing.T, pipelineID string, PipelineDisplayName stri
 	return body
 }
 
-func WaitForPipelineRunCompletion(t *testing.T, APIServerURL string) error {
+func WaitForPipelineRunCompletion(t *testing.T, httpClient http.Client, APIServerURL string) error {
 	timeout := time.After(6 * time.Minute)
 	ticker := time.NewTicker(6 * time.Second)
 	defer ticker.Stop()
@@ -117,7 +117,7 @@ func WaitForPipelineRunCompletion(t *testing.T, APIServerURL string) error {
 			return fmt.Errorf("timed out waiting for pipeline run completion")
 		case <-ticker.C:
 			// Check the status of the pipeline run
-			status, err := CheckPipelineRunStatus(t, APIServerURL)
+			status, err := CheckPipelineRunStatus(t, httpClient, APIServerURL)
 			require.NoError(t, err)
 			switch status {
 			case "SUCCEEDED":
@@ -129,8 +129,8 @@ func WaitForPipelineRunCompletion(t *testing.T, APIServerURL string) error {
 	}
 }
 
-func CheckPipelineRunStatus(t *testing.T, APIServerURL string) (string, error) {
-	response, err := http.Get(fmt.Sprintf("%s/apis/v2beta1/runs", APIServerURL))
+func CheckPipelineRunStatus(t *testing.T, httpClient http.Client, APIServerURL string) (string, error) {
+	response, err := httpClient.Get(fmt.Sprintf("%s/apis/v2beta1/runs", APIServerURL))
 	require.NoError(t, err)
 	responseData, err := io.ReadAll(response.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves partially [RHOAIENG-10212](https://issues.redhat.com//browse/RHOAIENG-10212)

## Description of your changes:

This PR introduces enhancements to the test suite by allowing the use of either a route or a Kubernetes service as the target endpoint for interacting with the Data Science Pipelines Operator (DSPO).

1. **New `--endpointType` Flag**:
   - A new `--endpointType` flag is introduced in the test suite configuration, which specifies whether the test should use a Kubernetes service (`service`) or an OpenShift route (`route`) as the target endpoint for DSPO.
   
2. **Infrastructure Cleanup Option**:
   - The `--cleanup` flag is renamed to `--clean-infra`. This option allows automated cleanup of infrastructure before rerunning tests.

3. **Modifications in Test Scripts**:
   - Updated the shell scripts and Go test files to accommodate the new endpoint selection mechanism.
   - The HTTP client in the tests is now initialized with custom transport to support token-based authentication when necessary.
   - Various test functions now rely on the `Clientmgr.httpClient` to perform HTTP requests, decoupling from the standard Go `http` package.

4. **New Test Resources**:
   - Two new DSPA (Data Science Pipelines Application) YAML resources (`dspa.yaml` and `dspa-external.yaml`) are added for testing RHOAI.

5. **Test Case Improvements**:
   - Improved the pod listing logic by retrieving only running pods, ensuring the test suite can be rerun multiple times without issues.

## Testing instructions
No manual testing required.
* `kind` it is done by GHA
* `rhoai`: a new PR will be added soon to allow passing: `-endpointType` via `test.sh`. If you wish to test RHOAI ( please call me first ) do the following:
** Modify `Makefile` and append `-endpointType=route` in the `integrationtest`
** Checkout https://github.com/diegolovison/ods-ci/tree/e2e
** From your local machine:
*** `oc login ....`
*** `sh run_robot_test.sh --set-urls-variables true --extra-robot-args '-L DEBUG -i ODS-2632' --skip-oclogin`

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
