### PR TITLE
fix: add NetworkPolicy for DSP apiserver pod self traffic

### DIFF
--- a/config/internal/common/argo/policy.yaml.tmpl
+++ b/config/internal/common/argo/policy.yaml.tmpl
@@ -31,6 +31,10 @@ spec:
               kubernetes.io/metadata.name: redhat-ods-monitoring
         - podSelector:
             matchLabels:
+              app: ds-pipeline-{{.Name}}
+              component: data-science-pipelines
+        - podSelector:
+            matchLabels:
               app: mariadb-{{.Name}}
               component: data-science-pipelines
         - podSelector:


### PR DESCRIPTION
## Description of your changes:

The DSP apiserver implements TLS by relying on the OpenShift service cert signer. In order to get this to work nicely with our openshift-oauth sidecar, we set the Kubernetes service as the upstream for the oauth container. This means that all incoming traffic to DSP goes like this:
`client -> DSP service -> DSP oauth -> DSP service -> DSP apiserver` 
DSP oauth and DSP apiserver are in the same pod. We haven't explicitly created a NetworkPolicy to allow that, but it works on AWS and OpenStack-based clusters. For some yet to be determined reason, it doesn't work on IBM / Calico / Secure-By-Default clusters.

Add a NetworkPolicy entry to allow the DSP pod to talk to itself on 8888 and 8887. This fixes the issue where DSP(oauth) can't talk to DSP(apiserver) via the service (that fronts both containers / the pod).

## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-14571

## Testing instructions
Provision a managed IBM Cloud OpenShift with SBD enabled.
Install the master release of DSPO. Create a DSPA. Verify that you can't connect to this DSPA's route. You'll see timeout errors in the DSPA oauth containter log.
Update to this PR's build of DSPO. Create another DSPA. Verify that you CAN connect to this DSPA's route. You won't see timeout errors in the DSPA oauth containter log.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
