### PR TITLE
Updated image tag from `main` to `odh-main` across configurations and workflows

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -22,7 +22,7 @@ jobs:
         id: tags
         run: |
           commit_sha=${{ github.event.after }}
-          tag=main-${commit_sha:0:7}
+          tag=odh-main-${commit_sha:0:7}
           echo "tag=${tag}" >> $GITHUB_OUTPUT
       - name: Build Image
         uses: ./.github/actions/build
@@ -42,5 +42,5 @@ jobs:
         run: |
           podman tag ${IMG}:${NEWEST_TAG} ${IMG}:latest
           podman push ${IMG}:latest
-          podman tag ${IMG}:${NEWEST_TAG} ${IMG}:main
-          podman push ${IMG}:main
+          podman tag ${IMG}:${NEWEST_TAG} ${IMG}:odh-main
+          podman push ${IMG}:odh-main

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/opendatahub/data-science-pipelines-operator:main
+IMG ?= quay.io/opendatahub/data-science-pipelines-operator:odh-main
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 # Namespace to deploy the operator

--- a/config/overlays/kind-tests/kustomization.yaml
+++ b/config/overlays/kind-tests/kustomization.yaml
@@ -10,4 +10,4 @@ patchesStrategicMerge:
 images:
   - name: controller
     newName: quay.io/opendatahub/data-science-pipelines-operator
-    newTag: main
+    newTag: odh-main

--- a/config/overlays/make-deploy/kustomization.yaml
+++ b/config/overlays/make-deploy/kustomization.yaml
@@ -9,4 +9,4 @@ patchesStrategicMerge:
 images:
 - name: controller
   newName: quay.io/opendatahub/data-science-pipelines-operator
-  newTag: main
+  newTag: odh-main


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://redhat.atlassian.net/browse/RHOAIENG-58245

## Description of your changes:

This is PR 1 of the following plan:

| PR       | Repo                    | Scope                                                                | Timing               |
|----------|-------------------------|----------------------------------------------------------------------|----------------------|
| **PR 1** | DSPO (ODH main)         | Change ODH main builds: `:main` → `:odh-main` (GHA)                  | Must merge with PR 2 |
| PR 2     | DSP (ODH main)          | Update `operator_deployer.py` for new tag patterns + registry change | Must merge with PR 1 |
| PR 3     | DSPO (ODH)              | Merge main → stable (conflict resolution for Konflux configs)        | Must merge with PR 4 |
| PR 4     | DSP (ODH)               | Merge main → stable                                                  | Must merge with PR 3 |
| PR 5     | DSPO (RHDS, after sync) | Add RHDS Konflux configs for `:main` and `:rhoai-*`                  | Independent          |
| PR 6     | DSP (RHDS, after PR 5)  | RHDS-specific DSP CI adjustments                                     | Independent          |

Adds the `odh-` prefix to the ODH main branch image tag so it is
distinguishable from RHDS builds that will later produce their own `:main`
images.

- GHA workflow: commit-SHA tags change from `main-<sha>` to `odh-main-<sha>`,
  floating tag from `:main` to `:odh-main`
- Makefile default `IMG` updated to `:odh-main`
- Kustomize overlays (`make-deploy`, `kind-tests`) updated to `odh-main`

The `:latest` convenience alias and `SOURCE_BRANCH: main` git ref are unchanged.

## Critical: Merge together with DSP PR 2

This PR **must merge simultaneously** with the corresponding DSP PR that updates
`operator_deployer.py` to expect `:odh-main`. Merging this alone will break
ODH main CI because DSP CI will still look for `:main`.

/hold

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tag naming scheme across build workflows and deployment configurations for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->