### PR TITLE
Add ilab kfp pipeline to the DSPO repo

### DIFF
--- a/api/v1/dspipeline_types.go
+++ b/api/v1/dspipeline_types.go
@@ -69,9 +69,13 @@ type APIServer struct {
 	// Include sample pipelines with the deployment of this DSP API Server. Default: true
 	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
-	EnableSamplePipeline bool   `json:"enableSamplePipeline"`
-	ArgoLauncherImage    string `json:"argoLauncherImage,omitempty"`
-	ArgoDriverImage      string `json:"argoDriverImage,omitempty"`
+	EnableSamplePipeline bool `json:"enableSamplePipeline"`
+	// Enable the Instructlab Multi-Phase Training pipeline with the deployment of this DSP API server. Default: false
+	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
+	EnableInstructLabPipeline bool   `json:"enableInstructLabPipeline"`
+	ArgoLauncherImage         string `json:"argoLauncherImage,omitempty"`
+	ArgoDriverImage           string `json:"argoDriverImage,omitempty"`
 	// Specify custom Pod resource requirements for this component.
 	Resources *ResourceRequirements `json:"resources,omitempty"`
 

--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -69,9 +69,13 @@ type APIServer struct {
 	// Include sample pipelines with the deployment of this DSP API Server. Default: true
 	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
-	EnableSamplePipeline bool   `json:"enableSamplePipeline"`
-	ArgoLauncherImage    string `json:"argoLauncherImage,omitempty"`
-	ArgoDriverImage      string `json:"argoDriverImage,omitempty"`
+	EnableSamplePipeline bool `json:"enableSamplePipeline"`
+	// Enable the Instructlab Multi-Phase Training pipeline with the deployment of this DSP API server. Default: false
+	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
+	EnableInstructLabPipeline bool   `json:"enableInstructLabPipeline"`
+	ArgoLauncherImage         string `json:"argoLauncherImage,omitempty"`
+	ArgoDriverImage           string `json:"argoDriverImage,omitempty"`
 	// Specify custom Pod resource requirements for this component.
 	Resources *ResourceRequirements `json:"resources,omitempty"`
 

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -105,6 +105,11 @@ spec:
                       Server. Setting Deploy to false disables operator reconciliation.
                       Default: true'
                     type: boolean
+                  enableInstructLabPipeline:
+                    default: false
+                    description: 'Enable the Instructlab Multi-Phase Training pipeline
+                      with the deployment of this DSP API server. Default: false'
+                    type: boolean
                   enableOauth:
                     default: true
                     description: 'Create an Openshift Route for this DSP API Server.
@@ -989,6 +994,11 @@ spec:
                     description: 'Enable DS Pipelines Operator management of DSP API
                       Server. Setting Deploy to false disables operator reconciliation.
                       Default: true'
+                    type: boolean
+                  enableInstructLabPipeline:
+                    default: false
+                    description: 'Enable the Instructlab Multi-Phase Training pipeline
+                      with the deployment of this DSP API server. Default: false'
                     type: boolean
                   enableOauth:
                     default: true

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -147,7 +147,7 @@ spec:
           args:
             - --config=/config
             - -logtostderr=true
-            {{ if .APIServer.EnableSamplePipeline }}
+            {{ if or .APIServer.EnableSamplePipeline .APIServer.EnableInstructLabPipeline }}
             - --sampleconfig=/config/sample_config.json
             {{ end }}
             {{ if .PodToPodTLS }}
@@ -206,18 +206,16 @@ spec:
             - mountPath: /etc/tls/private
               name: proxy-tls
           {{ end }}
-          {{ if or .APIServer.EnableSamplePipeline .CustomCABundle }}
-            {{ if .APIServer.EnableSamplePipeline }}
+          {{ if or .APIServer.EnableSamplePipeline .APIServer.EnableInstructLabPipeline}}
             - name: sample-config
               mountPath: /config/sample_config.json
               subPath: sample_config.json
             - name: sample-pipeline
               mountPath: /samples/
-            {{ end }}
-            {{ if .CustomCABundle }}
+          {{ end }}
+          {{ if .CustomCABundle }}
             - mountPath: {{ .CustomCABundleRootMountPath  }}
               name: ca-bundle
-            {{ end }}
           {{ end }}
         {{ if .APIServer.EnableRoute }}
         - name: oauth-proxy
@@ -287,7 +285,7 @@ spec:
           configMap:
             name: {{ .CustomCABundle.ConfigMapName }}
         {{ end }}
-        {{ if .APIServer.EnableSamplePipeline }}
+        {{ if or .APIServer.EnableSamplePipeline .APIServer.EnableInstructLabPipeline}}
         - name: sample-config
           configMap:
             name: sample-config-{{.Name}}

--- a/config/internal/apiserver/sample-pipeline/sample-config.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline/sample-config.yaml.tmpl
@@ -7,11 +7,21 @@ metadata:
         app: {{.APIServerDefaultResourceName}}
         component: data-science-pipelines
 data:
-    sample_config.json: |-
-        [
-          {
-            "name": "[Demo] iris-training",
-            "description": "[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/iris-sklearn) A simple pipeline to demonstrate a basic ML Training workflow",
-            "file": "/samples/iris-pipeline-compiled.yaml"
-          }
-        ]
+  sample_config.json: |-
+    [
+      {{- if .EnableSamplePipeline }}
+      {
+        "name": "[Demo] iris-training",
+        "description": "[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/iris-sklearn) A simple pipeline to demonstrate a basic ML Training workflow",
+        "file": "/samples/iris-pipeline-compiled.yaml"
+      }
+      {{- if and .EnableSamplePipeline .EnableInstructLabPipeline }},{{ end }}
+      {{- end }}
+      {{- if .EnableInstructLabPipeline }}
+      {
+        "name": "[InstructLab] Multi-Phase Training Pipeline",
+        "description": "[source code](https://github.com/opendatahub-io/ilab-on-ocp) Instructlab Multi-Phase Training Pipeline",
+        "file": "/pipelines/instructlab.yaml"
+      }
+      {{- end }}
+    ]

--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -68,7 +68,7 @@ func (r *DSPAReconciler) ReconcileAPIServer(ctx context.Context, dsp *dspav1.Dat
 	}
 
 	for cmName, template := range samplePipelineTemplates {
-		if dsp.Spec.APIServer.EnableSamplePipeline {
+		if dsp.Spec.APIServer.EnableSamplePipeline || dsp.Spec.APIServer.EnableInstructLabPipeline {
 			err := r.Apply(dsp, params, template)
 			if err != nil {
 				return err

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -92,9 +92,10 @@ type DSPAParams struct {
 	CustomCABundle *dspa.CABundle
 	DSPONamespace  string
 	// Use to enable tls communication between component pods.
-	PodToPodTLS bool
-
-	APIServerServiceDNSName string
+	PodToPodTLS               bool
+	EnableSamplePipeline      bool
+	EnableInstructLabPipeline bool
+	APIServerServiceDNSName   string
 }
 
 type DBConnection struct {
@@ -600,6 +601,9 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 		setStringDefault(argoLauncherImageFromConfig, &p.APIServer.ArgoLauncherImage)
 		setStringDefault(argoDriverImageFromConfig, &p.APIServer.ArgoDriverImage)
 		setResourcesDefault(config.APIServerResourceRequirements, &p.APIServer.Resources)
+
+		p.EnableSamplePipeline = dsp.Spec.APIServer.EnableSamplePipeline
+		p.EnableInstructLabPipeline = dsp.Spec.APIServer.EnableInstructLabPipeline
 
 		if p.APIServer.CustomServerConfig == nil {
 			p.APIServer.CustomServerConfig = &dspa.ScriptConfigMap{

--- a/tests/pipeline_test.go
+++ b/tests/pipeline_test.go
@@ -75,4 +75,29 @@ func (suite *IntegrationTestSuite) TestAPIServerDeployment() {
 		require.NoError(t, err)
 		assert.Equal(t, 200, response.StatusCode)
 	})
+
+	suite.T().Run("Should check for InstructLab pipeline existence based on EnableInstructLabPipeline flag", func(t *testing.T) {
+		expectedDisplayName := "[InstructLab] Multi-Phase Training Pipeline"
+
+		// Retrieve pipelines
+		pipelines, err := TestUtil.RetrievePipelines(t, suite.Clientmgr.httpClient, APIServerURL)
+		require.NoError(t, err, "Failed to retrieve pipelines")
+
+		found := false
+		for _, pipeline := range pipelines.Pipelines {
+			if pipeline.DisplayName == expectedDisplayName {
+				found = true
+				break
+			}
+		}
+		if suite.DSPA.Spec.APIServer.EnableInstructLabPipeline {
+			expectedCount := 4
+			assert.Equal(t, expectedCount, len(pipelines.Pipelines), "Pipeline count should match when EnableInstructLabPipeline flag is enabled")
+			assert.True(t, found, "InstructLab pipeline should exist when the flag is enabled")
+		} else {
+			expectedCount := 3
+			assert.Equal(t, expectedCount, len(pipelines.Pipelines), "Pipeline count should match when EnableInstructLabPipeline flag is disabled")
+			assert.False(t, found, "InstructLab pipeline should not exist when the flag is disabled")
+		}
+	})
 }

--- a/tests/resources/dspa-lite.yaml
+++ b/tests/resources/dspa-lite.yaml
@@ -9,6 +9,7 @@ spec:
     deploy: true
     enableOauth: false
     enableSamplePipeline: true
+    enableInstructLabPipeline: true
     cABundle:
       configMapName: nginx-tls-config
       configMapKey: rootCA.crt

--- a/tests/resources/test-pipeline-run.yaml
+++ b/tests/resources/test-pipeline-run.yaml
@@ -29,7 +29,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.10.1'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.11.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh

--- a/tests/resources/test-pipeline-with-custom-pip-server-run.yaml
+++ b/tests/resources/test-pipeline-with-custom-pip-server-run.yaml
@@ -24,7 +24,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url https://nginx-service.test-pypiserver.svc.cluster.local/simple/\
-          \ 'kfp==2.10.1' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"\
+          \ 'kfp==2.11.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"\
           3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location --index-url\
           \ https://nginx-service.test-pypiserver.svc.cluster.local/simple/ 'numpy'\
           \ && \"$0\" \"$@\"\n"
@@ -66,4 +66,4 @@ root:
       Output:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.10.1
+sdkVersion: kfp-2.11.0

--- a/tests/util/rest.go
+++ b/tests/util/rest.go
@@ -94,6 +94,17 @@ func RetrievePipelineId(t *testing.T, httpClient http.Client, APIServerURL strin
 	}
 }
 
+func RetrievePipelines(t *testing.T, httpClient http.Client, APIServerURL string) (Pipeline, error) {
+	response, err := httpClient.Get(fmt.Sprintf("%s/apis/v2beta1/pipelines", APIServerURL))
+	require.NoError(t, err)
+	responseData, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	var pipelineData Pipeline
+	err = json.Unmarshal(responseData, &pipelineData)
+	require.NoError(t, err)
+	return pipelineData, nil
+}
+
 func FormatRequestBody(t *testing.T, pipelineID string, PipelineDisplayName string) []byte {
 	requestBody := PipelineRequest{
 		DisplayName: PipelineDisplayName,


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #<[RHOAIENG-16507](https://issues.redhat.com/browse/RHOAIENG-16507)>

## Description of your changes:

- Added support for provisioning the iLab pipeline as part of a DSPA deployment.
- Introduced a new parameter, ```enableIlabKFPPipeline```(set to false by default), which can be set to true to enable the iLab KFP pipeline in the UI.

## Testing instructions

- Deploy DSPO.
- Deploy  DSPA using the provided yaml file:
- Scenario 1:
  Provision both the Iris and InstructLab pipelines, create pipeline runs, and ensure they complete successfully.
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true
    enableInstructlabPipeline: true
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-120
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  podToPodTLS: false
  objectStorage:
    # Need to enable this for artifact download links to work
    # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```
Scenario 2:
 Provision the Iris pipeline, create pipeline run, and ensure it completes successfully.
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    enableSamplePipeline: true    
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-120
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  podToPodTLS: false
  objectStorage:
    # Need to enable this for artifact download links to work
    # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```
Scenario 3:
Provision the Instructlab pipeline, create pipeline run, and ensure it completes successfully.
```
apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
kind: DataSciencePipelinesApplication
metadata:
  name: sample
spec:
  dspVersion: v2
  apiServer:
    enableInstructlabPipeline: true    
    image: quay.io/opendatahub/ds-pipelines-api-server:pr-120
    cABundle:
      configMapKey: ca.crt
      configMapName: kube-root-ca.crt
  podToPodTLS: false
  objectStorage:
    # Need to enable this for artifact download links to work
    # i.e. for when requesting /apis/v2beta1/artifacts/{id}?share_url=true
    enableExternalRoute: true
    minio:
      deploy: true
      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
  mlpipelineUI:
    image: quay.io/opendatahub/ds-pipelines-frontend:latest
```
## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
