### PR TITLE
Rename pipelineStorage field to pipelineStore in API server spec to align with KFP configuration

### DIFF
--- a/api/v1/dspipeline_types.go
+++ b/api/v1/dspipeline_types.go
@@ -157,7 +157,7 @@ type APIServer struct {
 	// +kubebuilder:default:=database
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=database;kubernetes
-	PipelineStorage string `json:"pipelineStorage,omitempty"`
+	PipelineStore string `json:"pipelineStore,omitempty"`
 
 	// Enable/disable caching in the DSP API server. Default: true
 	// +kubebuilder:default:=true

--- a/api/v1alpha1/dspipeline_types.go
+++ b/api/v1alpha1/dspipeline_types.go
@@ -209,7 +209,7 @@ type APIServer struct {
 	// +kubebuilder:default:=database
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=database;kubernetes
-	PipelineStorage string `json:"pipelineStorage,omitempty"`
+	PipelineStore string `json:"pipelineStore,omitempty"`
 
 	// Enable/disable caching in the DSP API server. Default: true
 	// +kubebuilder:default:=true

--- a/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/config/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -186,7 +186,7 @@ spec:
                             type: string
                         type: object
                     type: object
-                  pipelineStorage:
+                  pipelineStore:
                     default: database
                     description: The storage for pipeline definitions (pipelines and
                       pipeline versions). It can be either 'database' or 'kubernetes'
@@ -1175,7 +1175,7 @@ spec:
                       in the ''move-all-results-to-tekton-home'' step. Deprecated:
                       DSP V1 only, will be removed in the future.'
                     type: string
-                  pipelineStorage:
+                  pipelineStore:
                     default: database
                     description: The storage for pipeline definitions (pipelines and
                       pipeline versions). It can be either 'database' or 'kubernetes'

--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -200,7 +200,7 @@ spec:
             - --tlsCertPath=/etc/tls/private/tls.crt
             - --tlsCertKeyPath=/etc/tls/private/tls.key
             {{ end }}
-            {{ if eq .APIServer.PipelineStorage "kubernetes" }}
+            {{ if eq .APIServer.PipelineStore "kubernetes" }}
             - --pipelinesStoreKubernetes=true
             - --disableWebhook=true
             {{ end }}

--- a/config/samples/dspa-kubernetes/dspa_kubernetes.yaml
+++ b/config/samples/dspa-kubernetes/dspa_kubernetes.yaml
@@ -13,7 +13,7 @@ spec:
   apiServer:
     deploy: true
     enableSamplePipeline: true
-    pipelineStorage: kubernetes
+    pipelineStore: kubernetes
   objectStorage:
     minio:
       image: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -304,7 +304,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			return ctrl.Result{}, err
 		}
 
-		if dspa.Spec.APIServer.PipelineStorage == "kubernetes" {
+		if dspa.Spec.APIServer.PipelineStore == "kubernetes" {
 			err = r.ReconcileWebhook(ctx, params)
 			if err != nil {
 				dspaStatus.SetWebhookNotReady(err, config.FailingToDeploy)
@@ -443,7 +443,7 @@ func (r *DSPAReconciler) checkAvailableKubernetesDSPAs(ctx context.Context, excl
 		if dspa.Name == excludeName && dspa.Namespace == excludeNamespace {
 			continue
 		}
-		if dspa.Spec.APIServer != nil && dspa.Spec.APIServer.PipelineStorage == "kubernetes" {
+		if dspa.Spec.APIServer != nil && dspa.Spec.APIServer.PipelineStore == "kubernetes" {
 			return true, nil
 		}
 	}

--- a/controllers/testutil/util.go
+++ b/controllers/testutil/util.go
@@ -289,8 +289,8 @@ func CreateTestDSPA() *dspav1.DataSciencePipelinesApplication {
 	dspa.Spec = dspav1.DSPASpec{
 		PodToPodTLS: boolPtr(false),
 		APIServer: &dspav1.APIServer{
-			Deploy:          true,
-			PipelineStorage: "kubernetes",
+			Deploy:        true,
+			PipelineStore: "kubernetes",
 		},
 		MLMD: &dspav1.MLMD{
 			Deploy: true,

--- a/controllers/webhook.go
+++ b/controllers/webhook.go
@@ -62,7 +62,7 @@ func (r *DSPAReconciler) CleanUpWebhookIfUnused(ctx context.Context, dspa *dspav
 	}
 
 	if !hasK8sDSPAs {
-		log.Info("No other DSPAs with PipelineStorage 'kubernetes' found. Cleaning up webhook resources.")
+		log.Info("No other DSPAs with PipelineStore 'kubernetes' found. Cleaning up webhook resources.")
 		if err := r.cleanupWebhookResources(ctx, params.DSPONamespace); err != nil {
 			log.Error(err, "Failed to clean up webhook resources")
 			return err

--- a/controllers/webhook_test.go
+++ b/controllers/webhook_test.go
@@ -67,7 +67,7 @@ func TestWebhookLifecycle(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("WebhookNotDeployedWithoutKubernetesPipelineStorage", func(t *testing.T) {
+	t.Run("WebhookNotDeployedWithoutKubernetesPipelineStore", func(t *testing.T) {
 		dspa := testutil.CreateEmptyDSPA()
 		dspa.Name = "dspa-non-k8s"
 		dspa.Namespace = "testnamespace"
@@ -147,7 +147,7 @@ func TestWebhookLifecycle(t *testing.T) {
 	})
 
 	t.Run("WebhookPersistsWhenNonKubernetesDSPADeleted", func(t *testing.T) {
-		// First: create a DSPA with kubernetes PipelineStorage to ensure webhook exists
+		// First: create a DSPA with kubernetes PipelineStore to ensure webhook exists
 		k8sDSPA := testutil.CreateTestDSPA()
 
 		os.Setenv("DSPO_NAMESPACE", "testDSPONamespace")
@@ -175,7 +175,7 @@ func TestWebhookLifecycle(t *testing.T) {
 		assert.True(t, created)
 		require.NoError(t, err)
 
-		//Create a DSPA with non-kubernetes PipelineStorage
+		//Create a DSPA with non-kubernetes PipelineStore
 		nonK8sDSPA := testutil.CreateEmptyDSPA()
 		nonK8sDSPA.Name = "dspa-non-k8s"
 		nonK8sDSPA.Namespace = "testnamespace"

--- a/main.go
+++ b/main.go
@@ -148,12 +148,12 @@ func main() {
 		LeaderElectionID:       "f9eb95d5.opendatahub.io",
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
-				// Limit the watches to the pipelineversions.pipelines.kubeflow.org webhooks in the DSPO namespace.
+				// Limit the watches to only the pipelineversions.pipelines.kubeflow.org webhooks.
 				&admv1.ValidatingWebhookConfiguration{}: {
-					Field: fields.SelectorFromSet(fields.Set{"metadata.name": webhookConfigName, "metadata.namespace": dspoNamespace}),
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": webhookConfigName}),
 				},
 				&admv1.MutatingWebhookConfiguration{}: {
-					Field: fields.SelectorFromSet(fields.Set{"metadata.name": webhookConfigName, "metadata.namespace": dspoNamespace}),
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": webhookConfigName}),
 				},
 			},
 		},

--- a/tests/dspa_v2_test.go
+++ b/tests/dspa_v2_test.go
@@ -93,12 +93,12 @@ func (suite *IntegrationTestSuite) TestDSPADeployment() {
 }
 
 func (suite *IntegrationTestSuite) TestDSPADeploymentWithK8sNativeApi() {
-	// Skip the entire test if PipelineStorage is not set to kubernetes
-	if suite.DSPA.Spec.APIServer.PipelineStorage != "kubernetes" {
-		suite.T().Log("PipelineStorage is not set to kubernetes, skipping K8s Native API verification tests")
+	// Skip the entire test if PipelineStore is not set to kubernetes
+	if suite.DSPA.Spec.APIServer.PipelineStore != "kubernetes" {
+		suite.T().Log("PipelineStore is not set to kubernetes, skipping K8s Native API verification tests")
 		suite.T().SkipNow()
 	}
-	suite.T().Run("should verify API Server configuration based on PipelineStorage", func(t *testing.T) {
+	suite.T().Run("should verify API Server configuration based on PipelineStore", func(t *testing.T) {
 		timeout := time.Second * 120
 		interval := time.Second * 2
 

--- a/tests/pipeline_runs_test.go
+++ b/tests/pipeline_runs_test.go
@@ -32,8 +32,8 @@ func (suite *IntegrationTestSuite) TestPipelineSuccessfulRun() {
 
 	suite.T().Run("Should create a Pipeline Run", func(t *testing.T) {
 
-		if suite.DSPA.Spec.APIServer.PipelineStorage == "kubernetes" {
-			t.Log("PipelineStorage is set to kubernetes, skipping this test.")
+		if suite.DSPA.Spec.APIServer.PipelineStore == "kubernetes" {
+			t.Log("PipelineStore is set to kubernetes, skipping this test.")
 			t.SkipNow()
 		}
 		suite.runPipelineTest(t, "[Demo] iris-training")
@@ -44,8 +44,8 @@ func (suite *IntegrationTestSuite) TestPipelineSuccessfulRun() {
 	})
 
 	suite.T().Run("Should create a k8s Pipeline Run", func(t *testing.T) {
-		if suite.DSPA.Spec.APIServer.PipelineStorage != "kubernetes" {
-			t.Log("PipelineStorage is not set to kubernetes, skipping k8s pipeline run")
+		if suite.DSPA.Spec.APIServer.PipelineStore != "kubernetes" {
+			t.Log("PipelineStore is not set to kubernetes, skipping k8s pipeline run")
 			t.SkipNow()
 		}
 		// Apply the Pipeline and PipelineVersion Kubernetes resources

--- a/tests/resources/dspa-k8s.yaml
+++ b/tests/resources/dspa-k8s.yaml
@@ -12,7 +12,7 @@ spec:
     cABundle:
       configMapName: nginx-tls-config
       configMapKey: rootCA.crt
-    pipelineStorage: kubernetes
+    pipelineStore: kubernetes
     webhookAnnotations:
       cert-manager.io/inject-ca-from: opendatahub/dspa-webhook-cert
     resources:


### PR DESCRIPTION
## The issue resolved by this Pull Request:
This PR renames the field `spec.apiServer.pipelineStorage` to `spec.apiServer.pipelineStore` to align with the `pipelineStore` configuration option in Kubeflow Pipelines, which determines whether pipelines and pipeline versions are stored in the Kubernetes API or in a database.

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the configuration field from "pipelineStorage" to "pipelineStore" across all user-facing configuration files, CRDs, logs, and documentation.
  - Updated sample and test configurations to use the new field name for consistency.
- **Bug Fixes**
  - Improved webhook configuration caching by removing namespace restrictions, enhancing webhook management reliability.
- **Documentation**
  - Updated references and descriptions to reflect the new "pipelineStore" terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->