### PR TITLE
Add permissions to create InferenceService objects from a pipeline

### DIFF
--- a/.github/scripts/python_package_upload/package_upload_run.sh
+++ b/.github/scripts/python_package_upload/package_upload_run.sh
@@ -8,11 +8,11 @@ docker build -t package_upload .
 docker run --name package_upload_run -v /tmp/packages:/app/packages package_upload
 
 # Print the pods in the namespace
-oc -n test-pypiserver get pods
+kubectl -n test-pypiserver get pods
 
-pod_name=$(oc -n test-pypiserver get pod | grep pypi | awk '{print $1}')
+pod_name=$(kubectl -n test-pypiserver get pod | grep pypi | awk '{print $1}')
 
 # Copy packages
 for entry in /tmp/packages/*; do
-    oc -n test-pypiserver cp "$entry" $pod_name:/opt/app-root/packages
+    kubectl -n test-pypiserver cp "$entry" $pod_name:/opt/app-root/packages
 done

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   dspo-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   dspo-upgrade:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       OLM_VERSION: v0.24.0

--- a/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
+++ b/config/internal/apiserver/default/role_pipeline-runner.yaml.tmpl
@@ -131,3 +131,13 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -241,6 +241,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshots

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -167,6 +167,7 @@ func (r *DSPAReconciler) DeleteResourceIfItExists(ctx context.Context, obj clien
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=*
 //+kubebuilder:rbac:groups=machinelearning.seldon.io,resources=seldondeployments,verbs=*
 //+kubebuilder:rbac:groups=ray.io,resources=rayclusters;rayjobs;rayservices,verbs=create;get;list;patch;delete
+//+kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=create;get;list;patch;delete
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=image.openshift.io,resources=imagestreamtags,verbs=get


### PR DESCRIPTION
Relates:
https://issues.redhat.com/browse/RHOAIENG-19802

## Description of your changes:

This adds the required permissions to create InferenceService objects from a pipeline in the same namespace as the DSPA.

## Testing instructions

I used this simple pipeline to verify:


```python
from kfp import dsl
from kfp import compiler


from kfp import dsl

@dsl.component(packages_to_install=["kserve==0.12.0", "ray==2.9.3", "setuptools==69.5.1"])
#why setuptools with <70 version: ImportError: cannot import name 'packaging' from 'pkg_resources'
#https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863
def create_serving(
    serving_name: str, pvc_name: str,
):
    """This function uses the KServe library to create a KServe InferenceService."""

    from kserve import (
        KServeClient,
        V1beta1InferenceService,
        V1beta1InferenceServiceSpec,
        V1beta1PredictorSpec,
        V1beta1TFServingSpec,
        constants,
    )
    from kubernetes import client

    inference_service = V1beta1InferenceService(
        api_version=constants.KSERVE_V1BETA1,
        kind=constants.KSERVE_KIND,
        metadata=client.V1ObjectMeta(
            generate_name=serving_name + "-",
        ),
        spec=V1beta1InferenceServiceSpec(
            predictor=V1beta1PredictorSpec(
                min_replicas=0,
                tensorflow=V1beta1TFServingSpec(
                    runtime_version="2.14.1",
                    storage_uri=f"pvc://{pvc_name}/",
                ),
                service_account_name="testpipeline",
            )
        ),
    )

    kserve_client = KServeClient()
    inference_service = kserve_client.create(inference_service)
    print(
        f"Created InferenceService: {inference_service['metadata']['name']}. "
    )


@dsl.pipeline(name="my-pipeline", description="A simple intro pipeline")
def pipeline():
    create_serving(pvc_name="my-pvc", serving_name="my-serving-name")


if __name__ == "__main__":
    compiler.Compiler().compile(
        pipeline_func=pipeline, package_path="pipeline.yaml",
    )
```

I then verified that the `InferenceService` was created.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Grant pipelines permissions to manage KServe InferenceService resources.

Enhancements:
- Allow pipelines to create, get, list, patch, and delete InferenceService objects within their namespace.

Build:
- Update RBAC configuration files and code generation markers for InferenceService permissions.