### PR TITLE
Update oauth-proxy version in compatiblity table for 2.8

### DIFF
--- a/docs/release/compatibility.md
+++ b/docs/release/compatibility.md
@@ -6,7 +6,7 @@ Each row outlines the versions for individual subcomponents and images that are 
 
 | dsp | kfp | argo | ml-metadata | envoy | ocp-pipelines | oauth-proxy | mariadb-103 | ubi-minimal | ubi-micro | openshift |
 |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
-| 2.8 | 2.2.0 | 3.4.17 | 1.14.0 | 1.22.11 | N/A | v4.10 | 1 | N/A | N/A | 4.15,4.16,4.17 |
+| 2.8 | 2.2.0 | 3.4.17 | 1.14.0 | 1.22.11 | N/A | v4.14 | 1 | N/A | N/A | 4.15,4.16,4.17 |
 | 2.7 | 2.2.0 | 3.4.17 | 1.14.0 | 1.22.11 | N/A | v4.10 | 1 | N/A | N/A | 4.15,4.16,4.17 |
 | 2.6 | 2.0.5 | 3.3.10 | 1.14.0 | 1.22.11 | N/A | v4.10 | 1 | N/A | N/A | 4.14,4.15,4.16 |
 | 2.5 | 2.0.5 | 3.3.10 | 1.14.0 | 1.22.11 | N/A | v4.10 | 1 | N/A | N/A | 4.14,4.15,4.16 |

--- a/docs/release/compatibility.yaml
+++ b/docs/release/compatibility.yaml
@@ -4,7 +4,7 @@
   ml-metadata: 1.14.0
   envoy: 1.22.11
   ocp-pipelines: "N/A"
-  oauth-proxy: v4.10
+  oauth-proxy: v4.14
   mariadb-103: 1
   ubi-minimal: "N/A"
   ubi-micro: "N/A"


### PR DESCRIPTION
The oauth-proxy version was bumped to v4.14 in https://github.com/opendatahub-io/data-science-pipelines-operator/pull/725