### PR TITLE
Add WEBHOOK_ANNOTATION param to params.py

### DIFF
--- a/scripts/release/params.py
+++ b/scripts/release/params.py
@@ -47,7 +47,8 @@ OTHER_OPTIONS = {
     "DSPO_APISERVER_INCLUDE_OWNERREFERENCE": "true",
     "MANAGEDPIPELINES": "\"{}\"",
     "PLATFORMVERSION": "\"v0.0.0\"",
-    "FIPSENABLED": "false"
+    "FIPSENABLED": "false",
+    "WEBHOOK_ANNOTATIONS": ""
 }
 
 


### PR DESCRIPTION
Add WEBHOOK_ANNOTATION param to params.py in order to generate params.env correctly.

