### PR TITLE
Pin the KFP version in the custom PyPi integration test

### DIFF
--- a/.github/scripts/python_package_upload/package_download.sh
+++ b/.github/scripts/python_package_upload/package_download.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Download packages
 for python_version in "3.9" "3.10" "3.11" "3.12"; do
-  for package in "kfp" "numpy"; do
+  for package in "kfp==2.11.0" "numpy"; do
     # If we don't set the --python it will use the one from the computer that may not be the one that the
     # pipeline is running
     pip download $package -d packages --only-binary=:none: --python $python_version

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -14,6 +14,7 @@ on:
       - .github/actions/**
       - '.github/workflows/kind-integration.yml'
       - '.github/scripts/tests/tests.sh'
+      - '.github/scripts/python_package_upload/**'
       - Makefile
     types:
       - opened


### PR DESCRIPTION
## Description of your changes:

The pipelines use KFP 2.11.0 so we need that version to be present on the PyPi server.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
