### PR TITLE
Update CRDs and RBAC to reflect upstream Argo v3.6.7

### DIFF
--- a/config/argo/clusterrole.argo-aggregate-to-admin.yaml
+++ b/config/argo/clusterrole.argo-aggregate-to-admin.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: argo-aggregate-to-admin
-  annotations:
-    internal.kpt.dev/upstream-identifier: "rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-admin"
 rules:
 - apiGroups:
   - argoproj.io

--- a/config/argo/clusterrole.argo-aggregate-to-edit.yaml
+++ b/config/argo/clusterrole.argo-aggregate-to-edit.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: argo-aggregate-to-edit
-  annotations:
-    internal.kpt.dev/upstream-identifier: "rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-edit"
 rules:
 - apiGroups:
   - argoproj.io

--- a/config/argo/clusterrole.argo-aggregate-to-view.yaml
+++ b/config/argo/clusterrole.argo-aggregate-to-view.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: argo-aggregate-to-view
-  annotations:
-    internal.kpt.dev/upstream-identifier: "rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-view"
 rules:
 - apiGroups:
   - argoproj.io

--- a/config/argo/clusterrole.argo-cluster-role.yaml
+++ b/config/argo/clusterrole.argo-cluster-role.yaml
@@ -2,8 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: argo-cluster-role
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-cluster-role'
 rules:
 - apiGroups:
   - ""
@@ -22,6 +20,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   verbs:
   - get
   - watch
@@ -64,13 +63,13 @@ rules:
   - list
   - watch
 - apiGroups:
-  - argoproj.io
+    - argoproj.io
   resources:
-  - workflowtaskresults
+    - workflowtaskresults
   verbs:
-  - list
-  - watch
-  - deletecollection
+    - list
+    - watch
+    - deletecollection
 - apiGroups:
   - ""
   resources:
@@ -98,18 +97,18 @@ rules:
   - create
   - patch
 - apiGroups:
-  - "policy"
+    - "policy"
   resources:
-  - poddisruptionbudgets
+    - poddisruptionbudgets
   verbs:
-  - create
-  - get
-  - delete
+    - create
+    - get
+    - delete
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - secrets
+    - secrets
   verbs:
-  - get
+    - get
   resourceNames:
-  - argo-workflows-agent-ca-certificates
+    - argo-workflows-agent-ca-certificates

--- a/config/argo/clusterrolebinding.ds-pipeline-argo-binding.yaml
+++ b/config/argo/clusterrolebinding.ds-pipeline-argo-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argo-binding
+  name: ds-pipeline-argo-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/argo/crd.clusterworkflowtemplates.yaml
+++ b/config/argo/crd.clusterworkflowtemplates.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|clusterworkflowtemplates.argoproj.io
   name: clusterworkflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/config/argo/crd.cronworkflows.yaml
+++ b/config/argo/crd.cronworkflows.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|cronworkflows.argoproj.io
   name: cronworkflows.argoproj.io
 spec:
   group: argoproj.io

--- a/config/argo/crd.workflowartifactgctasks.yaml
+++ b/config/argo/crd.workflowartifactgctasks.yaml
@@ -1,3 +1,4 @@
+# This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9,33 +10,1129 @@ spec:
     listKind: WorkflowArtifactGCTaskList
     plural: workflowartifactgctasks
     shortNames:
