### PR TITLE
Add workflow to enforce consistency between Go versions in `go.mod` and Dockerfiles

### DIFF
--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG CI_BASE=registry.access.redhat.com/ubi8/go-toolset:1.25
+ARG CI_BASE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:df073e37d0cfe6c83df9fd4891b14252f3822cb511000c48f32c632f0d24920f
 
 FROM ${CI_BASE} as stage1
 

--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=stage1 /build/bin /build/bin
 USER root
 
 RUN dnf -y install \
-    python39 \
+    python3 \
     python3-pip \
     golang \
     git \

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Verifies that all Dockerfiles using a go-toolset base image
+# specify a Go major.minor version consistent with the root go.mod.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+
+if [[ -z "$GOMOD_VERSION" ]]; then
+    echo "ERROR: Could not extract Go version from go.mod" >&2
+    exit 1
+fi
+
+echo "go.mod Go version: $GOMOD_VERSION"
+
+ERRORS=0
+CHECKED=0
+
+while IFS= read -r dockerfile; do
+    relative="${dockerfile#"$REPO_ROOT"/}"
+    while IFS= read -r line; do
+        docker_version=$(echo "$line" | sed -E 's/.*go-toolset:([0-9]+\.[0-9]+).*/\1/')
+
+        if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "WARNING: Could not parse Go version from line in $relative: $line" >&2
+            continue
+        fi
+
+        CHECKED=$((CHECKED + 1))
+
+        if [[ "$docker_version" != "$GOMOD_VERSION" ]]; then
+            echo "MISMATCH: $relative has Go $docker_version, but go.mod requires $GOMOD_VERSION" >&2
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "  OK: $relative (Go $docker_version)"
+        fi
+    done < <(grep -iE '(FROM|ARG).*go-toolset:' "$dockerfile")
+done < <(cd "$REPO_ROOT" && git ls-files '*Dockerfile*' | xargs grep -il 'go-toolset:' | sed "s|^|$REPO_ROOT/|")
+
+echo ""
+
+if [[ $CHECKED -eq 0 ]]; then
+    echo "ERROR: No Dockerfiles with 'go-toolset:' found." >&2
+    exit 1
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "FAILED: $ERRORS Dockerfile(s) have a Go version mismatch with go.mod ($GOMOD_VERSION)." >&2
+    exit 1
+fi
+
+echo "PASSED: All $CHECKED Dockerfile(s) use Go $GOMOD_VERSION, matching go.mod."

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -17,14 +17,17 @@ echo "go.mod Go version: $GOMOD_VERSION"
 
 ERRORS=0
 CHECKED=0
+FOUND=0
 
 while IFS= read -r dockerfile; do
     relative="${dockerfile#"$REPO_ROOT"/}"
+    FOUND=$((FOUND + 1))
     while IFS= read -r line; do
         docker_version=$(echo "$line" | sed -E 's/.*go-toolset:([0-9]+\.[0-9]+).*/\1/')
 
         if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "WARNING: Could not parse Go version from line in $relative: $line" >&2
+            echo "ERROR: Could not parse Go version from line in $relative: $line" >&2
+            ERRORS=$((ERRORS + 1))
             continue
         fi
 
@@ -41,8 +44,13 @@ done < <(cd "$REPO_ROOT" && git ls-files '*Dockerfile*' | xargs grep -il 'go-too
 
 echo ""
 
-if [[ $CHECKED -eq 0 ]]; then
+if [[ $FOUND -eq 0 ]]; then
     echo "ERROR: No Dockerfiles with 'go-toolset:' found." >&2
+    exit 1
+fi
+
+if [[ $CHECKED -eq 0 ]]; then
+    echo "ERROR: Found $FOUND Dockerfile(s) with 'go-toolset:', but could not parse any Go version." >&2
     exit 1
 fi
 

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -94,7 +94,7 @@ while IFS= read -r dockerfile; do
             echo "  OK: $relative (Go $resolved_version)"
         fi
     done < <(grep -iE '^\s*(FROM|ARG).*(go-toolset|golang):' "$dockerfile" || true)
-done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- '(FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):|ARG[[:space:]]+.*go-toolset:)' | sed "s|^|$REPO_ROOT/|") || true)
+done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- '(FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):|ARG[[:space:]]+.*(go-toolset|golang):)' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""
 

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -39,8 +39,8 @@ while IFS= read -r dockerfile; do
         else
             echo "  OK: $relative (Go $docker_version)"
         fi
