### PR TITLE
Added support for TLS to scheduled-workflow

### DIFF
--- a/.github/resources/mariadb/deployment.yaml
+++ b/.github/resources/mariadb/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: mariadb
-          image: quay.io/centos7/mariadb-105-centos7:centos7
+          image: quay.io/sclorg/mariadb-105-c9s:latest
           ports:
             - containerPort: 3306
           readinessProbe:

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: Kubeflow Pipelines
-    version: 2.2.0
+    version: 2.4.0
     repoUrl: https://github.com/kubeflow/pipelines

--- a/config/internal/scheduled-workflow/deployment.yaml.tmpl
+++ b/config/internal/scheduled-workflow/deployment.yaml.tmpl
@@ -33,6 +33,12 @@ spec:
           name: ds-pipeline-scheduledworkflow
           command:
             - controller
+            - "--mlPipelineAPIServerName={{.APIServerServiceDNSName}}"
+            - "--mlPipelineServiceGRPCPort=8887"
+            {{ if .PodToPodTLS }}
+            - "--mlPipelineServiceTLSEnabled=true"
+            - "--mlPipelineServiceTLSCert={{ .PiplinesCABundleMountPath }}"
+            {{ end }}
             - "--logtostderr=true"
             - "--namespace={{.Namespace}}"
           livenessProbe:
@@ -72,4 +78,15 @@ spec:
               memory: {{.ScheduledWorkflow.Resources.Limits.Memory}}
               {{ end }}
             {{ end }}
+          volumeMounts:
+            {{ if and .CustomCABundle .PodToPodTLS }}
+            - mountPath: {{ .CustomCABundleRootMountPath  }}
+              name: ca-bundle
+            {{ end }}
       serviceAccountName: {{.ScheduledWorkflowDefaultResourceName}}
+      volumes:
+        {{ if and .CustomCABundle .PodToPodTLS }}
+        - name: ca-bundle
+          configMap:
+            name: {{ .CustomCABundle.ConfigMapName }}
+        {{ end }}


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://issues.redhat.com/browse/RHOAIENG-17788

This PR depends on: 

- https://github.com/opendatahub-io/data-science-pipelines/pull/142

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
Integration tests are expected to fail due to the dependency on https://github.com/opendatahub-io/data-science-pipelines/pull/134.

```
===== Pod: ds-pipeline-scheduledworkflow-test-dspa-68df7959c-8jqv2 in test-dspa =====
----- EVENTS -----
Events:
  Type     Reason     Age                   From               Message
  ----     ------     ----                  ----               -------
  Normal   Scheduled  3m18s                 default-scheduler  Successfully assigned test-dspa/ds-pipeline-scheduledworkflow-test-dspa-68df7959c-8jqv2 to cluster-control-plane
  Normal   Pulled     2m59s                 kubelet            Successfully pulled image "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest" in 3.243s (17.048s including waiting). Image size: 114466138 bytes.
  Normal   Pulled     2m45s                 kubelet            Successfully pulled image "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest" in 215ms (7.875s including waiting). Image size: 114466138 bytes.
  Warning  Unhealthy  2m38s                 kubelet            Readiness probe errored: rpc error: code = NotFound desc = failed to exec in container: failed to load task: no running task found: task 449fec054fd32fba619bc7051a399a10e8f6457a93339bafbd15af5c49d80170 not found: not found
  Normal   Pulled     2m20s                 kubelet            Successfully pulled image "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest" in 158ms (158ms including waiting). Image size: 114466138 bytes.
  Normal   Pulling    108s (x4 over 3m16s)  kubelet            Pulling image "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest"
  Normal   Created    107s (x4 over 2m59s)  kubelet            Created container ds-pipeline-scheduledworkflow
  Normal   Pulled     107s                  kubelet            Successfully pulled image "quay.io/opendatahub/ds-pipelines-scheduledworkflow:latest" in 176ms (176ms including waiting). Image size: 114466138 bytes.
  Normal   Started    105s (x4 over 2m56s)  kubelet            Started container ds-pipeline-scheduledworkflow
  Warning  BackOff    84s (x8 over 2m37s)   kubelet            Back-off restarting failed container ds-pipeline-scheduledworkflow in pod ds-pipeline-scheduledworkflow-test-dspa-68df7959c-8jqv2_test-dspa(e22351b4-a328-4893-aa55-819b49b37ea5)
----- LOGS -----
time="2025-02-12T17:35:19Z" level=info msg="Location: UTC"
flag provided but not defined: -mlPipelineAPIServerName           <-------------------------------- New flag added
```

### How to test it

Deploy a pipeline and start a recurring run. At least two runs must succeed.
Use the images from:

- https://github.com/opendatahub-io/data-science-pipelines/pull/142

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