-      - wfat
+    - wfat
     singular: workflowartifactgctask
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              x-kubernetes-map-type: atomic
-              x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              x-kubernetes-map-type: atomic
-              x-kubernetes-preserve-unknown-fields: true
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              artifactsByNode:
+                additionalProperties:
+                  properties:
+                    archiveLocation:
+                      properties:
+                        archiveLogs:
+                          type: boolean
+                        artifactory:
+                          properties:
+                            passwordSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            url:
+                              type: string
+                            usernameSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - url
+                          type: object
+                        azure:
+                          properties:
+                            accountKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            blob:
+                              type: string
+                            container:
+                              type: string
+                            endpoint:
+                              type: string
+                            useSDKCreds:
+                              type: boolean
+                          required:
+                          - blob
+                          - container
+                          - endpoint
+                          type: object
+                        gcs:
+                          properties:
+                            bucket:
+                              type: string
+                            key:
+                              type: string
+                            serviceAccountKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - key
+                          type: object
+                        git:
+                          properties:
+                            branch:
+                              type: string
+                            depth:
+                              format: int64
+                              type: integer
+                            disableSubmodules:
+                              type: boolean
+                            fetch:
+                              items:
+                                type: string
+                              type: array
+                            insecureIgnoreHostKey:
+                              type: boolean
+                            insecureSkipTLS:
+                              type: boolean
+                            passwordSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            repo:
+                              type: string
+                            revision:
+                              type: string
+                            singleBranch:
+                              type: boolean
+                            sshPrivateKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            usernameSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - repo
+                          type: object
+                        hdfs:
+                          properties:
+                            addresses:
+                              items:
+                                type: string
+                              type: array
+                            dataTransferProtection:
+                              type: string
+                            force:
+                              type: boolean
+                            hdfsUser:
+                              type: string
+                            krbCCacheSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbConfigConfigMap:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbKeytabSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbRealm:
+                              type: string
+                            krbServicePrincipalName:
+                              type: string
+                            krbUsername:
+                              type: string
+                            path:
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        http:
+                          properties:
+                            auth:
+                              properties:
+                                basicAuth:
+                                  properties:
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    usernameSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                clientCert:
+                                  properties:
+                                    clientCertSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientKeySecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                oauth2:
+                                  properties:
+                                    clientIDSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientSecretSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    endpointParams:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenURLSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        oss:
+                          properties:
+                            accessKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            bucket:
+                              type: string
+                            createBucketIfNotPresent:
+                              type: boolean
+                            endpoint:
+                              type: string
+                            key:
+                              type: string
+                            lifecycleRule:
+                              properties:
+                                markDeletionAfterDays:
+                                  format: int32
+                                  type: integer
+                                markInfrequentAccessAfterDays:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            secretKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            securityToken:
+                              type: string
+                            useSDKCreds:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        raw:
+                          properties:
+                            data:
+                              type: string
+                          required:
+                          - data
+                          type: object
+                        s3:
+                          properties:
+                            accessKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            bucket:
+                              type: string
+                            caSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            createBucketIfNotPresent:
+                              properties:
+                                objectLocking:
+                                  type: boolean
+                              type: object
+                            encryptionOptions:
+                              properties:
+                                enableEncryption:
+                                  type: boolean
+                                kmsEncryptionContext:
+                                  type: string
+                                kmsKeyId:
+                                  type: string
+                                serverSideCustomerKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            endpoint:
+                              type: string
+                            insecure:
+                              type: boolean
+                            key:
+                              type: string
+                            region:
+                              type: string
+                            roleARN:
+                              type: string
+                            secretKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sessionTokenSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            useSDKCreds:
+                              type: boolean
+                          type: object
+                      type: object
+                    artifacts:
+                      additionalProperties:
+                        properties:
+                          archive:
+                            properties:
+                              none:
+                                type: object
+                              tar:
+                                properties:
+                                  compressionLevel:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              zip:
+                                type: object
+                            type: object
+                          archiveLogs:
+                            type: boolean
+                          artifactGC:
+                            properties:
+                              podMetadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              serviceAccountName:
+                                type: string
+                              strategy:
+                                enum:
+                                - ""
+                                - OnWorkflowCompletion
+                                - OnWorkflowDeletion
+                                - Never
+                                type: string
+                            type: object
+                          artifactory:
+                            properties:
+                              passwordSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              url:
+                                type: string
+                              usernameSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - url
+                            type: object
+                          azure:
+                            properties:
+                              accountKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              blob:
+                                type: string
+                              container:
+                                type: string
+                              endpoint:
+                                type: string
+                              useSDKCreds:
+                                type: boolean
+                            required:
+                            - blob
+                            - container
+                            - endpoint
+                            type: object
+                          deleted:
+                            type: boolean
+                          from:
+                            type: string
+                          fromExpression:
+                            type: string
+                          gcs:
+                            properties:
+                              bucket:
+                                type: string
+                              key:
+                                type: string
+                              serviceAccountKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - key
+                            type: object
+                          git:
+                            properties:
+                              branch:
+                                type: string
+                              depth:
+                                format: int64
+                                type: integer
+                              disableSubmodules:
+                                type: boolean
+                              fetch:
+                                items:
+                                  type: string
+                                type: array
+                              insecureIgnoreHostKey:
+                                type: boolean
+                              insecureSkipTLS:
+                                type: boolean
+                              passwordSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              repo:
+                                type: string
+                              revision:
+                                type: string
+                              singleBranch:
+                                type: boolean
+                              sshPrivateKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              usernameSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - repo
+                            type: object
+                          globalName:
+                            type: string
+                          hdfs:
+                            properties:
+                              addresses:
+                                items:
+                                  type: string
+                                type: array
+                              dataTransferProtection:
+                                type: string
+                              force:
+                                type: boolean
+                              hdfsUser:
+                                type: string
+                              krbCCacheSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbConfigConfigMap:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbKeytabSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbRealm:
+                                type: string
+                              krbServicePrincipalName:
+                                type: string
+                              krbUsername:
+                                type: string
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          http:
+                            properties:
+                              auth:
+                                properties:
+                                  basicAuth:
+                                    properties:
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      usernameSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientCert:
+                                    properties:
+                                      clientCertSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      clientKeySecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  oauth2:
+                                    properties:
+                                      clientIDSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      clientSecretSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      endpointParams:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - key
+                                          type: object
+                                        type: array
+                                      scopes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      tokenURLSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                type: object
+                              headers:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              url:
+                                type: string
+                            required:
+                            - url
+                            type: object
+                          mode:
+                            format: int32
+                            type: integer
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                          oss:
+                            properties:
+                              accessKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              bucket:
+                                type: string
+                              createBucketIfNotPresent:
+                                type: boolean
+                              endpoint:
+                                type: string
+                              key:
+                                type: string
+                              lifecycleRule:
+                                properties:
+                                  markDeletionAfterDays:
+                                    format: int32
+                                    type: integer
+                                  markInfrequentAccessAfterDays:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              secretKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              securityToken:
+                                type: string
+                              useSDKCreds:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          path:
+                            type: string
+                          raw:
+                            properties:
+                              data:
+                                type: string
+                            required:
+                            - data
+                            type: object
+                          recurseMode:
+                            type: boolean
+                          s3:
+                            properties:
+                              accessKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              bucket:
+                                type: string
+                              caSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              createBucketIfNotPresent:
+                                properties:
+                                  objectLocking:
+                                    type: boolean
+                                type: object
+                              encryptionOptions:
+                                properties:
+                                  enableEncryption:
+                                    type: boolean
+                                  kmsEncryptionContext:
+                                    type: string
+                                  kmsKeyId:
+                                    type: string
+                                  serverSideCustomerKeySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              endpoint:
+                                type: string
+                              insecure:
+                                type: boolean
+                              key:
+                                type: string
+                              region:
+                                type: string
+                              roleARN:
+                                type: string
+                              secretKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sessionTokenSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              useSDKCreds:
+                                type: boolean
+                            type: object
+                          subPath:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: object
+                  type: object
+                type: object
+            type: object
+          status:
+            properties:
+              artifactResultsByNode:
+                additionalProperties:
+                  properties:
+                    artifactResults:
+                      additionalProperties:
+                        properties:
+                          error:
+                            type: string
+                          name:
+                            type: string
+                          success:
+                            type: boolean
+                        required:
+                        - name
+                        type: object
+                      type: object
+                  type: object
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/argo/crd.workfloweventbinding.yaml
+++ b/config/argo/crd.workfloweventbinding.yaml
@@ -1,8 +1,7 @@
+# This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workfloweventbindings.argoproj.io
   name: workfloweventbindings.argoproj.io
 spec:
   group: argoproj.io
