### PR TITLE
Fix run submissions with OwnerReferencesPermissionEnforcement on

### DIFF
--- a/config/internal/apiserver/default/role_ds-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/default/role_ds-pipeline.yaml.tmpl
@@ -46,6 +46,12 @@ rules:
       - update
       - patch
       - delete
+  - verbs:
+      - update
+    apiGroups:
+      - kubeflow.org
+    resources:
+      - scheduledworkflows/finalizers
   - apiGroups:
       - authorization.k8s.io
     resources:


### PR DESCRIPTION
## Description of your changes:

If the run is associated with a ScheduledWorkflow and the OwnerReferencesPermissionEnforcement admission controller is on (default in OpenShift), it requires the update verb on scheduledworkflows/finalizers to set the proper owner reference.

Relates:
https://issues.redhat.com/browse/RHOAIENG-23606
https://github.com/kubeflow/pipelines/pull/11821

## Testing instructions

The easiest way is to create a recurring run that always uses the latest pipeline version.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
