### PR TITLE
fix: surface all ExtractParams errors on APIServerReady status

### DIFF
--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -773,7 +773,7 @@ func TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors(t *testing.T) {
 				d.Namespace = "testnamespace"
 				return d
 			},
-			wantMsgContains: []string{"not found"},
+			wantMsgContains: []string{`configmaps "missing-launcher-cm"`, "not found"},
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -46,6 +46,17 @@ const (
 	dsPipelineAPIServerContainerName  = "ds-pipeline-api-server"
 )
 
+func requireAPIServerReadyCondition(t *testing.T, dspa *dspav1.DataSciencePipelinesApplication) *metav1.Condition {
+	t.Helper()
+	for i := range dspa.Status.Conditions {
+		if dspa.Status.Conditions[i].Type == config.APIServerReady {
+			return &dspa.Status.Conditions[i]
+		}
+	}
+	t.Fatalf("expected APIServerReady condition in status")
+	return nil
+}
+
 // getInitManagedPipelinesContainer returns the init-managed-pipelines container from the deployment, or nil if not found.
 func getInitManagedPipelinesContainer(t testing.TB, deployment *appsv1.Deployment) *corev1.Container {
 	t.Helper()
@@ -715,39 +726,83 @@ func TestExtractParams_ManagedPipelinesWhitespaceOnlyFailsWithoutOperatorConfig(
 	require.Contains(t, err.Error(), "IMAGES_PIPELINES_COMPONENTS")
 }
 
-func TestReconcile_SetsAPIServerNotReadyWhenManagedPipelinesImageUnset(t *testing.T) {
-	t.Cleanup(func() { viper.Reset() })
-
-	dspa := testutil.CreateDSPAWithManagedPipelines("", nil, nil)
-	dspa.Name = "dspa-mp-status"
-	dspa.Namespace = "testnamespace"
-
-	ctx, _, reconciler := CreateNewTestObjects()
-	require.NoError(t, reconciler.Client.Create(ctx, dspa))
-
-	result, err := reconciler.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: dspa.Name, Namespace: dspa.Namespace},
-	})
-	require.NoError(t, err)
-	assert.True(t, result.Requeue, "should requeue when managed pipelines image is unset")
-	assert.NotZero(t, result.RequeueAfter, "RequeueAfter should be set")
-
-	updated := &dspav1.DataSciencePipelinesApplication{}
-	require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: dspa.Name, Namespace: dspa.Namespace}, updated))
-
-	var apiCond *metav1.Condition
-	for i := range updated.Status.Conditions {
-		if updated.Status.Conditions[i].Type == config.APIServerReady {
-			apiCond = &updated.Status.Conditions[i]
-			break
-		}
+func TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		prepareDSPA     func(t *testing.T) *dspav1.DataSciencePipelinesApplication
+		wantMsgContains []string
+	}{
+		{
+			name: "managed_pipelines_image_unset",
+			prepareDSPA: func(_ *testing.T) *dspav1.DataSciencePipelinesApplication {
+				d := testutil.CreateDSPAWithManagedPipelines("", nil, nil)
+				d.Name = "dspa-mp-status"
+				d.Namespace = "testnamespace"
+				return d
+			},
+			wantMsgContains: []string{"managedPipelines", "Images.PipelinesComponents", "IMAGES_PIPELINES_COMPONENTS"},
+		},
+		{
+			name: "invalid_related_image_env_var_name",
+			prepareDSPA: func(t *testing.T) *dspav1.DataSciencePipelinesApplication {
+				clearRelatedImageEnv(t)
+				t.Setenv("RELATED_IMAGE_toolbox", "registry.example/x:latest")
+				d := testutil.CreateDSPAWithManagedPipelines("img:latest", nil, nil)
+				d.Name = "dspa-extract-bad-related"
+				d.Namespace = "testnamespace"
+				return d
+			},
+			wantMsgContains: []string{"invalid RELATED_IMAGE_* env var name"},
+		},
+		{
+			name: "invalid_managed_pipelines_volume_size_limit",
+			prepareDSPA: func(_ *testing.T) *dspav1.DataSciencePipelinesApplication {
+				d := testutil.CreateDSPAWithManagedPipelines("img:latest", nil, nil)
+				d.Spec.APIServer.ManagedPipelines.VolumeSizeLimit = "not-a-quantity"
+				d.Name = "dspa-extract-volume"
+				d.Namespace = "testnamespace"
+				return d
+			},
+			wantMsgContains: []string{"managedPipelines.volumeSizeLimit must be a valid Kubernetes quantity"},
+		},
+		{
+			name: "custom_kfp_launcher_configmap_not_found",
+			prepareDSPA: func(_ *testing.T) *dspav1.DataSciencePipelinesApplication {
+				d := testutil.CreateDSPAWithCustomKfpLauncherConfigMap("missing-launcher-cm")
+				d.Name = "dspa-extract-launcher-cm"
+				d.Namespace = "testnamespace"
+				return d
+			},
+			wantMsgContains: []string{"not found"},
+		},
 	}
