### PR TITLE
Bump k8s version to 1.31

### DIFF
--- a/.github/actions/kind/action.yml
+++ b/.github/actions/kind/action.yml
@@ -35,10 +35,14 @@ runs:
         EOF'
 
     - name: Setup KinD cluster
-      uses: helm/kind-action@v1.8.0
+      uses: helm/kind-action@v1
       with:
         cluster_name: cluster
-        version: v0.17.0
+        # The kind version to use
+        version: v0.21.0
+        # The Docker image for the cluster nodes - https://hub.docker.com/r/kindest/node/
+        node_image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
+        # The path to the kind config file
         config: ${{ env.KIND_CONFIG_FILE }}
 
     - name: Print cluster info

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -11,6 +11,7 @@ on:
       - config/**
       - tests/**
       - .github/resources/**
+      - .github/actions/**
       - '.github/workflows/kind-integration.yml'
       - '.github/scripts/tests/tests.sh'
       - Makefile


### PR DESCRIPTION
## JIRA
This PR demonstrate the problem of https://issues.redhat.com/browse/RHOAIENG-16037

## Description of your changes:
Update k8s to 1.31

## Testing instructions
NA

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
