### PR TITLE
correct github octokit calls

### DIFF
--- a/.github/workflows/release_create.yaml
+++ b/.github/workflows/release_create.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@v3.1.0
         with:
           script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            let allArtifacts = await github.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: ${{github.event.workflow_run.id}},
@@ -37,7 +37,7 @@ jobs:
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
                 return artifact.name == "pr"
             })[0];
-            let download = await github.rest.actions.downloadArtifact({
+            let download = await github.actions.downloadArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 artifact_id: matchArtifact.id,


### PR DESCRIPTION
It seems whatever octokit rest versioning used in github-script 3.1.0 is the older one ([v17 at latest](https://octokit.github.io/rest.js/v17/)). It is not clear where the mismatch is within the[ github-script package.json ](https://github.com/actions/github-script/blob/releases/v3/package.json)

but this is consistent with how [we use it upstream](https://github.com/kubeflow/pipelines/blob/master/.github/workflows/add-ci-passed-label.yml#L32), and we don't have issues there 🤷🏾 