### PR TITLE
correct dspo platformversion

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
             value: $(DSPO_APISERVER_INCLUDE_OWNERREFERENCE)
           - name: MANAGEDPIPELINES
             value: $(MANAGEDPIPELINES)
-          - name: PLATFORMVERSION
+          - name: DSPO_PLATFORMVERSION
             value: $(PLATFORMVERSION)
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
this should override the config: https://github.com/opendatahub-io/data-science-pipelines-operator/blob/28b1a5b4872dd2418977ab5a8a53738cb5662472/controllers/apiserver.go#L60