### PR TITLE
Add resources and docs to deploy DSPO with KinD

### DIFF
--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -40,6 +40,10 @@ ENDPOINT_TYPE="service"
 DSPO_IMAGE_REF="${DSPO_IMAGE_REF:-}"
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 RUN_PKG_UPLOADER_IN_CONTAINER="${RUN_PKG_UPLOADER_IN_CONTAINER:-true}"
+SETUP_ONLY="${SETUP_ONLY}"
+TEST_BASIC="${INTTEST_BASIC}"
+TEST_EXT_CONNECTIONS="${INTTEST_EXT_CONNECTIONS}"
+TEST_K8S_STORE="${INTTEST_K8S_STORE}"
 
 get_dspo_image() {
   if [ ! -z "$DSPO_IMAGE_REF" ]; then
@@ -546,8 +550,32 @@ else
   if [ "$DEPLOY_EXTERNAL_ARGO" = true ]; then
     setup_external_argo
   fi
+
+  # If SETUP_ONLY set, exit without running tests.
+  if [ "$SETUP_ONLY" = true ]; then
+    exit 0
+  fi
+
+  # If TEST_BASIC set, run integration tests only with no modifications.
+  if [ "$TEST_BASIC" = true ]; then
+    run_tests
+    exit 0
+  fi
+
+  # If TEST_K8S_STORE set, run integration tests only with k8s pipeline storage enabled.
+  if [ "$TEST_K8S_STORE" = true ]; then
+    run_tests_dspa_k8s
+    exit 0
+  fi
+
+  # If TEST_EXT_CONNECTIONS set, run integration tests only with external connections enabled.
+  if [ "$TEST_EXT_CONNECTIONS" = true ]; then
+    run_tests_dspa_external_connections
+    exit 0
+  fi
 fi
 
+# If none of the above modifications are enabled, run all three iterations of integration tests.
 run_tests
 run_tests_dspa_k8s
 run_tests_dspa_external_connections

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# How to Contribute
+
+## Contribution Guidelines
+See the below guidelines for contributing to DSPO.
+
+## Deploy DSPO on Kind
+Run integration tests on a local [kind](https://kind.sigs.k8s.io/) cluster.
+
+### Prerequisites
+- The [kind CLI](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) is installed.
+
+### 1. Create Kind cluster and deploy DSPO
+#### Optional: Deploy DSPO with non-main changes
+By default, the commands above deploy an image built from the DSPO `main` branch. To deploy DSPO with local changes, run the following command to build and push the custom image to your image repository.
+>Note: Set `IMG_REGISTRY` to your preferred image registry before running this command.
+
+```shell
+make image-dspo
+```
+Then update `config/overlays/kind-tests/kustomization.yaml` with the DSPO image you built and pushed above. For example:
+```yaml
+images:
+- name: controller
+  newName: quay.io/username/dspo
+  newTag: 1
+```
+
+
+#### Deploy DSPO with default settings
+The following command creates a kind cluster, sets up DSPO requirements and deploys DSPO on the cluster.
+```shell
+make kind-setup
+```
+
+#### OR Deploy DSPO with external Argo Workflows enabled
+To deploy DSPO with external Argo Workflows enabled instead, execute the command below.
+```shell
+make kind-setup-externalargo
+```
+
+### 2. Run integration tests
+`tests/suite_test.go` deploys DSPA and runs the integration tests, with different configurations in the following Make targets:
+- `kind-integrationtest` deploys and runs integration tests with default settings.
+- `kind-integrationtest-k8s` deploys and runs integration tests with Kubernetes pipeline storage enabled.
+- `kind-integrationtest-extconnection` deploys and runs integration tests with external connections enabled.
+
+#### Optional: Deploy DSPA with non-main changes
+- Build and push DSP images to `IMG_REGISTRY`. You'll need to change directory to the `data-science-pipelines` project root.
+>Note that the first time you push these images to Quay (if using Quay), you will need to set each image as public.
+
+```shell
+make -C backend image_apiserver
+${CONTAINER_ENGINE} push quay.io/username/apiserver:1
+```
+```shell
+make -C backend image_driver
+${CONTAINER_ENGINE} push quay.io/username/driver:1
+```
+```shell
+make -C backend image_launcher
+${CONTAINER_ENGINE} push quay.io/username/launcher:1
+```
+- Update the appropriate test manifest. The table below lists each integration test target and its corresponding manifest file.
+
+| Test Makefile target                 | Manifest path                             |
+|--------------------------------------|-------------------------------------------|
+| `kind-integrationtest`               | `tests/resources/dspa-lite.yaml`          |
+| `kind-integrationtest-k8s`           | `tests/resources/dspa-k8s.yaml`           |
+| `kind-integrationtest-extconnection` | `tests/resources/dspa-external-lite.yaml` |
+
+For example:
+```yaml
+  apiServer:
+    image:  quay.io/username/apiserver:1
+    argoLauncherImage:  quay.io/username/launcher:1
+    argoDriverImage:  quay.io/username/driver:1
+```

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,19 @@ INTTEST_SKIP_DEPLOY ?= false
 INTTEST_SKIP_CLEANUP ?= false
 INTTEST_AWF_MANAGEMENT_STATE ?= Managed
 
+# KinD Cluster Config EnvVars
+KIND_NAME ?= dspo
+CONTAINER_ENGINE ?= $(shell \
+	if command -v docker >/dev/null 2>&1; then \
+		echo docker; \
+	elif command -v podman >/dev/null 2>&1; then \
+		echo podman; \
+	fi \
+)
+
+IMG_REGISTRY ?= kind-registry:5000
+IMG_TAG_DSPO ?= dspo:1
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -287,3 +300,48 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) podman-push IMG=$(CATALOG_IMG)
+
+# Build DSPO from local changes and push to IMG_REGISTRY.
+.PHONY: image-dspo
+image-dspo:
+	${CONTAINER_ENGINE} build --platform linux/amd64 . -t $(IMG_REGISTRY)/$(IMG_TAG_DSPO)
+	${CONTAINER_ENGINE} push $(IMG_REGISTRY)/$(IMG_TAG_DSPO)
+
+# Create a KinD cluster and deploy DSPO.
+.PHONY: kind-setup
+kind-setup:
+	# Deploy KinD cluster
+	kind create cluster --name=$(KIND_NAME)
+	# Set and deploy cluster requirements
+	cd .github/scripts/tests && TARGET="kind" SETUP_ONLY="true" GIT_WORKSPACE=$(CURDIR) DSPO_IMAGE_REF=$(IMG_REGISTRY)/$(IMG_TAG_DSPO) ./tests.sh
+
+# Create a KinD cluster and deploy DSPO with external Argo.
+.PHONY: kind-setup-externalargo
+kind-setup-externalargo:
+	# Deploy KinD cluster
+	kind create cluster --name=$(KIND_NAME)
+	# Set and deploy cluster requirements
+	cd .github/scripts/tests && TARGET="kind" SETUP_ONLY="true" GIT_WORKSPACE=$(CURDIR) DSPO_IMAGE_REF=$(IMG_REGISTRY)/$(IMG_TAG_DSPO)  DEPLOY_EXTERNAL_ARGO="true" ./tests.sh
+
+# NOTE: Run the integration test targets below only after executing kind-setup or kind-setup-externalargo targets.
+# Deploy DSPA and run integration tests with default settings.
+.PHONY: kind-integrationtest
+kind-integrationtest:
+	make integrationtest INTTEST_BASIC="true" K8SAPISERVERHOST="" DSPANAMESPACE="test-dspa" ENDPOINT_TYPE=$(ENDPOINT_TYPE) INTTEST_AWF_MANAGEMENT_STATE=$(INTTEST_AWF_MANAGEMENT_STATE) INTTEST_SKIP_DEPLOY=$(INTTEST_SKIP_DEPLOY) INTTEST_SKIP_CLEANUP=$(INTTEST_SKIP_CLEANUP)
+
+# Deploy DSPA and run integration tests with K8s storage enabled.
+.PHONY: kind-integrationtest-k8s
+kind-integrationtest-k8s:
+	# Deploy cert manager
+	kubectl create namespace "cert-manager"
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+	# Apply webhook certs
+	kubectl wait -n "cert-manager" --timeout=90s --for=condition=Ready pods --all
+	cd ".github/resources/webhook" && kubectl -n "opendatahub" apply -k .
+	# Run integration tests
+	make integrationtest INTTEST_K8S_STORE="true" K8SAPISERVERHOST="" DSPANAMESPACE="test-k8s-dspa" DSPAPATH="resources/dspa-k8s.yaml" ENDPOINT_TYPE=$(ENDPOINT_TYPE) INTTEST_AWF_MANAGEMENT_STATE=$(INTTEST_AWF_MANAGEMENT_STATE) INTTEST_SKIP_DEPLOY=$(INTTEST_SKIP_DEPLOY) INTTEST_SKIP_CLEANUP=$(INTTEST_SKIP_CLEANUP)
+
+# Deploy DSPA and run integration tests with external connections enabled.
+.PHONY: kind-integrationtest-extconnection
+kind-integrationtest-extconnection:
+	make integrationtest INTTEST_EXT_CONNECTIONS="true" K8SAPISERVERHOST="" DSPANAMESPACE="dspa-ext" DSPAPATH="resources/dspa-external-lite.yaml" ENDPOINT_TYPE=$(ENDPOINT_TYPE) MINIONAMESPACE="test-minio" INTTEST_AWF_MANAGEMENT_STATE=$(INTTEST_AWF_MANAGEMENT_STATE) INTTEST_SKIP_DEPLOY=$(INTTEST_SKIP_DEPLOY) INTTEST_SKIP_CLEANUP=$(INTTEST_SKIP_CLEANUP)


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves #<issue_number>

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Update root `Makefile` and `.github/scripts/tests/tests.sh` with Make targets and env variables for deploying DSPO on a local KinD cluster to run integration tests. Add CONTRIBUTING.md as well to walk users through process.  

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->
Run instructions locally and verify DSPO is successfully deployed on KinD cluster and integration tests pass. 

## Checklist
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local workflows to build/push DSPO images, create KinD clusters (option for external Argo), and run multiple integration test variants including Kubernetes-backed and external-connection runs.

* **Documentation**
  * Added a CONTRIBUTING guide with KinD deployment steps, image build/push instructions, manifest guidance, and integration test usage.

* **Chores**
  * Test orchestration now supports environment-driven selective test modes with early-exit paths for faster targeted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->