### PR TITLE
chore: Use go.mod to get go version for CI setup

### DIFF
--- a/.github/workflows/functests.yml
+++ b/.github/workflows/functests.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Functional Tests
         env:
           SSL_CERT_FILE: ${{ github.workspace }}/controllers/testdata/tls/ca-bundle.crt

--- a/.github/workflows/kind-integration-byoargo.yml
+++ b/.github/workflows/kind-integration-byoargo.yml
@@ -40,9 +40,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
         id: go
 
       - name: Setup and start KinD cluster

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -40,9 +40,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
         id: go
 
       - name: Setup and start KinD cluster

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Build
         run: make build
       - name: Run Unit Tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
       - name: Run Unit Tests
         run: make unittest


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Update CI to dynamically retrieve the go version to set up the its environment with

## Description of your changes:
update setup-go actions to use v4 and source go version from project `go.mod` file rather than a hard-coded value

## Testing instructions
CI passes

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows (Functional Tests, Kind Integration including BYO Argo, Nightly Tests, Unit Tests) now derive the Go toolchain version from go.mod instead of a hard-coded value.
  * Upgraded the Go setup action to the latest major version across these workflows for improved reliability.
  * No changes to application behavior; updates streamline maintenance and ensure consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->