### PR TITLE
Add CacheEnabled field to APIServer for configurable caching in DSPA

### DIFF
--- a/api/v1/dspipeline_types.go
+++ b/api/v1/dspipeline_types.go
@@ -151,6 +151,10 @@ type APIServer struct {
 	// +kubebuilder:default:=60
 	// +kubebuilder:validation:Optional
 	ArtifactSignedURLExpirySeconds *int `json:"artifactSignedURLExpirySeconds"`
+
+	// Enable/disable caching in the DSP API server. Default: true
+	// +kubebuilder:default:=true
+	CacheEnabled *bool `json:"cacheEnabled,omitempty"`
 }
 
 type CABundle struct {

--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -203,6 +203,10 @@ type APIServer struct {
 	// +kubebuilder:default:=60
 	// +kubebuilder:validation:Optional
 	ArtifactSignedURLExpirySeconds *int `json:"artifactSignedURLExpirySeconds"`
+
+	// Enable/disable caching in the DSP API server. Default: true
+	// +kubebuilder:default:=true
+	CacheEnabled *bool `json:"cacheEnabled,omitempty"`
 }
 
 type CABundle struct {

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -86,6 +86,11 @@ spec:
                       This is the filename of the ca bundle that will be created in the
                       pipeline server and user executor pods
                     type: string
+                  cacheEnabled:
+                    default: true
+                    description: 'Enable/disable caching in the DSP API server. Default:
+                      true'
+                    type: boolean
                   customKfpLauncherConfigMap:
                     description: |-
                       When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes
@@ -1031,6 +1036,11 @@ spec:
                       This is the filename of the ca bundle that will be created in the
                       pipeline server and user executor pods
                     type: string
+                  cacheEnabled:
+                    default: true
+                    description: 'Enable/disable caching in the DSP API server. Default:
+                      true'
+                    type: boolean
                   cacheImage:
                     description: 'Deprecated: DSP V1 only, will be removed in the
                       future.'

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -162,6 +162,8 @@ spec:
             - name: V2_LAUNCHER_COMMAND
               value: "launcher-v2-fips"
             {{ end }}
+            - name: CACHEENABLED
+              value: "{{.APIServer.CacheEnabled}}"
           {{ if .APIServer.InitResources }}
           resources:
             requests:

--- a/config/samples/dspa-all-fields/dspa_all_fields.yaml
+++ b/config/samples/dspa-all-fields/dspa_all_fields.yaml
@@ -14,6 +14,7 @@ spec:
     customKfpLauncherConfigMap: configmapname
     deploy: true
     enableSamplePipeline: true
+    cacheEnabled: true
     image: quay.io/opendatahub/ds-pipelines-api-server:latest
     argoLauncherImage: quay.io/org/kfp-launcher:latest
     argoDriverImage: quay.io/org/kfp-driver:latest

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -799,6 +799,10 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 			expiry := config.DefaultSignedUrlExpiryTimeSeconds
 			p.APIServer.ArtifactSignedURLExpirySeconds = &expiry
 		}
+
+		if dsp.Spec.APIServer.CacheEnabled != nil {
+			p.APIServer.CacheEnabled = dsp.Spec.APIServer.CacheEnabled
+		}
 	}
 
 	if p.PersistenceAgent != nil {

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: toolbox:test0
             - name: RHELAI_IMAGE
               value: rhelai:test0
+            - name: CACHEENABLED
+              value: "true"
           resources:
             limits:
               memory: 256Mi
@@ -216,6 +218,8 @@ spec:
               value: toolbox:test0
             - name: RHELAI_IMAGE
               value: rhelai:test0
+            - name: CACHEENABLED
+              value: "true"
           image: api-server:test0
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_2/deploy/cr.yaml
+++ b/controllers/testdata/declarative/case_2/deploy/cr.yaml
@@ -13,6 +13,7 @@ spec:
     argoDriverImage: argodriverimage:test2
     enableOauth: true
     enableSamplePipeline: true
+    cacheEnabled: false
     managedPipelines:
       instructLab:
         state: Managed

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -120,6 +120,8 @@ spec:
               value: rhelai:test2
             - name: V2_LAUNCHER_COMMAND
               value: "launcher-v2-fips"
+            - name: CACHEENABLED
+              value: "false"
           resources:
             limits:
               memory: 6Gi
@@ -220,6 +222,8 @@ spec:
               value: rhelai:test2
             - name: V2_LAUNCHER_COMMAND
               value: "launcher-v2-fips"
+            - name: CACHEENABLED
+              value: "false"
           image: api-server:test2
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: toolbox:test3
             - name: RHELAI_IMAGE
               value: rhelai:test3
+            - name: CACHEENABLED
+              value: "true"
           resources:
             limits:
               memory: 256Mi
@@ -216,6 +218,8 @@ spec:
               value: toolbox:test3
             - name: RHELAI_IMAGE
               value: rhelai:test3
+            - name: CACHEENABLED
+              value: "true"
           image: api-server:test3
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: toolbox:test4
             - name: RHELAI_IMAGE
               value: rhelai:test4
+            - name: CACHEENABLED
+              value: "true"
           resources:
             limits:
               memory: 256Mi
@@ -216,6 +218,8 @@ spec:
               value: toolbox:test4
             - name: RHELAI_IMAGE
               value: rhelai:test4
+            - name: CACHEENABLED
+              value: "true"
           image: this-apiserver-image-from-cr-should-be-used:test4
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -130,6 +130,8 @@ spec:
               value: toolbox:test5
             - name: RHELAI_IMAGE
               value: rhelai:test5
+            - name: CACHEENABLED
+              value: "true"
           resources:
             limits:
               memory: 256Mi
@@ -240,6 +242,8 @@ spec:
               value: toolbox:test5
             - name: RHELAI_IMAGE
               value: rhelai:test5
+            - name: CACHEENABLED
+              value: "true"
           image: api-server:test5
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: toolbox:test6
             - name: RHELAI_IMAGE
               value: rhelai:test6
+            - name: CACHEENABLED
+              value: "true"
           resources:
             limits:
               memory: 256Mi
@@ -216,6 +218,8 @@ spec:
               value: toolbox:test6
             - name: RHELAI_IMAGE
               value: rhelai:test6
+            - name: CACHEENABLED
+              value: "true"
           image: api-server:test6
           # imagePullPolicy: default - https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
           name: ds-pipeline-api-server


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #[RHOAIENG-24379](https://issues.redhat.com/browse/RHOAIENG-24379)

## Description of your changes:
This PR adds a new field `CacheEnabled` to the APIServer configuration in DSPA to allow users to enable or disable caching.

***NOTE***
- This PR should be merged only after the corresponding [upstream commit](https://github.com/kubeflow/pipelines/pull/11831) has been cherry-picked into the DSP repository.
## Testing instructions
1. Deploy DSPA using a sample yaml with either:
   ```yaml
   apiServer:
     cacheEnabled: "true"  # Enable caching
   ```
   or
   ```yaml
   apiServer:
     cacheEnabled: "false" # Disable caching
   ```

2. Verify the API Server deployment has the correct environment variable:
   ```yaml
   env:
   - name: CACHEENABLED
     value: "false"  # Should match the value set in the DSPA spec
   ```
## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to enable or disable caching in the API server configuration for Data Science Pipelines Application. This setting defaults to enabled.
  - The new cache control option is now available in both the CRD schema and sample configurations.
  - Corresponding environment variable support for cache control has been added to API server deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->