### PR TITLE
Bump Go version used in nightly tests

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19.x'
+          go-version: '1.21.x'
       - name: Run Build
         run: make build
       - name: Run Unit Tests


### PR DESCRIPTION
Nightly tests have been failing for months, which happened when we upgraded the containertools version.  It appears bumping goversion to 1.21+ may fix this, and also brings this in alignment with all the other workflows

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly testing workflow to use a newer Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->