### PR TITLE
revert accidental change to test flag

### DIFF
--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -52,7 +52,7 @@ jobs:
         id: test
         working-directory: ${{ github.workspace }}/.github/scripts/tests
         run: |
-          sh tests.sh --standard
+          sh tests.sh --kind
         continue-on-error: true
 
       - name: Collect events and logs


### PR DESCRIPTION
## The issue resolved by this Pull Request:
After splitting kind into kind & standard runs, I forgot to change the standard call back to kind in the kind integration tests. 


## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test execution in the KinD integration workflow to use KinD-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->