@@ -26,9 +25,674 @@ spec:
           metadata:
             type: object
           spec:
+            properties:
+              event:
+                properties:
+                  selector:
+                    type: string
+                required:
+                - selector
+                type: object
+              submit:
+                properties:
+                  arguments:
+                    properties:
+                      artifacts:
+                        items:
+                          properties:
+                            archive:
+                              properties:
+                                none:
+                                  type: object
+                                tar:
+                                  properties:
+                                    compressionLevel:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                zip:
+                                  type: object
+                              type: object
+                            archiveLogs:
+                              type: boolean
+                            artifactGC:
+                              properties:
+                                podMetadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                serviceAccountName:
+                                  type: string
+                                strategy:
+                                  enum:
+                                  - ""
+                                  - OnWorkflowCompletion
+                                  - OnWorkflowDeletion
+                                  - Never
+                                  type: string
+                              type: object
+                            artifactory:
+                              properties:
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                url:
+                                  type: string
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - url
+                              type: object
+                            azure:
+                              properties:
+                                accountKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                blob:
+                                  type: string
+                                container:
+                                  type: string
+                                endpoint:
+                                  type: string
+                                useSDKCreds:
+                                  type: boolean
+                              required:
+                              - blob
+                              - container
+                              - endpoint
+                              type: object
+                            deleted:
+                              type: boolean
+                            from:
+                              type: string
+                            fromExpression:
+                              type: string
+                            gcs:
+                              properties:
+                                bucket:
+                                  type: string
+                                key:
+                                  type: string
+                                serviceAccountKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - key
+                              type: object
+                            git:
+                              properties:
+                                branch:
+                                  type: string
+                                depth:
+                                  format: int64
+                                  type: integer
+                                disableSubmodules:
+                                  type: boolean
+                                fetch:
+                                  items:
+                                    type: string
+                                  type: array
+                                insecureIgnoreHostKey:
+                                  type: boolean
+                                insecureSkipTLS:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                repo:
+                                  type: string
+                                revision:
+                                  type: string
+                                singleBranch:
+                                  type: boolean
+                                sshPrivateKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - repo
+                              type: object
+                            globalName:
+                              type: string
+                            hdfs:
+                              properties:
+                                addresses:
+                                  items:
+                                    type: string
+                                  type: array
+                                dataTransferProtection:
+                                  type: string
+                                force:
+                                  type: boolean
+                                hdfsUser:
+                                  type: string
+                                krbCCacheSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbConfigConfigMap:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbKeytabSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbRealm:
+                                  type: string
+                                krbServicePrincipalName:
+                                  type: string
+                                krbUsername:
+                                  type: string
+                                path:
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            http:
+                              properties:
+                                auth:
+                                  properties:
+                                    basicAuth:
+                                      properties:
+                                        passwordSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        usernameSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    clientCert:
+                                      properties:
+                                        clientCertSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        clientKeySecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    oauth2:
+                                      properties:
+                                        clientIDSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        clientSecretSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        endpointParams:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - key
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenURLSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                headers:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                url:
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            mode:
+                              format: int32
+                              type: integer
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                            oss:
+                              properties:
+                                accessKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                bucket:
+                                  type: string
+                                createBucketIfNotPresent:
+                                  type: boolean
+                                endpoint:
+                                  type: string
+                                key:
+                                  type: string
+                                lifecycleRule:
+                                  properties:
+                                    markDeletionAfterDays:
+                                      format: int32
+                                      type: integer
+                                    markInfrequentAccessAfterDays:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                secretKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                securityToken:
+                                  type: string
+                                useSDKCreds:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            path:
+                              type: string
+                            raw:
+                              properties:
+                                data:
+                                  type: string
+                              required:
+                              - data
+                              type: object
+                            recurseMode:
+                              type: boolean
+                            s3:
+                              properties:
+                                accessKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                bucket:
+                                  type: string
+                                caSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                createBucketIfNotPresent:
+                                  properties:
+                                    objectLocking:
+                                      type: boolean
+                                  type: object
+                                encryptionOptions:
+                                  properties:
+                                    enableEncryption:
+                                      type: boolean
+                                    kmsEncryptionContext:
+                                      type: string
+                                    kmsKeyId:
+                                      type: string
+                                    serverSideCustomerKeySecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                endpoint:
+                                  type: string
+                                insecure:
+                                  type: boolean
+                                key:
+                                  type: string
+                                region:
+                                  type: string
+                                roleARN:
+                                  type: string
+                                secretKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sessionTokenSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                useSDKCreds:
+                                  type: boolean
+                              type: object
+                            subPath:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      parameters:
+                        items:
+                          properties:
+                            default:
+                              type: string
+                            description:
+                              type: string
+                            enum:
+                              items:
+                                type: string
+                              type: array
+                            globalName:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                default:
+                                  type: string
+                                event:
+                                  type: string
+                                expression:
+                                  type: string
+                                jqFilter:
+                                  type: string
+                                jsonPath:
+                                  type: string
+                                parameter:
+                                  type: string
+                                path:
+                                  type: string
+                                supplied:
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  workflowTemplateRef:
+                    properties:
+                      clusterScope:
+                        type: boolean
+                      name:
+                        type: string
+                    type: object
+                required:
+                - workflowTemplateRef
+                type: object
+            required:
+            - event
             type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - spec

