### PR TITLE
prevent dspa status update on a terminating dspa

### DIFF
--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -218,6 +218,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			if err := r.Update(ctx, dspa); err != nil {
 				return ctrl.Result{}, err
 			}
+			log.Info("DSPA resources cleaned up.")
 		}
 
 		// Stop reconciliation as the item is being deleted
@@ -363,6 +364,11 @@ func (r *DSPAReconciler) setStatus(ctx context.Context, resourceName string, con
 func (r *DSPAReconciler) updateStatus(ctx context.Context, dspa *dspav1alpha1.DataSciencePipelinesApplication,
 	dspaStatus dspastatus.DSPAStatus, log logr.Logger, req ctrl.Request) {
 	r.refreshDspa(ctx, dspa, req, log)
+
+	// TODO: this is a workaround, handle deletion more gracefully
+	if dspa.DeletionTimestamp != nil {
+		return
+	}
 	dspa.Status.Components = r.GetComponents(ctx, dspa)
 	dspa.Status.Conditions = dspaStatus.GetConditions()
 	err := r.Status().Update(ctx, dspa)


### PR DESCRIPTION
When a dspa is marked for deletion, there is no state logic to handle dspa statuses, so the update can at times try to update a dspa that may have already been deleted, this change should prevent (or reduce) the chances of this happening, in the future proper/graceful dspa termination handling should be added. 

The following error appears when you try to delete the dspa, it may not always show up, it depends on reconcile timing and k8s server response:

```
2024-10-18T17:10:32-04:00       ERROR   Encountered error when updating the DSPA status {"namespace": "dspa2", "dspa_name": "sample", "error": "Operation cannot be fulfilled on datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io \"sample\": StorageError: invalid object, Code: 4, Key: /kubernetes.io/datasciencepipelinesapplications.opendatahub.io/datasciencepipelinesapplications/dspa2/sample, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: a17d9b5d-127f-4e5d-8560-1fbce2e27dcd, UID in object meta: "}
github.com/opendatahub-io/data-science-pipelines-operator/controllers.(*DSPAReconciler).updateStatus
        /home/hukhan/projects/github/rhods/data-science-pipelines-operator/controllers/dspipeline_controller.go:370
github.com/opendatahub-io/data-science-pipelines-operator/controllers.(*DSPAReconciler).Reconcile
        /home/hukhan/projects/github/rhods/data-science-pipelines-operator/controllers/dspipeline_controller.go:224
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /home/hukhan/go/1.21.3/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:118
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/hukhan/go/1.21.3/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:314
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/hukhan/go/1.21.3/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/hukhan/go/1.21.3/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226

```

notice: 

```
ERROR   Encountered error when updating the DSPA status
```

This happens between: 

```
r.refreshDspa(ctx, dspa, req, log)
...
err := r.Status().Update(ctx, dspa)
```

So we just do a check for the deletiontimestamp field, and if it's set, we don't attempt to update the status

