### PR TITLE
Print if REGISTRY_ADDRESS is not defined

### DIFF
--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -31,7 +31,10 @@ ENDPOINT_TYPE="service"
 
 get_dspo_image() {
   if [ "$REGISTRY_ADDRESS" = "" ]; then
-  echo "REGISTRY_ADDRESS variable not defined." && exit 1
+    # this function is called by `IMG=$(get_dspo_image)` that captures the standard output of get_dspo_image
+    set -x
+    echo "REGISTRY_ADDRESS variable not defined."
+    exit 1
   fi
   local image="${REGISTRY_ADDRESS}/data-science-pipelines-operator"
   echo $image


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Partial resolves #[RHOAIENG-15407](https://issues.redhat.com//browse/RHOAIENG-15407)

## Description of your changes:
Print the error if the variable REGISTRY_ADDRESS is not defined

## Testing instructions
Execute `sh .github/scripts/tests/tests.sh --kind` and you should see the error

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