--- a/config/argo/crd.workflows.yaml
+++ b/config/argo/crd.workflows.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: "apiextensions.k8s.io|CustomResourceDefinition|default|workflows.argoproj.io"
   name: workflows.argoproj.io
 spec:
   group: argoproj.io
@@ -25,7 +23,8 @@ spec:
       jsonPath: .status.startedAt
       name: Age
       type: date
-    - description: Human readable message indicating details about why the workflow is in this condition.
+    - description: Human readable message indicating details about why the workflow
+        is in this condition.
       jsonPath: .status.message
       name: Message
       type: string

--- a/config/argo/crd.workflowtaskresult.yaml
+++ b/config/argo/crd.workflowtaskresult.yaml
@@ -1,9 +1,8 @@
+# This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtaskresults.argoproj.io
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtaskresults.argoproj.io'
 spec:
   group: argoproj.io
   names:
@@ -75,12 +74,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         url:
                           type: string
                         usernameSecret:
@@ -88,12 +89,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - url
                       type: object
@@ -104,12 +107,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         blob:
                           type: string
                         container:
@@ -140,12 +145,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - key
                       type: object
@@ -164,17 +171,21 @@ spec:
                           type: array
                         insecureIgnoreHostKey:
                           type: boolean
+                        insecureSkipTLS:
+                          type: boolean
                         passwordSecret:
                           properties:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         repo:
                           type: string
                         revision:
