### PR TITLE
feat: add AutoML and AutoRAG related images to manager

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -188,5 +188,19 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.WEBHOOK_ANNOTATIONS
+  - name: RELATED_IMAGE_ODH_AUTOML_IMAGE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.RELATED_IMAGE_ODH_AUTOML_IMAGE
+  - name: RELATED_IMAGE_ODH_AUTORAG_IMAGE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.RELATED_IMAGE_ODH_AUTORAG_IMAGE
 configurations:
   - params.yaml

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -22,3 +22,5 @@ MANAGEDPIPELINES="{}"
 PLATFORMVERSION="v0.0.0"
 FIPSENABLED=false
 WEBHOOK_ANNOTATIONS=
+RELATED_IMAGE_ODH_AUTOML_IMAGE=quay.io/opendatahub/odh-automl:odh-stable
+RELATED_IMAGE_ODH_AUTORAG_IMAGE=quay.io/opendatahub/odh-autorag:odh-stable

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -90,6 +90,10 @@ spec:
             value: $(FIPSENABLED)
           - name: WEBHOOK_ANNOTATIONS
             value: $(WEBHOOK_ANNOTATIONS)
+          - name: RELATED_IMAGE_ODH_AUTOML_IMAGE
+            value: $(RELATED_IMAGE_ODH_AUTOML_IMAGE)
+          - name: RELATED_IMAGE_ODH_AUTORAG_IMAGE
+            value: $(RELATED_IMAGE_ODH_AUTORAG_IMAGE)
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Related jira issue:
https://redhat.atlassian.net/browse/RHOAIENG-59026

We need to enable managed pipelines, it turns out we need to add images to three different repos. The following two images added to the manager.yaml:

RELATED_IMAGE_ODH_AUTOML_IMAGE
RELATED_IMAGE_ODH_AUTORAG_IMAGE
First image will use autogluon_timeseries_training_pipeline and autogluon_tabular_training_pipeline managed pipelines. The second one will use documents_rag_optimization_pipeline manged pipeline.

When it comes to registry that will be used:

quay.io/opendatahub/odh-automl:odh-stable
quay.io/opendatahub/odh-autorag:odh-stable



## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

Tests:
Manual manifest building works without a problem -> `kubectl kustomize config/base`
Also unit tests passed:
```bash
go test ./controllers/ -run 'ManagedPipelineImage|ManagedPipeline' -tags=test_unit -v
...
PASS
ok      github.com/opendatahub-io/data-science-pipelines-operator/controllers   1.457s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled support for ODH AutoML and ODH AutoRAG components through configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->