-	require.NotNil(t, apiCond, "expected APIServerReady condition")
-	assert.Equal(t, metav1.ConditionFalse, apiCond.Status)
-	assert.Equal(t, config.FailingToDeploy, apiCond.Reason)
-	assert.Contains(t, apiCond.Message, "managedPipelines")
-	assert.Contains(t, apiCond.Message, "Images.PipelinesComponents")
-	assert.Contains(t, apiCond.Message, "IMAGES_PIPELINES_COMPONENTS")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Reset()
+
+			dspa := tt.prepareDSPA(t)
+			ctx, _, reconciler := CreateNewTestObjects()
+			require.NoError(t, reconciler.Client.Create(ctx, dspa))
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: dspa.Name, Namespace: dspa.Namespace},
+			})
+			require.NoError(t, err)
+			assert.True(t, result.Requeue, "should requeue when ExtractParams fails")
+			assert.NotZero(t, result.RequeueAfter, "RequeueAfter should be set")
+
+			updated := &dspav1.DataSciencePipelinesApplication{}
+			require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: dspa.Name, Namespace: dspa.Namespace}, updated))
+
+			apiCond := requireAPIServerReadyCondition(t, updated)
+			assert.Equal(t, metav1.ConditionFalse, apiCond.Status)
+			assert.Equal(t, config.FailingToDeploy, apiCond.Reason)
+			for _, sub := range tt.wantMsgContains {
+				assert.Contains(t, apiCond.Message, sub)
+			}
+		})
+	}
 }
 
 func TestDeployAPIServerWithManagedPipelines_OmittedImageUsesOperatorConfigDefault(t *testing.T) {

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -46,15 +46,15 @@ const (
 	dsPipelineAPIServerContainerName  = "ds-pipeline-api-server"
 )
 
-func requireAPIServerReadyCondition(t *testing.T, dspa *dspav1.DataSciencePipelinesApplication) *metav1.Condition {
+func requireDSPAStatusCondition(t *testing.T, dspa *dspav1.DataSciencePipelinesApplication, conditionType string) metav1.Condition {
 	t.Helper()
 	for i := range dspa.Status.Conditions {
-		if dspa.Status.Conditions[i].Type == config.APIServerReady {
-			return &dspa.Status.Conditions[i]
+		if dspa.Status.Conditions[i].Type == conditionType {
+			return dspa.Status.Conditions[i]
 		}
 	}
-	t.Fatalf("expected APIServerReady condition in status")
-	return nil
+	t.Fatalf("expected condition type %q in status", conditionType)
+	return metav1.Condition{}
 }
 
 // getInitManagedPipelinesContainer returns the init-managed-pipelines container from the deployment, or nil if not found.
@@ -745,7 +745,6 @@ func TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors(t *testing.T) {
 		{
 			name: "invalid_related_image_env_var_name",
 			prepareDSPA: func(t *testing.T) *dspav1.DataSciencePipelinesApplication {
-				clearRelatedImageEnv(t)
 				t.Setenv("RELATED_IMAGE_toolbox", "registry.example/x:latest")
 				d := testutil.CreateDSPAWithManagedPipelines("img:latest", nil, nil)
 				d.Name = "dspa-extract-bad-related"
@@ -780,6 +779,7 @@ func TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(viper.Reset)
 			viper.Reset()
+			clearRelatedImageEnv(t)
 
 			dspa := tt.prepareDSPA(t)
 			ctx, _, reconciler := CreateNewTestObjects()
@@ -790,16 +790,24 @@ func TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.True(t, result.Requeue, "should requeue when ExtractParams fails")
-			assert.NotZero(t, result.RequeueAfter, "RequeueAfter should be set")
+			wantRequeueAfter := config.GetDurationConfigWithDefault(config.RequeueTimeConfigName, config.DefaultRequeueTime)
+			assert.Equal(t, wantRequeueAfter, result.RequeueAfter, "RequeueAfter should match configured value")
 
 			updated := &dspav1.DataSciencePipelinesApplication{}
 			require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: dspa.Name, Namespace: dspa.Namespace}, updated))
 
-			apiCond := requireAPIServerReadyCondition(t, updated)
+			apiCond := requireDSPAStatusCondition(t, updated, config.APIServerReady)
 			assert.Equal(t, metav1.ConditionFalse, apiCond.Status)
 			assert.Equal(t, config.FailingToDeploy, apiCond.Reason)
 			for _, sub := range tt.wantMsgContains {
 				assert.Contains(t, apiCond.Message, sub)
+			}
+
+			crCond := requireDSPAStatusCondition(t, updated, config.CrReady)
+			assert.Equal(t, metav1.ConditionFalse, crCond.Status)
+			assert.Equal(t, config.FailingToDeploy, crCond.Reason)
+			for _, sub := range tt.wantMsgContains {
+				assert.Contains(t, crCond.Message, sub)
 			}
 		})
 	}

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -307,7 +307,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	requeueTime := config.GetDurationConfigWithDefault(config.RequeueTimeConfigName, config.DefaultRequeueTime)
 
 	// ExtractParams resolves CR fields, operator config, and cluster references before any component
