### PR TITLE
Make leader election leases longer

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,6 +138,12 @@ func main() {
 		glog.Fatal(err)
 	}
 
+	// Lease is valid for 60 seconds, but renew it after 15 seconds and then give up after 50 seconds.
+	// This will lessen the load on the Kubernetes API server and help reduce the number of restarts on the pod.
+	leaseDuration := 60 * time.Second
+	retryPeriod := 15 * time.Second
+	renewDeadline := 50 * time.Second
+
 	webhookConfigName := "pipelineversions.pipelines.kubeflow.org"
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -147,6 +153,9 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f9eb95d5.opendatahub.io",
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
+		RetryPeriod:            &retryPeriod,
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				// Limit the watches to only the pipelineversions.pipelines.kubeflow.org webhooks.


### PR DESCRIPTION
## The issue resolved by this Pull Request:

https://issues.redhat.com/browse/RHOAIENG-5498

## Description of your changes:

This will lessen the load on the Kubernetes API server and help reduce the number of restarts on the pod.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces leader election lease configuration for the controller manager, improving stability and failover behavior in high-availability environments.
  * Applies tuned lease duration, renew deadline, and retry period to reduce downtime during restarts and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->