-    done < <(grep -iE '(FROM|ARG).*go-toolset:' "$dockerfile" || true)
-done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -il 'go-toolset:' | sed "s|^|$REPO_ROOT/|") || true)
+    done < <(grep -iE '^\s*(FROM|ARG).*go-toolset:' "$dockerfile" || true)
+done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -ilE '^\s*(FROM|ARG).*go-toolset:' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""
 
@@ -55,7 +55,7 @@ if [[ $CHECKED -eq 0 ]]; then
 fi
 
 if [[ $ERRORS -gt 0 ]]; then
-    echo "FAILED: $ERRORS go-toolset reference(s) have a Go version mismatch with go.mod ($GOMOD_VERSION)." >&2
+    echo "FAILED: $ERRORS error(s) found when checking go-toolset references against go.mod ($GOMOD_VERSION)." >&2
     exit 1
 fi
 

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
-GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/' || true)
 
 if [[ -z "$GOMOD_VERSION" ]]; then
     echo "ERROR: Could not extract Go version from go.mod" >&2
@@ -39,8 +39,8 @@ while IFS= read -r dockerfile; do
         else
             echo "  OK: $relative (Go $docker_version)"
         fi
-    done < <(grep -iE '(FROM|ARG).*go-toolset:' "$dockerfile")
-done < <(cd "$REPO_ROOT" && git ls-files '*Dockerfile*' | xargs grep -il 'go-toolset:' | sed "s|^|$REPO_ROOT/|")
+    done < <(grep -iE '(FROM|ARG).*go-toolset:' "$dockerfile" || true)
+done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -il 'go-toolset:' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""
 
@@ -50,13 +50,13 @@ if [[ $FOUND -eq 0 ]]; then
 fi
 
 if [[ $CHECKED -eq 0 ]]; then
-    echo "ERROR: Found $FOUND Dockerfile(s) with 'go-toolset:', but could not parse any Go version." >&2
+    echo "ERROR: Found $FOUND Dockerfile(s) with 'go-toolset:', but could not parse any Go version reference." >&2
     exit 1
 fi
 
 if [[ $ERRORS -gt 0 ]]; then
-    echo "FAILED: $ERRORS Dockerfile(s) have a Go version mismatch with go.mod ($GOMOD_VERSION)." >&2
+    echo "FAILED: $ERRORS go-toolset reference(s) have a Go version mismatch with go.mod ($GOMOD_VERSION)." >&2
     exit 1
 fi
 
-echo "PASSED: All $CHECKED Dockerfile(s) use Go $GOMOD_VERSION, matching go.mod."
+echo "PASSED: All $CHECKED go-toolset reference(s) use Go $GOMOD_VERSION, matching go.mod."

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Verifies that all Dockerfiles using a go-toolset base image
-# specify a Go major.minor version consistent with the root go.mod.
+# Verifies that all Dockerfiles using a golang or go-toolset base image
+# specify a Go version consistent with the root go.mod.
 
 set -euo pipefail
 
+if ! command -v skopeo &>/dev/null; then
+    echo "ERROR: skopeo is required but not found in PATH" >&2
+    exit 1
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
-GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' | sed -E 's/^([0-9]+\.[0-9]+).*/\1/' || true)
+GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' || true)
 
 if [[ -z "$GOMOD_VERSION" ]]; then
     echo "ERROR: Could not extract Go version from go.mod" >&2
@@ -14,6 +19,37 @@ if [[ -z "$GOMOD_VERSION" ]]; then
 fi
 
 echo "go.mod Go version: $GOMOD_VERSION"
