### PR TITLE
Added `kubectl get pods` to log collection in the CI

### DIFF
--- a/.github/scripts/tests/collect_logs.sh
+++ b/.github/scripts/tests/collect_logs.sh
@@ -51,6 +51,13 @@ function display_pod_info {
     done
 }
 
+function get_pods {
+    local NAMESPACE=$1
+    echo "===== kubectl get pods -n ${NAMESPACE} ====="
+    kubectl get pods -n "${NAMESPACE}"
+    echo "==========================="
+}
+
 function collect_workflow_info {
     local NAMESPACE=$1
 
@@ -67,6 +74,8 @@ function collect_workflow_info {
 
 check_namespace "$DSPA_NS"
 check_namespace "$DSPO_NS"
+
+get_pods "$DSPA_NS"
 
 display_pod_info "$DSPA_NS"
 display_pod_info "$DSPO_NS"

--- a/.github/scripts/tests/collect_logs.sh
+++ b/.github/scripts/tests/collect_logs.sh
@@ -53,7 +53,7 @@ function display_pod_info {
 
 function get_pods {
     local NAMESPACE=$1
-    echo "===== kubectl get pods -n ${NAMESPACE} ====="
+    echo "===== List of pods in the '${NAMESPACE}' namespace ====="
     kubectl get pods -n "${NAMESPACE}"
     echo "==========================="
 }


### PR DESCRIPTION
## Description of your changes:
Added `kubectl get pods` to log collection in the CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log collection script to display pod information with clearer formatting.
  - Addressed a syntax error that could cause a runtime issue in the script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->