### PR TITLE
Use a UBI 9 image for the Iris pipeline

### DIFF
--- a/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
+++ b/config/internal/apiserver/sample-pipeline/sample-pipeline.yaml.tmpl
@@ -96,7 +96,7 @@ data:
                 \    col_names = [\n        'Sepal_Length', 'Sepal_Width', 'Petal_Length',\
                 \ 'Petal_Width', 'Labels'\n    ]\n    df = pd.read_csv(csv_url, names=col_names)\n\
                 \n    with open(iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+              image: registry.access.redhat.com/ubi9/python-311:latest
           exec-normalize-dataset:
             container:
               args:
@@ -133,7 +133,7 @@ data:
                 \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
                 \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
                 \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+              image: registry.access.redhat.com/ubi9/python-311:latest
           exec-train-model:
             container:
               args:
@@ -178,7 +178,7 @@ data:
                 \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
                 \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
                 \ f)\n\n"
-              image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+              image: registry.access.redhat.com/ubi9/python-311:latest
       pipelineInfo:
         name: iris-training-pipeline
       root:

--- a/docs/example_pipelines/iris/iris-pipeline.py
+++ b/docs/example_pipelines/iris/iris-pipeline.py
@@ -11,7 +11,7 @@ from kfp.dsl import ClassificationMetrics
 
 
 @dsl.component(
-    base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0",
+    base_image="registry.access.redhat.com/ubi9/python-311:latest",
     packages_to_install=['pandas==2.2.0']
 )
 def create_dataset(iris_dataset: Output[Dataset]):
@@ -27,7 +27,7 @@ def create_dataset(iris_dataset: Output[Dataset]):
         df.to_csv(f)
 
 @dsl.component(
-    base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0",
+    base_image="registry.access.redhat.com/ubi9/python-311:latest",
     packages_to_install=['pandas==2.2.0', 'scikit-learn==1.4.0']
 )
 def normalize_dataset(
@@ -54,7 +54,7 @@ def normalize_dataset(
 
 
 @dsl.component(
-    base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0",
+    base_image="registry.access.redhat.com/ubi9/python-311:latest",
     packages_to_install=['pandas==2.2.0', 'scikit-learn==1.4.0']
 )
 def train_model(

--- a/docs/example_pipelines/iris/iris-pipeline.yaml
+++ b/docs/example_pipelines/iris/iris-pipeline.yaml
@@ -86,7 +86,7 @@ deploymentSpec:
           \    col_names = [\n        'Sepal_Length', 'Sepal_Width', 'Petal_Length',\
           \ 'Petal_Width', 'Labels'\n    ]\n    df = pd.read_csv(csv_url, names=col_names)\n\
           \n    with open(iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+        image: registry.access.redhat.com/ubi9/python-311:latest
     exec-normalize-dataset:
       container:
         args:
@@ -123,7 +123,7 @@ deploymentSpec:
           \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
           \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
           \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+        image: registry.access.redhat.com/ubi9/python-311:latest
     exec-train-model:
       container:
         args:
@@ -168,7 +168,7 @@ deploymentSpec:
           \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
           \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
           \ f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+        image: registry.access.redhat.com/ubi9/python-311:latest
 pipelineInfo:
   name: iris-training-pipeline
 root:


### PR DESCRIPTION
## The issue resolved by this Pull Request:

https://issues.redhat.com/browse/RHOAIENG-24702

## Description of your changes:

This uses a UBI 9 image that doesn't require authentication which is more stable than one on Quay. Using a UBI 9 based image will allow it to work on FIPS clusters.

## Testing instructions

I manually uploaded the Iris pipeline to a FIPS cluster and it ran successfully.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the base container image for all pipeline components to use a newer Python 3.11 image. This change affects the runtime environment but does not impact pipeline functionality or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->