-	// reconciles. Failures here block the whole reconcile; we surface them on APIServerReady 
+	// reconciles. Failures here block the whole reconcile; we surface them on APIServerReady
 	// and the API server is the first workload that consumes these parameters—without inventing a
 	// new condition type or touching downstream component conditions that never ran.
 	err = params.ExtractParams(ctx, dspa, r.Client, r.Log)

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -306,9 +306,13 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	requeueTime := config.GetDurationConfigWithDefault(config.RequeueTimeConfigName, config.DefaultRequeueTime)
 
+	// ExtractParams resolves CR fields, operator config, and cluster references before any component
+	// reconciles. Failures here block the whole reconcile; we surface them on APIServerReady 
+	// and the API server is the first workload that consumes these parameters—without inventing a
+	// new condition type or touching downstream component conditions that never ran.
 	err = params.ExtractParams(ctx, dspa, r.Client, r.Log)
 	if err != nil {
-		log.Error(err, "Encountered error when parsing CR")
+		log.Error(err, "Failed to extract or resolve DSPA parameters")
 		r.setStatusAsNotReady(config.APIServerReady, err, dspaStatus.SetApiServerStatus)
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTime}, nil
 	}

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -309,9 +309,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err = params.ExtractParams(ctx, dspa, r.Client, r.Log)
 	if err != nil {
 		log.Error(err, "Encountered error when parsing CR")
-		if errors.Is(err, ErrManagedPipelinesImageUnset) {
-			r.setStatusAsNotReady(config.APIServerReady, err, dspaStatus.SetApiServerStatus)
-		}
+		r.setStatusAsNotReady(config.APIServerReady, err, dspaStatus.SetApiServerStatus)
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTime}, nil
 	}
 

--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -314,6 +314,7 @@ func (r *DSPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err != nil {
 		log.Error(err, "Failed to extract or resolve DSPA parameters")
 		r.setStatusAsNotReady(config.APIServerReady, err, dspaStatus.SetApiServerStatus)
+		dspaStatus.SetDSPANotReady(err, config.FailingToDeploy)
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueTime}, nil
 	}
 


### PR DESCRIPTION
## Summary

- Resolves follow-up to review on [opendatahub-io/data-science-pipelines-operator#1005](https://github.com/opendatahub-io/data-science-pipelines-operator/pull/1005#discussion_r3039673189) (only ErrManagedPipelinesImageUnset previously updated status; other ExtractParams errors requeued without surfacing the reason in status).

- Call setStatusAsNotReady for every ExtractParams failure, not only ErrManagedPipelinesImageUnset, so the DSPA APIServerReady condition shows why reconciliation is stuck (for example invalid volume limits, invalid RELATED_IMAGE_* env names, missing ConfigMap references).

- Add table-driven Reconcile tests that cover several real ExtractParams error paths and assert status + requeue behavior.


## Description of your changes

### Why APIServerReady for every ExtractParams failure:
We surface them on APIServerReady because that condition already represented this gate (including the earlier managed-pipelines image special case), the API server is the first workload that consumes these parameters, and we avoid adding a new condition type or updating downstream component conditions that never ran.

### controllers/dspipeline_controller.go
On any ExtractParams error: log the error, call setStatusAsNotReady for APIServerReady with FailingToDeploy and the error message, then return the same requeue result as before.

### controllers/apiserver_test.go

- Helper requireAPIServerReadyCondition to read the APIServerReady condition from status.
- TestReconcile_SetsAPIServerNotReadyOnExtractParamsErrors: table-driven cases for managed pipelines image unset, invalid RELATED_IMAGE_* env var name, invalid managed pipelines volumeSizeLimit, and missing custom KFP launcher ConfigMap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for parameter extraction during deployment, ensuring the API server status is consistently updated when configuration extraction fails, regardless of the specific error type.

* **Tests**
  * Expanded test coverage to validate API server status reporting across multiple parameter extraction failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->