### PR TITLE
generalize standard tests

### DIFF
--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -195,7 +195,7 @@ remove_namespace_created_for_rhoai() {
   kubectl delete projects $PYPISERVER_NAMESPACE --now || true
 }
 
-setup_kind_requirements() {
+setup_requirements() {
   apply_crd
   build_image
   create_opendatahub_namespace
@@ -230,6 +230,10 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --kind)
       TARGET="kind"
+      shift
+      ;;
+    --standard)
+      TARGET="standard"
       shift
       ;;
     --rhoai)
@@ -329,7 +333,9 @@ if [ "$TARGET" = "kind" ]; then
   if [ "$CLEAN_INFRA" = true ] ; then
       undeploy_kind_resources
   fi
-  setup_kind_requirements
+  setup_requirements
+elif [ "$TARGET" = "standard" ]; then
+  setup_requirements
 elif [ "$TARGET" = "rhoai" ]; then
   if [ "$CLEAN_INFRA" = true ] ; then
       remove_namespace_created_for_rhoai

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -52,7 +52,7 @@ jobs:
         id: test
         working-directory: ${{ github.workspace }}/.github/scripts/tests
         run: |
-          sh tests.sh --kind
+          sh tests.sh --standard
         continue-on-error: true
 
       - name: Collect events and logs

--- a/tests/resources/dspa-lite-tls.yaml
+++ b/tests/resources/dspa-lite-tls.yaml
@@ -1,0 +1,80 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: test-dspa
+spec:
+  dspVersion: v2
+  podToPodTLS: true
+  apiServer:
+    deploy: true
+    enableSamplePipeline: true
+    cABundle:
+      configMapName: nginx-tls-config
+      configMapKey: rootCA.crt
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100Mi
+  scheduledWorkflow:
+    deploy: true
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100Mi
+  persistenceAgent:
+    deploy: true
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100Mi
+  mlmd:
+    deploy: true
+    envoy:
+      deployRoute: false
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100Mi
+    grpc:
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100Mi
+  database:
+    mariaDB:
+      deploy: true
+      pvcSize: 500Mi
+      resources:
+        limits:
+          cpu: 60m
+          memory: 500Mi
+        requests:
+          cpu: 60m
+          memory: 500Mi
+  objectStorage:
+    minio:
+      deploy: true
+      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
+      pvcSize: 500Mi
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100Mi


### PR DESCRIPTION
and add a dspa-lite to be used for testing with podtopodtls

we will use this dspa to deploy dsp in openshift-ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new Kubernetes resource manifest for deploying a DataSciencePipelinesApplication with pod-to-pod TLS and detailed resource specifications.

- **Chores**
  - Updated test scripts and workflows to use a "standard" configuration instead of "kind", including renaming related script functions and adjusting workflow arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->