### PR TITLE
fix: missing new parameter WEBHOOK_ANNOTATION by kustomization

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -188,5 +188,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.FIPSENABLED
+  - name: WEBHOOK_ANNOTATIONS
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.WEBHOOK_ANNOTATIONS
 configurations:
   - params.yaml


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #<issue_number>

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
follow changes from https://github.com/opendatahub-io/data-science-pipelines-operator/pull/871
to fix error when DSPO start up:
```
        - name: WEBHOOK_ANNOTATIONS
          value: $(WEBHOOK_ANNOTATIONS)
```
crashloop:
```
2025-06-17T08:44:05Z ERROR setup the WEBHOOK_ANNOTATIONS environment variable is not a valid JSON object {"error": "invalid character '$' looking for beginning of value"}
main.main
/workspace/main.go:172
runtime.main
/usr/lib/golang/src/runtime/proc.go:271
```

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
