### PR TITLE
Provide APIServer init and main Containers with same envs

### DIFF
--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -29,39 +29,7 @@ spec:
           command: [ '/bin/sh', '-c']
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
-          env:
-            - name: BUILD_FOLDER
-              value: /opt/app-root/src/build
-            - name: PYTHON_IMAGE
-              value: {{.APIServer.RuntimeGenericImage}}
-            - name: TOOLBOX_IMAGE
-              value: {{.APIServer.ToolboxImage}}
-            - name: RHELAI_IMAGE
-              value: {{.APIServer.RHELAIImage}}
-          {{ if .APIServer.InitResources }}
-          resources:
-            requests:
-              {{ if .APIServer.InitResources.Requests.CPU }}
-              cpu: {{.APIServer.InitResources.Requests.CPU}}
-              {{ end }}
-              {{ if .APIServer.InitResources.Requests.Memory }}
-              memory: {{.APIServer.InitResources.Requests.Memory}}
-              {{ end }}
-            {{ end }}
-            {{ if .APIServer.InitResources.Limits }}
-            limits:
-              {{ if .APIServer.InitResources.Limits.CPU }}
-              cpu: {{.APIServer.InitResources.Limits.CPU}}
-              {{ end }}
-              {{ if .APIServer.InitResources.Limits.Memory }}
-              memory: {{.APIServer.InitResources.Limits.Memory}}
-              {{ end }}
-          {{ end }}
-          volumeMounts:
-            - mountPath: /opt/app-root/src/build
-              name: managed-pipelines
-      containers:
-        - env:
+          env: &apiserverEnvs
             {{ if .IncludeOwnerReference }}
             - name: OWNER_UID
               value: "{{.UID}}"
@@ -180,6 +148,38 @@ spec:
               value: "{{.DBConnection.Host}}"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "{{.DBConnection.Port}}"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: {{.APIServer.RuntimeGenericImage}}
+            - name: TOOLBOX_IMAGE
+              value: {{.APIServer.ToolboxImage}}
+            - name: RHELAI_IMAGE
+              value: {{.APIServer.RHELAIImage}}
+          {{ if .APIServer.InitResources }}
+          resources:
+            requests:
+              {{ if .APIServer.InitResources.Requests.CPU }}
+              cpu: {{.APIServer.InitResources.Requests.CPU}}
+              {{ end }}
+              {{ if .APIServer.InitResources.Requests.Memory }}
+              memory: {{.APIServer.InitResources.Requests.Memory}}
+              {{ end }}
+            {{ end }}
+            {{ if .APIServer.InitResources.Limits }}
+            limits:
+              {{ if .APIServer.InitResources.Limits.CPU }}
+              cpu: {{.APIServer.InitResources.Limits.CPU}}
+              {{ end }}
+              {{ if .APIServer.InitResources.Limits.Memory }}
+              memory: {{.APIServer.InitResources.Limits.Memory}}
+              {{ end }}
+          {{ end }}
+          volumeMounts:
+            - mountPath: /opt/app-root/src/build
+              name: managed-pipelines
+      containers:
+        - env: *apiserverEnvs
           image: {{.APIServer.Image}}
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,82 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "mlpipeline"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp0"
+            - name: DBCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp0.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "ds-pipeline-s3-testdsp0"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "accesskey"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "secretkey"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp0"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp0"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp0"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp0.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: V2_LAUNCHER_IMAGE
+              value: "argolauncherimage:test0"
+            - name: V2_DRIVER_IMAGE
+              value: "argodriverimage:test0"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp0.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp0.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: "mlpipeline"
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp0"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "mariadb-testdsp0.default.svc.cluster.local"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "3306"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -128,6 +204,14 @@ spec:
               value: "mariadb-testdsp0.default.svc.cluster.local"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test0
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test0
+            - name: RHELAI_IMAGE
+              value: rhelai:test0
           image: api-server:test0
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,82 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "testuser"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp2"
+            - name: DBCONFIG_DBNAME
+              value: "randomDBName"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp2.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "ds-pipeline-s3-testdsp2"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "accesskey"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "secretkey"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp2"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp2"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp2"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp2.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: V2_LAUNCHER_IMAGE
+              value: "argolauncherimage:test2"
+            - name: V2_DRIVER_IMAGE
+              value: "argodriverimage:test2"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp2.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp2.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: "testuser"
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp2"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "randomDBName"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "mariadb-testdsp2.default.svc.cluster.local"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "3306"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -128,6 +204,14 @@ spec:
               value: "mariadb-testdsp2.default.svc.cluster.local"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test2
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test2
+            - name: RHELAI_IMAGE
+              value: rhelai:test2
           image: api-server:test2
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,82 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "testuser3"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "testpswkey3"
+                  name: "testdbpswsecretname3"
+            - name: DBCONFIG_DBNAME
+              value: "testdbname3"
+            - name: DBCONFIG_HOST
+              value: "testdbhost3"
+            - name: DBCONFIG_PORT
+              value: "test3"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "teststoragesecretname3"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "testaccesskey3"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "testsecretkey3"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp3"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "testbucket3"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "testaccesskey3"
+                  name: "teststoragesecretname3"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "testsecretkey3"
+                  name: "teststoragesecretname3"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "true"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "teststoragehost3"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "80"
+            - name: V2_LAUNCHER_IMAGE
+              value: "argolauncherimage:test3"
+            - name: V2_DRIVER_IMAGE
+              value: "argodriverimage:test3"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp3.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp3.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: "testuser3"
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "testpswkey3"
+                  name: "testdbpswsecretname3"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "testdbname3"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "testdbhost3"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "test3"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -128,6 +204,14 @@ spec:
               value: "testdbhost3"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "test3"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test3
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test3
+            - name: RHELAI_IMAGE
+              value: rhelai:test3
           image: api-server:test3
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,82 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "testuser"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp4"
+            - name: DBCONFIG_DBNAME
+              value: "randomDBName"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp4.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "ds-pipeline-s3-testdsp4"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "accesskey"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "secretkey"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp4"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp4"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp4"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp4.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: V2_LAUNCHER_IMAGE
+              value: "this-argolauncher-image-from-cr-should-be-used:test4"
+            - name: V2_DRIVER_IMAGE
+              value: "this-argodriver-image-from-cr-should-be-used:test4"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp4.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp4.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: "testuser"
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp4"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "randomDBName"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "mariadb-testdsp4.default.svc.cluster.local"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "3306"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -128,6 +204,14 @@ spec:
               value: "mariadb-testdsp4.default.svc.cluster.local"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test4
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test4
+            - name: RHELAI_IMAGE
+              value: rhelai:test4
           image: this-apiserver-image-from-cr-should-be-used:test4
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,94 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "mlpipeline"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp5"
+            - name: DBCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp5.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_NAME
+              value: dsp-trusted-ca-testdsp5
+            - name: ARTIFACT_COPY_STEP_CABUNDLE_CONFIGMAP_KEY
+              value: testcabundleconfigmapkey5.crt
+            - name: ARTIFACT_COPY_STEP_CABUNDLE_MOUNTPATH
+              value: /dsp-custom-certs
+            - name: SSL_CERT_DIR
+              value: "/dsp-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "ds-pipeline-s3-testdsp5"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "accesskey"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "secretkey"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp5"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp5"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp5"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp5.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: V2_LAUNCHER_IMAGE
+              value: "launcherimage:test5"
+            - name: V2_DRIVER_IMAGE
+              value: "driverimage:test5"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp5.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp5.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: ML_PIPELINE_TLS_ENABLED
+              value: "true"
+            - name: METADATA_TLS_ENABLED
+              value: "true"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: "mlpipeline"
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp5"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "mariadb-testdsp5.default.svc.cluster.local"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "3306"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -140,6 +228,14 @@ spec:
               value: "mariadb-testdsp5.default.svc.cluster.local"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test5
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test5
+            - name: RHELAI_IMAGE
+              value: rhelai:test5
           image: api-server:test5
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -32,6 +32,82 @@ spec:
           args:
             - "make pipeline && cp pipeline.yaml ${BUILD_FOLDER}"
           env:
