### PR TITLE
Bump DSPO test suite to KFP 2.10.0

### DIFF
--- a/tests/dspa_v2_test.go
+++ b/tests/dspa_v2_test.go
@@ -51,8 +51,8 @@ func (suite *IntegrationTestSuite) TestDSPADeployment() {
 	}
 	suite.T().Run("with default MariaDB and Minio", func(t *testing.T) {
 		t.Run(fmt.Sprintf("should have %d pods", podCount), func(t *testing.T) {
-			timeout := time.Second * 10
-			interval := time.Millisecond * 2
+			timeout := time.Second * 120
+			interval := time.Second * 2
 			actualPodCount := 0
 
 			require.Eventually(t, func() bool {

--- a/tests/resources/test-pipeline-run.yaml
+++ b/tests/resources/test-pipeline-run.yaml
@@ -29,7 +29,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.10.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -77,4 +77,4 @@ root:
       Output:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.9.0
+sdkVersion: kfp-2.10.0

--- a/tests/resources/test-pipeline-with-custom-pip-server-run.yaml
+++ b/tests/resources/test-pipeline-with-custom-pip-server-run.yaml
@@ -24,7 +24,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url https://nginx-service.test-pypiserver.svc.cluster.local/simple/\
-          \ 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"\
+          \ 'kfp==2.10.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"\
           3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location --index-url\
           \ https://nginx-service.test-pypiserver.svc.cluster.local/simple/ 'numpy'\
           \ && \"$0\" \"$@\"\n"
@@ -66,4 +66,4 @@ root:
       Output:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.9.0
+sdkVersion: kfp-2.10.0


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #[RHOAIENG-15760](https://issues.redhat.com//browse/RHOAIENG-15760)

## Description of your changes:
Bump KFP to 2.10.0. The tests that are using the pip server were downloaded 2.10.0 and the yaml has 2.9.0. Due to that the test simulates the air-gap environment. The test was failing.

I also changed the timeout. Sometimes it will take more than 10 seconds and iterating every 2ms is not feasible. Each operation take more time than that.

## Testing instructions
NA

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
