### PR TITLE
fix: support arm64 builder for Dockerfile and add CI validation

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,38 @@
+name: Build image (arm64)
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - Dockerfile
+      - Makefile
+      - go.mod
+      - go.sum
+      - .github/workflows/build-arm64.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build image (cross-compile to amd64)
+        run: make podman-build BUILDER_ARCH=arm64 IMG=localhost/dspo:amd64
+      - name: Verify amd64 image architecture
+        run: |
+          arch=$(podman inspect localhost/dspo:amd64 --format '{{.Architecture}}')
+          echo "Image architecture: $arch"
+          [ "$arch" = "amd64" ] || { echo "Expected amd64, got $arch"; exit 1; }
+      - name: Build image (native arm64)
+        run: make podman-build BUILDER_ARCH=arm64 TARGETARCH=arm64 IMG=localhost/dspo:arm64
+      - name: Verify arm64 image architecture
+        run: |
+          arch=$(podman inspect localhost/dspo:arm64 --format '{{.Architecture}}')
+          echo "Image architecture: $arch"
+          [ "$arch" = "arm64" ] || { echo "Expected arm64, got $arch"; exit 1; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 AS builder
+ARG BUILDER_ARCH=multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:45bd06d392349dfdb09073514cfebcc5082db33301347b51dcae8e5516a89126 AS go-toolset-multiarch
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:3880436381044c6d89c2311f2a7dc8d64224668bf84b43810982b5a9ddd851d0 AS go-toolset-arm64
+FROM go-toolset-${BUILDER_ARCH} AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ IMG ?= quay.io/opendatahub/data-science-pipelines-operator:odh-main
 # Default is amd64.
 TARGETARCH ?= amd64
 
+# BUILDER_ARCH selects the builder stage platform in the Dockerfile (multiarch or arm64).
+# Default is multiarch for production builds on Linux.
+# Mac users must set BUILDER_ARCH=arm64 for local development because the
+# multiarch image segfaults under QEMU emulation on Apple Silicon.
+BUILDER_ARCH ?= multiarch
+
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.34.0
 # Namespace to deploy the operator
@@ -189,7 +196,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: podman-build
 podman-build: ## Build container image with the manager.
-	podman build --platform linux/$(TARGETARCH) --build-arg TARGETARCH=$(TARGETARCH) -t ${IMG} .
+	podman build --platform linux/$(TARGETARCH) \
+		--build-arg "TARGETARCH=$(TARGETARCH)" \
+		--build-arg "BUILDER_ARCH=$(BUILDER_ARCH)" \
+		-t "$(IMG)" .
 
 .PHONY: podman-push
 podman-push: ## Push container image with the manager.

--- a/README.md
+++ b/README.md
@@ -537,12 +537,15 @@ podman build . -f backend/Dockerfile -t quay.io/your_repo/dsp-apiserver:sometag
 
 > **Building on Apple Silicon**:
 >
+> The multiarch Go toolset image segfaults under QEMU emulation on Apple Silicon.
+> Set `BUILDER_ARCH=arm64` to use the native arm64 Go toolset instead:
+>
 > ```bash
-> # Build amd64 image on Apple Silicon
-> make podman-build IMG=quay.io/your_repo/data-science-pipelines-operator:tag
+> # Build amd64 image on Apple Silicon (cross-compile for OpenShift)
+> make podman-build BUILDER_ARCH=arm64 IMG=quay.io/your_repo/data-science-pipelines-operator:tag
 >
 > # Build arm64 image for local Kind testing
-> TARGETARCH=arm64 make podman-build IMG=quay.io/your_repo/data-science-pipelines-operator:tag
+> make podman-build BUILDER_ARCH=arm64 TARGETARCH=arm64 IMG=quay.io/your_repo/data-science-pipelines-operator:tag
 > ```
 
 **To run the tests:**


### PR DESCRIPTION
## Summary

- **Dockerfile**: Multi-stage builder with per-platform digests (multiarch + arm64), selected by `BUILDER_ARCH` ARG. Both pin Go 1.26.3 matching `go.mod`.
- **Makefile**: Add `BUILDER_ARCH` (default: `multiarch`) to `podman-build` target. Mac users must set `BUILDER_ARCH=arm64` for local development.
- **New `build-arm64.yml` workflow**: Validates arm64 builds on an arm64 runner on PRs and pushes to main so we stop breaking it silently.

## Context

Go's assembler segfaults under QEMU amd64 emulation on Apple Silicon. The previous Dockerfile pinned an amd64-specific digest, making local builds impossible on Mac. We keep breaking the arm64 build path because there was no CI coverage for it — changes to the Dockerfile or Go version would only surface when someone needed to deploy urgently from a Mac.

The default `BUILDER_ARCH=multiarch` uses the multiarch image digest for production Linux builds. Mac users override with `BUILDER_ARCH=arm64` to use the arm64-specific digest and avoid QEMU emulation.