+
+resolve_go_version() {
+    local image_ref="$1" tag_version="$2"
+    # X.Y.Z tags are trusted without inspection — the patch version is explicit
+    if [[ "$tag_version" == *.*.* ]]; then
+        echo "$tag_version"
+        return
+    fi
+    local resolved skopeo_stderr skopeo_ref="$image_ref" attempt
+    if [[ "$skopeo_ref" == *:*@* ]]; then
+        skopeo_ref="${skopeo_ref%%:*}@${skopeo_ref#*@}"
+    fi
+    skopeo_stderr=$(mktemp)
+    for attempt in 1 2 3; do
+        resolved=$(skopeo inspect --override-arch amd64 --override-os linux "docker://$skopeo_ref" 2>"$skopeo_stderr" \
+            | grep -oE '"(VERSION|GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+"' \
+            | head -1 \
+            | sed -E 's/"(VERSION|GOLANG_VERSION)=([0-9]+\.[0-9]+\.[0-9]+)"/\2/')
+        [[ -n "$resolved" ]] && break
+        [[ $attempt -lt 3 ]] && sleep 2
+    done
+    if [[ -z "$resolved" ]]; then
+        echo "  skopeo inspect failed for $image_ref after $attempt attempts:" >&2
+        cat "$skopeo_stderr" >&2
+        rm -f "$skopeo_stderr"
+        echo ""
+        return
+    fi
+    rm -f "$skopeo_stderr"
+    echo "$resolved"
+}
 
 ERRORS=0
 CHECKED=0
@@ -23,40 +59,58 @@ while IFS= read -r dockerfile; do
     relative="${dockerfile#"$REPO_ROOT"/}"
     FOUND=$((FOUND + 1))
     while IFS= read -r line; do
-        docker_version=$(echo "$line" | sed -E 's/.*go-toolset:([0-9]+\.[0-9]+).*/\1/')
+        docker_version=$(echo "$line" | sed -E 's/.*[Ff][Rr][Oo][Mm][[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):([0-9]+\.[0-9]+(\.[0-9]+)?).*/\3/')
 
-        if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            docker_version=$(echo "$line" | sed -E 's/.*go-toolset:([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/')
+        fi
+
+        if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
             echo "ERROR: Could not parse Go version from line in $relative: $line" >&2
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+
+        image_ref=$(echo "$line" | sed -E 's/^[[:space:]]*(FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*|ARG[[:space:]]+[^=]+=)([^[:space:]]+)[[:space:]]*.*/\3/')
+
+        resolved_version=$(resolve_go_version "$image_ref" "$docker_version")
+
+        if [[ -z "$resolved_version" ]]; then
+            echo "ERROR: Could not resolve Go version from image $image_ref in $relative" >&2
             ERRORS=$((ERRORS + 1))
             continue
         fi
 
         CHECKED=$((CHECKED + 1))
 
-        if [[ "$docker_version" != "$GOMOD_VERSION" ]]; then
-            echo "MISMATCH: $relative has Go $docker_version, but go.mod requires $GOMOD_VERSION" >&2
+        if [[ "$resolved_version" != "$docker_version" ]]; then
+            echo "  INFO: $relative tag $docker_version resolved to Go $resolved_version"
+        fi
+
+        if [[ "$resolved_version" != "$GOMOD_VERSION" ]]; then
+            echo "MISMATCH: $relative has Go $resolved_version, but go.mod requires $GOMOD_VERSION" >&2
             ERRORS=$((ERRORS + 1))
         else
-            echo "  OK: $relative (Go $docker_version)"
+            echo "  OK: $relative (Go $resolved_version)"
         fi
-    done < <(grep -iE '^\s*(FROM|ARG).*go-toolset:' "$dockerfile" || true)
-done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -ilE '^\s*(FROM|ARG).*go-toolset:' | sed "s|^|$REPO_ROOT/|") || true)
+    done < <(grep -iE '^\s*(FROM|ARG).*go-toolset:' "$dockerfile" || grep -iE '^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang):' "$dockerfile" || true)
+done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- '(FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):|ARG[[:space:]]+.*go-toolset:)' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""
 
 if [[ $FOUND -eq 0 ]]; then
-    echo "ERROR: No Dockerfiles with 'go-toolset:' found." >&2
+    echo "ERROR: No Dockerfiles with Go base images found." >&2
     exit 1
 fi
 
 if [[ $CHECKED -eq 0 ]]; then
