### PR TITLE
chore: Update GHActions to source go version from go.mod

### DIFF
--- a/.github/workflows/functests.yml
+++ b/.github/workflows/functests.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Functional Tests
         env:
           SSL_CERT_FILE: ${{ github.workspace }}/controllers/testdata/tls/ca-bundle.crt

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -40,9 +40,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
         id: go
 
       - name: Setup and start KinD cluster

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Build
         run: make build
       - name: Run Unit Tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Unit Tests
         run: make unittest


### PR DESCRIPTION
Source the go version used in github actions dynamically from the repo go.mod file

## Testing instructions
CI Passes

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the latest version of the Go setup action.
  * Go version is now automatically detected from the project configuration file instead of being hardcoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->