+            - name: POD_NAMESPACE
+              value: "default"
+            - name: DBCONFIG_USER
+              value: "mlpipeline"
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp6"
+            - name: DBCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_HOST
+              value: "mariadb-testdsp6.default.svc.cluster.local"
+            - name: DBCONFIG_PORT
+              value: "3306"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST
+              value: "ds-pipeline-visualizationserver"
+            - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
+              value: "8888"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRET
+              value: "ds-pipeline-s3-testdsp6"
+            - name: OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY
+              value: "accesskey"
+            - name: OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY
+              value: "secretkey"
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "pipeline-runner-testdsp6"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "mlpipeline"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "accesskey"
+                  name: "ds-pipeline-s3-testdsp6"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: "secretkey"
+                  name: "ds-pipeline-s3-testdsp6"
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+            - name: MINIO_SERVICE_SERVICE_HOST
+              value: "minio-testdsp6.default.svc.cluster.local"
+            - name: MINIO_SERVICE_SERVICE_PORT
+              value: "9000"
+            - name: V2_LAUNCHER_IMAGE
+              value: "launcherimage:test6"
+            - name: V2_DRIVER_IMAGE
+              value: "driverimage:test6"
+            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
+              value: "ds-pipeline-metadata-grpc-testdsp6.default.svc.cluster.local"
+            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
+              value: "8080"
+            - name: ML_PIPELINE_SERVICE_HOST
+              value: ds-pipeline-testdsp6.default.svc.cluster.local
+            - name: ML_PIPELINE_SERVICE_PORT_GRPC
+              value: "8887"
+            - name: SIGNED_URL_EXPIRY_TIME_SECONDS
+              value: "60"
+            - name: EXECUTIONTYPE
+              value: Workflow
+            - name: DB_DRIVER_NAME
+              value: mysql
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              value: mlpipeline
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "password"
+                  name: "ds-pipeline-db-testdsp6"
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              value: "mlpipeline"
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: "mariadb-testdsp6.default.svc.cluster.local"
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              value: "3306"
             - name: BUILD_FOLDER
               value: /opt/app-root/src/build
             - name: PYTHON_IMAGE
@@ -128,6 +204,14 @@ spec:
               value: "mariadb-testdsp6.default.svc.cluster.local"
             - name: DBCONFIG_MYSQLCONFIG_PORT
               value: "3306"
+            - name: BUILD_FOLDER
+              value: /opt/app-root/src/build
+            - name: PYTHON_IMAGE
+              value: runtimegeneric:test6
+            - name: TOOLBOX_IMAGE
+              value: toolbox:test6
+            - name: RHELAI_IMAGE
+              value: rhelai:test6
           image: api-server:test6
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server


### PR DESCRIPTION
## Description of your changes:
Init and Main container should have access to the same env vars

To do this:
- Move all env vars to Init container
- Mark the env section with `&apiserverEnvs` anchor
- Reference `*apiserverEnvs` in main container env section rather than duplicating

## Testing instructions
1. Deploy DSPO.
2. Deploy DSPA.
3. Verify `env` sections are identical in `init-pipelines` and `ds-pipeline-api-server` containers in newly created API Server pod

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