-    echo "ERROR: Found $FOUND Dockerfile(s) with 'go-toolset:', but could not parse any Go version reference." >&2
+    echo "ERROR: Found $FOUND Dockerfile(s) with Go base images, but could not parse any Go version." >&2
     exit 1
 fi
 
 if [[ $ERRORS -gt 0 ]]; then
-    echo "FAILED: $ERRORS error(s) found when checking go-toolset references against go.mod ($GOMOD_VERSION)." >&2
+    echo "FAILED: $ERRORS error(s) found when checking Go base image stages against go.mod ($GOMOD_VERSION)." >&2
     exit 1
 fi
 
-echo "PASSED: All $CHECKED go-toolset reference(s) use Go $GOMOD_VERSION, matching go.mod."
+echo "PASSED: All $CHECKED Go base image stage(s) use Go $GOMOD_VERSION, matching go.mod."

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -62,7 +62,7 @@ while IFS= read -r dockerfile; do
         docker_version=$(echo "$line" | sed -E 's/.*[Ff][Rr][Oo][Mm][[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):([0-9]+\.[0-9]+(\.[0-9]+)?).*/\3/')
 
         if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-            docker_version=$(echo "$line" | sed -E 's/.*go-toolset:([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/')
+            docker_version=$(echo "$line" | sed -E 's/.*(go-toolset|golang):([0-9]+\.[0-9]+(\.[0-9]+)?).*/\2/')
         fi
 
         if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
@@ -93,7 +93,7 @@ while IFS= read -r dockerfile; do
         else
             echo "  OK: $relative (Go $resolved_version)"
         fi
-    done < <(grep -iE '^\s*(FROM|ARG).*go-toolset:' "$dockerfile" || grep -iE '^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang):' "$dockerfile" || true)
+    done < <(grep -iE '^\s*(FROM|ARG).*(go-toolset|golang):' "$dockerfile" || true)
 done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- '(FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):|ARG[[:space:]]+.*go-toolset:)' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -1,0 +1,19 @@
+name: Go Version Consistency
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - '**/Dockerfile*'
+      - '.github/scripts/verify-go-version-consistency.sh'
+      - '.github/workflows/go-version-consistency.yml'
+
+jobs:
+  verify-go-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Verify Go version consistency
+        run: bash .github/scripts/verify-go-version-consistency.sh

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   verify-go-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -7,6 +7,11 @@ on:
       - '**/Dockerfile*'
       - '.github/scripts/verify-go-version-consistency.sh'
       - '.github/workflows/go-version-consistency.yml'
+  push:
+    branches:
+      - main
+      - stable
+      - 'rhoai-*'
 
 jobs:
   verify-go-version:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:df073e37d0cfe6c83df9fd4891b14252f3822cb511000c48f32c632f0d24920f AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 ARG FIPS_ENABLED=1


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://redhat.atlassian.net/browse/RHOAIENG-59364

## Description of your changes:

- Add a CI workflow and verification script that enforces Go version consistency between `go.mod` and Dockerfile base images (`golang` and `go-toolset`).
- The script uses `skopeo inspect` to resolve floating `X.Y` image tags to their actual patch version, comparing against the full version in `go.mod`.
- The workflow runs on PRs (path-filtered to `go.mod`, `**/Dockerfile*`, and the script/workflow files) and on pushes to `main`, `stable`, and `rhoai-*` branches.
- Pin both `Dockerfile` and `.github/build/Dockerfile` to the `go-toolset:1.25` digest containing Go 1.25.7, matching `go.mod`.
- Upgrade `.github/build/Dockerfile` base image from `ubi8/go-toolset` to `ubi9/go-toolset` and fix the `python39` → `python3` package name for UBI 9 compatibility.

## Testing instructions

- CI should pass.
- Run `bash .github/scripts/verify-go-version-consistency.sh` locally to verify both Dockerfiles match `go.mod`.

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated verification to ensure Go version consistency across build configurations.

* **Chores**
  * Updated base Docker images and pinned them with digest hashes for reproducible builds.
  * Updated Python dependencies in build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->