### PR TITLE
Use DSPA custom ca cert on MLMD and Persistence Agent clients

### DIFF
--- a/config/internal/persistence-agent/deployment.yaml.tmpl
+++ b/config/internal/persistence-agent/deployment.yaml.tmpl
@@ -55,6 +55,9 @@ spec:
             - "--namespace={{.Namespace}}"
             - "--mlPipelineServiceHttpPort=8888"
             - "--mlPipelineServiceGRPCPort=8887"
+            {{ if and .CustomCABundle .PodToPodTLS }}
+            - "--caCertPath={{ .PiplinesCABundleMountPath }}"
+            {{ end }}
           livenessProbe:
             exec:
               command:
@@ -96,6 +99,10 @@ spec:
             - mountPath: /var/run/secrets/kubeflow/tokens/persistenceagent-sa-token
               name: persistenceagent-sa-token
               subPath: ds-pipeline-persistenceagent-{{.Name}}-token
+            {{ if and .CustomCABundle .PodToPodTLS }}
+            - mountPath: {{ .CustomCABundleRootMountPath  }}
+              name: ca-bundle
+            {{ end }}
       serviceAccountName: ds-pipeline-persistenceagent-{{.Name}}
       volumes:
         - name: persistenceagent-sa-token
@@ -105,3 +112,8 @@ spec:
                 audience: pipelines.kubeflow.org
                 expirationSeconds: 3600
                 path: ds-pipeline-persistenceagent-{{.Name}}-token
+        {{ if and .CustomCABundle .PodToPodTLS }}
+        - name: ca-bundle
+          configMap:
+            name: {{ .CustomCABundle.ConfigMapName }}
+        {{ end }}


### PR DESCRIPTION
This PR must be merged with https://github.com/opendatahub-io/data-science-pipelines/pull/96

## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-13871

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
This PR adds validation of MLMD and Persistence Agent server certificates against CA in the clients.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
There are 2 scenarios:

### With `podToPodTLS: true`

1. Deploy the following DSPA:

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true
    podToPodTLS: true
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-96
    argoDriverImage: quay.io/opendatahub/ds-pipelines-driver:pr-96
    argoLauncherImage: quay.io/opendatahub/ds-pipelines-launcher:pr-96
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  persistenceAgent:
    deploy: true
    image: quay.io/opendatahub/ds-pipelines-persistenceagent:pr-96
    numWorkers: 2
    resources:
      requests:
        cpu: 120m
        memory: 500Mi
      limits:
        cpu: 250m
        memory: 1Gi
  objectStorage:
    # Need to enable this for artifact download links to work
    # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```

2. Run the iris pipeline
3. The run must complete successfully 

### With `podToPodTLS: false` 

1. Deploy the following DSPA:

```yaml
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true
    podToPodTLS: false
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-96
    argoDriverImage: quay.io/opendatahub/ds-pipelines-driver:pr-96
    argoLauncherImage: quay.io/opendatahub/ds-pipelines-launcher:pr-96
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  persistenceAgent:
    deploy: true
    image: quay.io/opendatahub/ds-pipelines-persistenceagent:pr-96
    numWorkers: 2
    resources:
      requests:
        cpu: 120m
        memory: 500Mi
      limits:
        cpu: 250m
        memory: 1Gi
  objectStorage:
    # Need to enable this for artifact download links to work
    # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```

2. Run the iris pipeline
3. The run must complete successfully 

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