@@ -186,23 +197,27 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         usernameSecret:
                           properties:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - repo
                       type: object
@@ -214,6 +229,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataTransferProtection:
+                          type: string
                         force:
                           type: boolean
                         hdfsUser:
@@ -223,34 +240,40 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         krbConfigConfigMap:
                           properties:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         krbKeytabSecret:
                           properties:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         krbRealm:
                           type: string
                         krbServicePrincipalName:
@@ -273,23 +296,27 @@ spec:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 usernameSecret:
                                   properties:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             clientCert:
                               properties:
@@ -298,23 +325,27 @@ spec:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 clientKeySecret:
                                   properties:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             oauth2:
                               properties:
@@ -323,23 +354,27 @@ spec:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 clientSecretSecret:
                                   properties:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 endpointParams:
                                   items:
                                     properties:
@@ -360,12 +395,14 @@ spec:
                                     key:
                                       type: string
                                     name:
+                                      default: ""
                                       type: string
                                     optional:
                                       type: boolean
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           type: object
                         headers:
@@ -399,12 +436,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         bucket:
                           type: string
                         createBucketIfNotPresent:
@@ -427,12 +466,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         securityToken:
                           type: string
                         useSDKCreds:
@@ -458,12 +499,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         bucket:
                           type: string
                         caSecret:
@@ -471,12 +514,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         createBucketIfNotPresent:
                           properties:
                             objectLocking:
@@ -495,12 +540,14 @@ spec:
                                 key:
                                   type: string
                                 name:
+                                  default: ""
                                   type: string
                                 optional:
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         endpoint:
                           type: string
@@ -517,12 +564,27 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
+                        sessionTokenSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                         useSDKCreds:
                           type: boolean
                       type: object
@@ -558,12 +620,14 @@ spec:
                             key:
                               type: string
                             name:
+                              default: ""
                               type: string
                             optional:
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         default:
                           type: string
                         event:

--- a/config/argo/crd.workflowtaskset.yaml
+++ b/config/argo/crd.workflowtaskset.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowtasksets.argoproj.io
   name: workflowtasksets.argoproj.io
 spec:
   group: argoproj.io

--- a/config/argo/crd.workflowtemplate.yaml
+++ b/config/argo/crd.workflowtemplate.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowtemplates.argoproj.io
   name: workflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/config/argo/kustomization.yaml
+++ b/config/argo/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 - clusterrole.argo-aggregate-to-edit.yaml
 - clusterrole.argo-aggregate-to-view.yaml
 - clusterrole.argo-cluster-role.yaml
-- clusterrolebinding.argo-binding.yaml
+- clusterrolebinding.ds-pipeline-argo-binding.yaml
 - configmap.workflow-controller-configmap.yaml
 # - deployment.workflow-controller.yaml
 # - priorityclass.yaml

--- a/config/argo/role.argo.yaml
+++ b/config/argo/role.argo.yaml
@@ -3,118 +3,116 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-role
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|argo-role'
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/exec
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-    - ""
-  resources:
-  - persistentvolumeclaims
-  - persistentvolumeclaims/finalizers
-  verbs:
-  - create
-  - update
-  - delete
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
-  - workflows
-  - workflows/finalizers
-  - workflowtasksets
-  - workflowtasksets/finalizers
-  - workflowartifactgctasks
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-  - create
-- apiGroups:
-  - argoproj.io
-  resources:
-  - workflowtemplates
-  - workflowtemplates/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - argoproj.io
-  resources:
-  - workflowtaskresults
-  verbs:
-  - list
-  - watch
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
-  - cronworkflows
-  - cronworkflows/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - "policy"
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-  - get
-  - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/exec
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+      - persistentvolumeclaims/finalizers
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+      - workflows/finalizers
+      - workflowtasksets
+      - workflowtasksets/finalizers
+      - workflowartifactgctasks
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+      - create
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtemplates
+      - workflowtemplates/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - list
+      - watch
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - cronworkflows
+      - cronworkflows/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "policy"
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - get
+      - delete


### PR DESCRIPTION
## Description of your changes:
Updating CRDs and RBAC to match upstream manifests.   Additionally, changing name of the argo-binding ClusterRoleBinding as this conflicts with unmanaged/external Argo Workflows installations and can cause some conflicts/collisions that prevent WCs from deploying

## Testing instructions
`make deploy` the codebase (no code changes so latest image is fine). deploy external argo v3.6.7 to `argo` namespace  ensure CRDs and RBAC files are `unchanged`.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded CRD schemas:
    - WorkflowArtifactGCTask: comprehensive spec/status schema.
    - WorkflowEventBinding: new event (required), submit, metadata, workflowTemplateRef fields.
    - WorkflowTaskResult: added dataTransferProtection, insecureSkipTLS, sessionTokenSecret, endpointParams, defaults.
  - ClusterRole now includes read access to namespaces.
- Chores
  - Renamed ClusterRoleBinding to ds-pipeline-argo-binding and updated kustomization.
  - Removed internal annotations from multiple Argo roles/CRDs.
- Style
  - Minor YAML formatting/indentation cleanups.
  - Updated a printer column description to multiline in Workflows CRD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->