### PR TITLE
Add MLFlow Integration tests

### DIFF
--- a/.github/scripts/tests/run_dsp_mlflow_tests.sh
+++ b/.github/scripts/tests/run_dsp_mlflow_tests.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# This script is defined as the following:
+# 1 - We declare the required environment variables
+# 2 - Has the functions defined
+# 3 - Port-forward to the API server and MLflow, then run ginkgo MLflow tests
+#     from quay.io/opendatahub/ds-pipelines-tests (invoked by tests.sh run_tests_dspa_mlflow)
+
+set -euo pipefail
+
+# Env vars
+DSPA_MLFLOW_NAMESPACE="${DSPA_MLFLOW_NAMESPACE:-test-dspa-mlflow}"
+MLFLOW_NAMESPACE="${MLFLOW_NAMESPACE:-opendatahub}"
+MLFLOW_CR_NAME="${MLFLOW_CR_NAME:-mlflow}"
+DSPA_NAME="${DSPA_NAME:-test-dspa-mlflow}"
+DSP_TESTS_IMAGE_TAG="${DSP_TESTS_IMAGE_TAG:-master}"
+DSP_TESTS_IMAGE="${DSP_TESTS_IMAGE:-quay.io/opendatahub/ds-pipelines-tests:${DSP_TESTS_IMAGE_TAG}}"
+CONTAINER_CLI="${CONTAINER_CLI:-docker}"
+TEST_LABEL="${TEST_LABEL:-MLflow}"
+NUM_PARALLEL_NODES="${NUM_PARALLEL_NODES:-1}"
+API_LOCAL_PORT="${API_LOCAL_PORT:-8888}"
+MLFLOW_LOCAL_PORT="${MLFLOW_LOCAL_PORT:-8080}"
+KUBECONFIG_PATH="${KUBECONFIG:-${HOME}/.kube/config}"
+KUBECTL_BIN="${KUBECTL_BIN:-$(command -v kubectl || true)}"
+CONTAINER_KUBECONFIG="/dspa/backend/test/.kube/config"
+CUSTOM_PIP_INDEX_URL="${CUSTOM_PIP_INDEX_URL:-https://pypi.org/simple}"
+CUSTOM_PIP_TRUSTED_HOST="${CUSTOM_PIP_TRUSTED_HOST:-pypi.org}"
+BASE_IMAGE="${BASE_IMAGE:-quay.io/opendatahub/ds-pipelines-ci-executor-image:v1.1}"
+
+DEPLOYMENT_NAME="ds-pipeline-${DSPA_NAME}"
+PIPELINE_RUNNER_SA="pipeline-runner-${DSPA_NAME}"
+API_PF_PID=""
+MLFLOW_PF_PID=""
+GINKGO_BIN_DIR=""
+GINKGO_BIN=""
+MLFLOW_CA_FILE=""
+MLFLOW_HOST=""
+MLFLOW_HOSTS_ENTRY_ADDED=""
+MLFLOW_TLS_SECRET_NAME="${MLFLOW_TLS_SECRET_NAME:-mlflow-tls}"
+MLFLOW_TLS_SECRET_CERT_KEY="${MLFLOW_TLS_SECRET_CERT_KEY:-tls.crt}"
+DRIVER_POD_NAME_PATTERN="-system-container-driver-"
+DRIVER_LOG_WATCHER_PID=""
+DRIVER_LOGGED_PODS_FILE=""
+
+if [ ! -f "${KUBECONFIG_PATH}" ]; then
+  echo "Kubeconfig not found at ${KUBECONFIG_PATH}" >&2
+  exit 1
+fi
+
+if [ -z "${KUBECTL_BIN}" ] || [ ! -x "${KUBECTL_BIN}" ]; then
+  echo "kubectl not found on host (set KUBECTL_BIN); ds-pipelines-tests needs it for workflow logs" >&2
+  exit 1
+fi
+
+cleanup() {
+  local exit_code=$?
+  if [ -n "${API_PF_PID}" ] && kill -0 "${API_PF_PID}" 2>/dev/null; then
+    kill "${API_PF_PID}" 2>/dev/null || true
+  fi
+  if [ -n "${MLFLOW_PF_PID}" ] && kill -0 "${MLFLOW_PF_PID}" 2>/dev/null; then
+    kill "${MLFLOW_PF_PID}" 2>/dev/null || true
+  fi
+  pkill -f "kubectl port-forward.*${DEPLOYMENT_NAME}.*${API_LOCAL_PORT}" 2>/dev/null || true
+  pkill -f "kubectl port-forward.*${MLFLOW_NAMESPACE}.*${MLFLOW_LOCAL_PORT}" 2>/dev/null || true
+  if [ -n "${GINKGO_BIN_DIR}" ] && [ -d "${GINKGO_BIN_DIR}" ]; then
+    rm -rf "${GINKGO_BIN_DIR}"
+  fi
+  if [ -n "${MLFLOW_CA_FILE}" ] && [ -f "${MLFLOW_CA_FILE}" ]; then
+    rm -f "${MLFLOW_CA_FILE}"
+  fi
+  if [ -n "${MLFLOW_HOSTS_ENTRY_ADDED}" ] && [ -n "${MLFLOW_HOST}" ]; then
+    sudo sed -i "\|127.0.0.1 ${MLFLOW_HOST}|d" /etc/hosts 2>/dev/null || true
+  fi
+  stop_driver_log_watcher
+  exit "${exit_code}"
+}
+trap cleanup EXIT INT TERM
+
+stop_conflicting_port_forwards() {
+  pkill -f "kubectl port-forward.*${DEPLOYMENT_NAME}.*${API_LOCAL_PORT}" 2>/dev/null || true
+  pkill -f "kubectl port-forward.*${MLFLOW_NAMESPACE}.*${MLFLOW_LOCAL_PORT}" 2>/dev/null || true
+  sleep 2
+}
+
+resolve_mlflow_service() {
+  local address_url
+  if ! kubectl get mlflow "${MLFLOW_CR_NAME}" -n "${MLFLOW_NAMESPACE}" >/dev/null 2>&1; then
+    echo "MLflow CR ${MLFLOW_CR_NAME} not found in ${MLFLOW_NAMESPACE}" >&2
+    exit 1
+  fi
+  address_url="$(kubectl get mlflow "${MLFLOW_CR_NAME}" -n "${MLFLOW_NAMESPACE}" \
+    -o jsonpath='{.status.address.url}' 2>/dev/null || true)"
+  if [ -z "${address_url}" ]; then
+    echo "MLflow CR ${MLFLOW_CR_NAME} has no status.address.url in ${MLFLOW_NAMESPACE}" >&2
+    kubectl get mlflow "${MLFLOW_CR_NAME}" -n "${MLFLOW_NAMESPACE}" -o yaml || true
+    exit 1
+  fi
+  # MLflow operator names the Service after the CR (must be "mlflow").
+  MLFLOW_SVC="${MLFLOW_CR_NAME}"
+  if ! kubectl get svc -n "${MLFLOW_NAMESPACE}" "${MLFLOW_SVC}" >/dev/null 2>&1; then
+    echo "MLflow service ${MLFLOW_SVC} not found in ${MLFLOW_NAMESPACE}" >&2
+    kubectl get svc -n "${MLFLOW_NAMESPACE}" || true
+    exit 1
+  fi
+  MLFLOW_REMOTE_PORT="$(kubectl get svc -n "${MLFLOW_NAMESPACE}" "${MLFLOW_SVC}" -o jsonpath='{.spec.ports[0].port}')"
+  # Port-forward uses localhost, but the TLS cert is issued for the in-cluster DNS name.
+  local authority="${address_url#*://}"
+  authority="${authority%%/*}"
+  MLFLOW_HOST="${authority%%:*}"
+  if [ -z "${MLFLOW_HOST}" ]; then
+    echo "Failed to parse MLflow host from address URL: ${address_url}" >&2
+    exit 1
+  fi
+  echo "MLflow service: ${MLFLOW_SVC}:${MLFLOW_REMOTE_PORT} (namespace ${MLFLOW_NAMESPACE}, address: ${address_url}, host: ${MLFLOW_HOST})"
+}
+
+ensure_mlflow_hosts_entry() {
+  if grep -qE "[[:space:]]${MLFLOW_HOST}([[:space:]]|$)" /etc/hosts 2>/dev/null; then
+    return 0
+  fi
+  echo "Mapping ${MLFLOW_HOST} -> 127.0.0.1 in /etc/hosts for port-forward TLS"
+  echo "127.0.0.1 ${MLFLOW_HOST}" | sudo tee -a /etc/hosts >/dev/null
+  MLFLOW_HOSTS_ENTRY_ADDED=1
+}
+
+resolve_mlflow_ca() {
+  MLFLOW_CA_FILE="$(mktemp)"
+  if kubectl get configmap mlflow-ca-bundle -n "${MLFLOW_NAMESPACE}" >/dev/null 2>&1; then
+    if ! kubectl get configmap mlflow-ca-bundle -n "${MLFLOW_NAMESPACE}" \
+      -o jsonpath='{.data.ca-bundle\.crt}' >"${MLFLOW_CA_FILE}" 2>/dev/null; then
+      echo "Failed to read MLflow CA from configmap mlflow-ca-bundle in ${MLFLOW_NAMESPACE}" >&2
+      exit 1
+    fi
+    echo "Using MLflow CA from ${MLFLOW_NAMESPACE}/mlflow-ca-bundle"
+  elif kubectl get secret "${MLFLOW_TLS_SECRET_NAME}" -n "${MLFLOW_NAMESPACE}" >/dev/null 2>&1; then
+    local jsonpath_key="${MLFLOW_TLS_SECRET_CERT_KEY//./\\.}"
+    if ! kubectl get secret "${MLFLOW_TLS_SECRET_NAME}" -n "${MLFLOW_NAMESPACE}" \
+      -o "jsonpath={.data.${jsonpath_key}}" | base64 -d >"${MLFLOW_CA_FILE}" 2>/dev/null; then
+      echo "Failed to read ${MLFLOW_TLS_SECRET_CERT_KEY} from secret ${MLFLOW_TLS_SECRET_NAME} in ${MLFLOW_NAMESPACE}" >&2
+      exit 1
+    fi
+    echo "Using MLflow CA from ${MLFLOW_NAMESPACE}/${MLFLOW_TLS_SECRET_NAME} (${MLFLOW_TLS_SECRET_CERT_KEY})"
+  else
+    echo "Neither mlflow-ca-bundle ConfigMap nor ${MLFLOW_TLS_SECRET_NAME} Secret found in ${MLFLOW_NAMESPACE}" >&2
+    exit 1
+  fi
+  if [ ! -s "${MLFLOW_CA_FILE}" ]; then
+    echo "MLflow CA material is empty" >&2
+    exit 1
+  fi
+}
+
+start_port_forwards() {
+  echo "---------------------------------"
+  echo "Port-forward API server and MLflow"
+  echo "---------------------------------"
+  stop_conflicting_port_forwards
+
+  kubectl port-forward -n "${DSPA_MLFLOW_NAMESPACE}" "svc/${DEPLOYMENT_NAME}" "${API_LOCAL_PORT}:8888" >/dev/null 2>&1 &
+  API_PF_PID=$!
+
+  kubectl port-forward -n "${MLFLOW_NAMESPACE}" "svc/${MLFLOW_SVC}" "${MLFLOW_LOCAL_PORT}:${MLFLOW_REMOTE_PORT}" >/dev/null 2>&1 &
+  MLFLOW_PF_PID=$!
+
+  sleep 3
+  if ! kill -0 "${API_PF_PID}" 2>/dev/null; then
+    echo "API server port-forward (PID ${API_PF_PID}) died immediately" >&2
+    exit 1
+  fi
+  if ! kill -0 "${MLFLOW_PF_PID}" 2>/dev/null; then
+    echo "MLflow port-forward (PID ${MLFLOW_PF_PID}) died immediately" >&2
+    exit 1
+  fi
+  ensure_mlflow_hosts_entry
+}
+
+wait_for_api_health() {
+  echo "Waiting for API server health on http://127.0.0.1:${API_LOCAL_PORT}..."
+  for _ in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${API_LOCAL_PORT}/apis/v2beta1/healthz" >/dev/null 2>&1; then
+      echo "API server is healthy"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "API server not healthy at http://127.0.0.1:${API_LOCAL_PORT}" >&2
+  exit 1
+}
+
+wait_for_mlflow_health() {
+  local health_url="https://${MLFLOW_HOST}:${MLFLOW_LOCAL_PORT}/mlflow/health"
+  local curl_resolve=(--resolve "${MLFLOW_HOST}:${MLFLOW_LOCAL_PORT}:127.0.0.1")
+  local curl_headers=(-H "X-MLflow-Workspace: ${DSPA_MLFLOW_NAMESPACE}")
+  if [ -n "${MLFLOW_BEARER_TOKEN:-}" ]; then
+    curl_headers+=(-H "Authorization: Bearer ${MLFLOW_BEARER_TOKEN}")
+  fi
+
+  echo "Waiting for MLflow health at ${health_url} (via port-forward on 127.0.0.1:${MLFLOW_LOCAL_PORT})..."
+  for _ in $(seq 1 30); do
+    status="$(curl --cacert "${MLFLOW_CA_FILE}" "${curl_resolve[@]}" -o /dev/null -w '%{http_code}' \
+      --connect-timeout 5 --max-time 10 \
+      "${curl_headers[@]}" "${health_url}" 2>/dev/null || echo "000")"
+    if [ "${status}" = "200" ]; then
+      echo "MLflow backend is healthy (status=${status})"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "MLflow backend not healthy at ${health_url} (last HTTP status: ${status})" >&2
+  exit 1
+}
+
+configure_auth() {
+  echo "---------------------------------"
+  echo "Generate API and MLflow auth tokens"
+  echo "---------------------------------"
+  API_TOKEN="$(kubectl create token "${DEPLOYMENT_NAME}" --namespace "${DSPA_MLFLOW_NAMESPACE}" --duration=60m)"
+  API_URL="http://127.0.0.1:${API_LOCAL_PORT}"
+  MLFLOW_BEARER_TOKEN="$(kubectl create token "${DEPLOYMENT_NAME}" --namespace "${DSPA_MLFLOW_NAMESPACE}" --duration=60m)"
+  export MLFLOW_BEARER_TOKEN
+  export MLFLOW_TRACKING_URI="https://${MLFLOW_HOST}:${MLFLOW_LOCAL_PORT}/mlflow"
+  export MLFLOW_WORKSPACE="${DSPA_MLFLOW_NAMESPACE}"
+}
+
+dump_failed_driver_pod_logs() {
+  local pod="$1"
+
+  if [ -z "${pod}" ] || [ -z "${DRIVER_LOGGED_PODS_FILE}" ]; then
+    return 0
+  fi
+  if grep -qxF "${pod}" "${DRIVER_LOGGED_PODS_FILE}" 2>/dev/null; then
+    return 0
+  fi
+  echo "${pod}" >>"${DRIVER_LOGGED_PODS_FILE}"
+
+  echo "===== FAILED workflow driver pod: ${pod} (namespace ${DSPA_MLFLOW_NAMESPACE}) ====="
+  echo "----- EVENTS -----"
+  kubectl describe pod -n "${DSPA_MLFLOW_NAMESPACE}" "${pod}" 2>&1 | grep -A 100 Events || echo "No events found for pod ${pod}."
+  echo "----- LOGS (all containers) -----"
+  kubectl logs -n "${DSPA_MLFLOW_NAMESPACE}" "${pod}" --all-containers=true 2>&1 || echo "No logs found for pod ${pod}."
+  echo "----- LOGS (main container) -----"
+  kubectl logs -n "${DSPA_MLFLOW_NAMESPACE}" "${pod}" -c main 2>&1 || echo "No main container logs found for pod ${pod}."
+  echo "----- PREVIOUS LOGS (main container) -----"
+  kubectl logs -n "${DSPA_MLFLOW_NAMESPACE}" "${pod}" -c main --previous 2>&1 || echo "No previous main container logs found for pod ${pod}."
+  echo "================================================================="
+}
+
+collect_failed_driver_logs_once() {
+  local pods pod
+
+  pods="$(kubectl get pods -n "${DSPA_MLFLOW_NAMESPACE}" \
+    --field-selector=status.phase=Failed \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | grep -F -- "${DRIVER_POD_NAME_PATTERN}" || true)"
+  if [ -z "${pods}" ]; then
+    return 0
+  fi
+
+  for pod in ${pods}; do
+    dump_failed_driver_pod_logs "${pod}"
+  done
+}
+
+start_driver_log_watcher() {
+  DRIVER_LOGGED_PODS_FILE="$(mktemp)"
+  (
+    while true; do
+      collect_failed_driver_logs_once
+      sleep 0.5
+    done
+  ) &
+  DRIVER_LOG_WATCHER_PID=$!
+  echo "Watching for failed workflow driver pods in ${DSPA_MLFLOW_NAMESPACE} (PID ${DRIVER_LOG_WATCHER_PID})"
+}
+
+stop_driver_log_watcher() {
+  if [ -n "${DRIVER_LOG_WATCHER_PID}" ] && kill -0 "${DRIVER_LOG_WATCHER_PID}" 2>/dev/null; then
+    kill "${DRIVER_LOG_WATCHER_PID}" 2>/dev/null || true
+    wait "${DRIVER_LOG_WATCHER_PID}" 2>/dev/null || true
+  fi
+  DRIVER_LOG_WATCHER_PID=""
+  collect_failed_driver_logs_once
+  if [ -n "${DRIVER_LOGGED_PODS_FILE}" ] && [ -f "${DRIVER_LOGGED_PODS_FILE}" ]; then
+    rm -f "${DRIVER_LOGGED_PODS_FILE}"
+  fi
+  DRIVER_LOGGED_PODS_FILE=""
+}
+
+build_ginkgo_binary() {
+  echo "---------------------------------"
+  echo "Pre-build ginkgo binary (${DSP_TESTS_IMAGE})"
+  echo "---------------------------------"
+  GINKGO_BIN_DIR="$(mktemp -d)"
+  GINKGO_BIN="${GINKGO_BIN_DIR}/ginkgo"
+
+  local ginkgo_mount="${GINKGO_BIN_DIR}:/out"
+  if [ "${CONTAINER_CLI}" = "podman" ]; then
+    ginkgo_mount="${ginkgo_mount}:Z"
+  fi
+
+  # shellcheck disable=SC2086
+  ${CONTAINER_CLI} run --rm \
+    --entrypoint bash \
+    -v "${ginkgo_mount}" \
+    --workdir=/dspa/backend/test/end2end \
+    "${DSP_TESTS_IMAGE}" \
+    -c 'go build -o /out/ginkgo github.com/onsi/ginkgo/v2/ginkgo'
+
+  if [ ! -x "${GINKGO_BIN}" ]; then
+    echo "Failed to build ginkgo binary at ${GINKGO_BIN}" >&2
+    exit 1
+  fi
+}
+
+run_dsp_tests() {
+  echo "---------------------------------"
+  echo "Run DSP MLflow tests (${DSP_TESTS_IMAGE})"
+  echo "---------------------------------"
+
+  local kube_mount="${KUBECONFIG_PATH}:${CONTAINER_KUBECONFIG}"
+  local ginkgo_mount="${GINKGO_BIN_DIR}:/out:ro"
+  local kubectl_mount="${KUBECTL_BIN}:/usr/local/bin/kubectl:ro"
+  local mlflow_ca_mount="${MLFLOW_CA_FILE}:/mlflow-ca/ca-bundle.crt:ro"
+  if [ "${CONTAINER_CLI}" = "podman" ]; then
+    kube_mount="${kube_mount}:Z"
+    ginkgo_mount="${GINKGO_BIN_DIR}:/out:ro,Z"
+    kubectl_mount="${kubectl_mount},Z"
+    mlflow_ca_mount="${mlflow_ca_mount},Z"
+  fi
+
+  local network_args=""
+  if [ "$(uname -s)" = "Linux" ]; then
+    network_args="--network host"
+  fi
+
+  start_driver_log_watcher
+
+  set +e
+  # shellcheck disable=SC2086
+  ${CONTAINER_CLI} run --rm \
+    --entrypoint bash \
+    ${network_args} \
+    -v "${kube_mount}" \
+    -v "${ginkgo_mount}" \
+    -v "${kubectl_mount}" \
+    -v "${mlflow_ca_mount}" \
+    -e KUBECONFIG="${CONTAINER_KUBECONFIG}" \
+    -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-minio}" \
+    -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-minio123}" \
+    -e MLFLOW_TRACKING_URI \
+    -e MLFLOW_WORKSPACE \
+    -e MLFLOW_BEARER_TOKEN \
+    -e MLFLOW_CA_BUNDLE_PATH="/mlflow-ca/ca-bundle.crt" \
+    -e REQUESTS_CA_BUNDLE="/mlflow-ca/ca-bundle.crt" \
+    -e SSL_CERT_FILE="/mlflow-ca/ca-bundle.crt" \
+    -e DSP_TEST_NAMESPACE="${DSPA_MLFLOW_NAMESPACE}" \
+    -e DSP_TEST_API_URL="${API_URL}" \
+    -e DSP_TEST_API_TOKEN="${API_TOKEN}" \
+    -e DSP_TEST_PIPELINE_RUNNER_SA="${PIPELINE_RUNNER_SA}" \
+    -e DSP_TEST_LABEL="${TEST_LABEL}" \
+    -e DSP_TEST_NUM_PARALLEL_NODES="${NUM_PARALLEL_NODES}" \
+    -e DSP_TEST_CUSTOM_PIP_INDEX_URL="${CUSTOM_PIP_INDEX_URL}" \
+    -e DSP_TEST_CUSTOM_PIP_TRUSTED_HOST="${CUSTOM_PIP_TRUSTED_HOST}" \
+    -e DSP_TEST_BASE_IMAGE="${BASE_IMAGE}" \
+    --workdir=/dspa/backend/test/end2end \
+    "${DSP_TESTS_IMAGE}" \
+    -c '/out/ginkgo -r -v -p \
+      --nodes="${DSP_TEST_NUM_PARALLEL_NODES}" \
+      --label-filter="${DSP_TEST_LABEL}" \
+      -- -namespace="${DSP_TEST_NAMESPACE}" \
+      -apiUrl="${DSP_TEST_API_URL}" \
+      -authToken="${DSP_TEST_API_TOKEN}" \
+      -disableTlsCheck=true \
+      -mlflowEnabled=true \
+      -customPipIndexURL="${DSP_TEST_CUSTOM_PIP_INDEX_URL}" \
+      -customPipTrustedHost="${DSP_TEST_CUSTOM_PIP_TRUSTED_HOST}" \
+      -serviceAccountName="${DSP_TEST_PIPELINE_RUNNER_SA}" \
+      -baseImage="${DSP_TEST_BASE_IMAGE}" \
+      -disconnectedCluster=false'
+  local test_exit=$?
+  set -e
+
+  stop_driver_log_watcher
+  return "${test_exit}"
+}
+
+resolve_mlflow_service
+resolve_mlflow_ca
+configure_auth
+build_ginkgo_binary
+start_port_forwards
+wait_for_api_health
+wait_for_mlflow_health
+run_dsp_tests

--- a/.github/scripts/tests/tests.sh
+++ b/.github/scripts/tests/tests.sh
@@ -20,6 +20,7 @@ K8SAPISERVERHOST=""
 DSPA_NAMESPACE="test-dspa"
 DSPA_EXTERNAL_NAMESPACE="dspa-ext"
 DSPA_K8S_NAMESPACE="test-k8s-dspa"
+DSPA_MLFLOW_NAMESPACE="test-dspa-mlflow"
 MINIO_NAMESPACE="test-minio"
 MARIADB_NAMESPACE="test-mariadb"
 PYPISERVER_NAMESPACE="test-pypiserver"
@@ -33,6 +34,16 @@ INTEGRATION_TESTS_DIR="${GIT_WORKSPACE}/tests"
 DSPA_PATH="${GIT_WORKSPACE}/tests/resources/dspa-lite.yaml"
 DSPA_EXTERNAL_PATH="${GIT_WORKSPACE}/tests/resources/dspa-external-lite.yaml"
 DSPA_K8S_PATH="${GIT_WORKSPACE}/tests/resources/dspa-k8s.yaml"
+DSPA_MLFLOW_PATH="${GIT_WORKSPACE}/tests/resources/dspa-mlflow-lite.yaml"
+DSPA_MLFLOW_NAME="test-dspa-mlflow"
+MLFLOW_NAMESPACE="${MLFLOW_NAMESPACE:-opendatahub}"
+MLFLOW_CA_BUNDLE_NAME="${MLFLOW_CA_BUNDLE_NAME:-mlflow-ca-bundle}"
+MLFLOW_CA_BUNDLE_KEY="${MLFLOW_CA_BUNDLE_KEY:-ca-bundle.crt}"
+MLFLOW_TLS_SECRET_NAME="${MLFLOW_TLS_SECRET_NAME:-mlflow-tls}"
+MLFLOW_TLS_SECRET_CERT_KEY="${MLFLOW_TLS_SECRET_CERT_KEY:-tls.crt}"
+DSP_TESTS_IMAGE_TAG="${DSP_TESTS_IMAGE_TAG:-master}"
+DSP_TESTS_IMAGE="${DSP_TESTS_IMAGE:-quay.io/opendatahub/ds-pipelines-tests:${DSP_TESTS_IMAGE_TAG}}"
+TESTS_SCRIPT_DIR="${GIT_WORKSPACE}/.github/scripts/tests"
 CONFIG_DIR="${GIT_WORKSPACE}/config"
 RESOURCES_DIR_CRD="${GIT_WORKSPACE}/.github/resources"
 OPENDATAHUB_NAMESPACE="opendatahub"
@@ -41,6 +52,8 @@ ENDPOINT_TYPE="service"
 DSPO_IMAGE_REF="${DSPO_IMAGE_REF:-}"
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 RUN_PKG_UPLOADER_IN_CONTAINER="${RUN_PKG_UPLOADER_IN_CONTAINER:-true}"
+MLFLOW_ONLY="${MLFLOW_ONLY:-false}"
+MLFLOW_TEST_LABEL="${MLFLOW_TEST_LABEL:-${TEST_LABEL:-MLflow}}"
 
 get_dspo_image() {
   if [ ! -z "$DSPO_IMAGE_REF" ]; then
@@ -254,6 +267,46 @@ create_dspa_k8s_namespace() {
   kubectl create namespace $DSPA_K8S_NAMESPACE
 }
 
+create_dspa_mlflow_namespace() {
+  echo "---------------------------------"
+  echo "Create DSPA Namespace for MLflow-enabled DSPA"
+  echo "---------------------------------"
+  kubectl get namespace $DSPA_MLFLOW_NAMESPACE >/dev/null 2>&1 || \
+  kubectl create namespace $DSPA_MLFLOW_NAMESPACE
+}
+
+copy_mlflow_ca_bundle() {
+  echo "---------------------------------"
+  echo "Copy MLflow CA bundle (${MLFLOW_CA_BUNDLE_NAME}) to ${DSPA_MLFLOW_NAMESPACE}"
+  echo "---------------------------------"
+  local ca_pem=""
+  local ca_source=""
+  local jsonpath_key=""
+  if kubectl get configmap "${MLFLOW_CA_BUNDLE_NAME}" -n "${MLFLOW_NAMESPACE}" >/dev/null 2>&1; then
+    jsonpath_key="${MLFLOW_CA_BUNDLE_KEY//./\\.}"
+    ca_pem="$(kubectl get configmap "${MLFLOW_CA_BUNDLE_NAME}" -n "${MLFLOW_NAMESPACE}" \
+      -o "jsonpath={.data.${jsonpath_key}}")"
+    ca_source="${MLFLOW_NAMESPACE}/${MLFLOW_CA_BUNDLE_NAME}"
+  elif kubectl get secret "${MLFLOW_TLS_SECRET_NAME}" -n "${MLFLOW_NAMESPACE}" >/dev/null 2>&1; then
+    jsonpath_key="${MLFLOW_TLS_SECRET_CERT_KEY//./\\.}"
+    ca_pem="$(kubectl get secret "${MLFLOW_TLS_SECRET_NAME}" -n "${MLFLOW_NAMESPACE}" \
+      -o "jsonpath={.data.${jsonpath_key}}" | base64 -d)"
+    ca_source="${MLFLOW_NAMESPACE}/${MLFLOW_TLS_SECRET_NAME} (${MLFLOW_TLS_SECRET_CERT_KEY})"
+  else
+    echo "Neither ConfigMap ${MLFLOW_CA_BUNDLE_NAME} nor Secret ${MLFLOW_TLS_SECRET_NAME} found in ${MLFLOW_NAMESPACE}" >&2
+    exit 1
+  fi
+  if [ -z "${ca_pem}" ]; then
+    echo "MLflow CA material from ${ca_source} is empty" >&2
+    exit 1
+  fi
+  echo "Using MLflow CA from ${ca_source}"
+  kubectl create configmap "${MLFLOW_CA_BUNDLE_NAME}" \
+    --from-literal="${MLFLOW_CA_BUNDLE_KEY}=${ca_pem}" \
+    -n "${DSPA_MLFLOW_NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
 apply_mariadb_minio_secrets_configmaps_external_namespace() {
   echo "---------------------------------"
   echo "Apply MariaDB and Minio Secrets and Configmaps in the External Namespace"
@@ -265,7 +318,7 @@ apply_pip_server_configmap() {
   echo "---------------------------------"
   echo "Apply PIP Server ConfigMap"
   echo "---------------------------------"
-  for ns in $DSPA_NAMESPACE $DSPA_K8S_NAMESPACE; do
+  for ns in $DSPA_NAMESPACE $DSPA_K8S_NAMESPACE $DSPA_MLFLOW_NAMESPACE; do
     echo "Applying ConfigMap in namespace: $ns"
     ( cd "${GIT_WORKSPACE}/.github/resources/pypiserver/base" && kubectl apply -f "$RESOURCES_DIR_PYPI/nginx-tls-config.yaml" -n "$ns" )
   done
@@ -313,6 +366,88 @@ run_tests_dspa_k8s() {
   ( cd $GIT_WORKSPACE && make integrationtest K8SAPISERVERHOST=${K8SAPISERVERHOST} DSPANAMESPACE=${DSPA_K8S_NAMESPACE} DSPAPATH=${DSPA_K8S_PATH} ENDPOINT_TYPE=${ENDPOINT_TYPE} INTTEST_AWF_MANAGEMENT_STATE=${AWF_MANAGEMENT_STATE} INTTEST_SKIP_DEPLOY=${SKIP_DEPLOY} INTTEST_SKIP_CLEANUP=${SKIP_CLEANUP})
 }
 
+deploy_dspa_mlflow() {
+  echo "---------------------------------"
+  echo "Deploy MLflow-enabled DSPA"
+  echo "---------------------------------"
+  if [ ! -f "${DSPA_MLFLOW_PATH}" ]; then
+    echo "MLflow DSPA manifest not found at ${DSPA_MLFLOW_PATH}" >&2
+    exit 1
+  fi
+  kubectl apply -f "${DSPA_MLFLOW_PATH}" -n "${DSPA_MLFLOW_NAMESPACE}"
+}
+
+wait_for_dspa_mlflow_deployment() {
+  local deployment_name="ds-pipeline-${DSPA_MLFLOW_NAME}"
+  local elapsed=0
+  echo "---------------------------------"
+  echo "Wait for MLflow-enabled DSPA API server (${deployment_name})"
+  echo "---------------------------------"
+  echo "Waiting for deployment ${deployment_name} to be ready..."
+  while [ "${elapsed}" -lt "${DSPA_DEPLOY_WAIT_TIMEOUT}" ]; do
+    if kubectl wait --for=condition=available \
+        "deployment/${deployment_name}" \
+        -n "${DSPA_MLFLOW_NAMESPACE}" \
+        --timeout=5s >/dev/null 2>&1; then
+      return 0
+    fi
+    elapsed=$((elapsed + 5))
+    sleep 5
+  done
+  echo "Timed out waiting for deployment ${deployment_name} after ${DSPA_DEPLOY_WAIT_TIMEOUT}s"
+  kubectl get "deployment/${deployment_name}" -n "${DSPA_MLFLOW_NAMESPACE}" || true
+  return 1
+}
+
+wait_for_dspa_mlflow_plugin() {
+  local deployment_name="ds-pipeline-${DSPA_MLFLOW_NAME}"
+  local server_config_cm="ds-pipeline-server-config-${DSPA_MLFLOW_NAME}"
+  local elapsed=0
+
+  # Plugin config is generated only after the API server deployment is Available, then
+  # server-config and the deployment configHash annotation are updated on the next reconcile.
+  echo "Waiting for MLflow plugin in ${server_config_cm}..."
+  elapsed=0
+  while [ "${elapsed}" -lt "${DSPA_DEPLOY_WAIT_TIMEOUT}" ]; do
+    if kubectl get configmap "${server_config_cm}" -n "${DSPA_MLFLOW_NAMESPACE}" -o jsonpath='{.data.config\.json}' 2>/dev/null \
+        | grep -q '"mlflow"'; then
+      break
+    fi
+    elapsed=$((elapsed + 5))
+    sleep 5
+  done
+  if [ "${elapsed}" -ge "${DSPA_DEPLOY_WAIT_TIMEOUT}" ]; then
+    echo "Timed out waiting for MLflow plugin in ${server_config_cm} after ${DSPA_DEPLOY_WAIT_TIMEOUT}s"
+    kubectl get configmap "${server_config_cm}" -n "${DSPA_MLFLOW_NAMESPACE}" -o yaml || true
+    return 1
+  fi
+
+  echo "Waiting for API server rollout after MLflow plugin config..."
+  if ! kubectl rollout status "deployment/${deployment_name}" \
+      -n "${DSPA_MLFLOW_NAMESPACE}" \
+      --timeout="${DSPA_DEPLOY_WAIT_TIMEOUT}s"; then
+    kubectl get "deployment/${deployment_name}" -n "${DSPA_MLFLOW_NAMESPACE}" || true
+    return 1
+  fi
+}
+
+run_tests_dspa_mlflow() {
+  echo "---------------------------------"
+  echo "Run DSP MLflow tests for DSPA with MLflow enabled"
+  echo "---------------------------------"
+  create_dspa_mlflow_namespace
+  copy_mlflow_ca_bundle
+  deploy_dspa_mlflow
+  wait_for_dspa_mlflow_deployment
+  wait_for_dspa_mlflow_plugin
+  (
+    export DSPA_MLFLOW_NAMESPACE MLFLOW_NAMESPACE DSP_TESTS_IMAGE DSP_TESTS_IMAGE_TAG CONTAINER_CLI
+    export DSPA_NAME="${DSPA_MLFLOW_NAME}"
+    export TEST_LABEL="${MLFLOW_TEST_LABEL}"
+    bash "${TESTS_SCRIPT_DIR}/run_dsp_mlflow_tests.sh"
+  )
+}
+
 update_dspo_env() {
   echo "---------------------------------"
   echo "Update DSPO Environment Variable"
@@ -357,6 +492,7 @@ setup_kind_requirements() {
   create_dspa_namespace
   create_namespace_dspa_external_connections
   create_dspa_k8s_namespace
+  create_dspa_mlflow_namespace
   apply_mariadb_minio_secrets_configmaps_external_namespace
   apply_pip_server_configmap
 }
@@ -375,6 +511,7 @@ setup_openshift_ci_requirements() {
   create_dspa_namespace
   create_namespace_dspa_external_connections
   create_dspa_k8s_namespace
+  create_dspa_mlflow_namespace
   apply_mariadb_minio_secrets_configmaps_external_namespace
   apply_pip_server_configmap
 }
@@ -388,6 +525,7 @@ setup_rhoai_requirements() {
   create_dspa_namespace
   create_namespace_dspa_external_connections
   create_dspa_k8s_namespace
+  create_dspa_mlflow_namespace
   apply_mariadb_minio_secrets_configmaps_external_namespace
   apply_pip_server_configmap
 }
@@ -408,6 +546,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --skip-cleanup)
       SKIP_CLEANUP=true
+      shift
+      ;;
+    --mlflow-only)
+      MLFLOW_ONLY=true
       shift
       ;;
     --kind)
@@ -548,6 +690,11 @@ done
 if [ "$K8SAPISERVERHOST" = "" ]; then
   echo "K8SAPISERVERHOST is empty. It will use suite_test.go::Defaultk8sApiServerHost"
   echo "If the TARGET is OpenShift or RHOAI. You can use: oc whoami --show-server"
+fi
+
+if [ "${MLFLOW_ONLY}" = "true" ]; then
+  run_tests_dspa_mlflow
+  exit 0
 fi
 
 if [ "$SKIP_DEPLOY" = true ]; then

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -77,28 +77,10 @@ jobs:
           s3_access_key: minio
           s3_secret_key: minio123
 
-      - name: Wait for MLflow readiness
+      - name: Verify MLflow deployment
         if: ${{ steps.deploy-mlflow.outcome == 'success' }}
         run: |
-          kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running \
-            -n opendatahub --timeout=180s
-          echo "All running pods in opendatahub are Ready"
-          elapsed=0
-          interval=5
-          timeout=300
-          while [ "${elapsed}" -lt "${timeout}" ]; do
-            address_url="$(kubectl get mlflow mlflow -n opendatahub -o jsonpath='{.status.address.url}' 2>/dev/null || true)"
-            if [ -n "${address_url}" ]; then
-              echo "MLflow is ready at ${address_url}"
-              exit 0
-            fi
-            echo "Waiting for MLflow status.address.url (${elapsed}s/${timeout}s)..."
-            sleep "${interval}"
-            elapsed=$((elapsed + interval))
-          done
-          echo "Timed out waiting for MLflow CR status.address.url"
-          kubectl get mlflow mlflow -n opendatahub -o yaml || true
-          exit 1
+          kubectl get mlflow mlflow -n opendatahub
 
       - name: Run DSP MLflow tests
         id: test-mlflow

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -19,6 +19,7 @@ on:
       - .github/actions/**
       - '.github/workflows/kind-integration.yml'
       - '.github/scripts/tests/tests.sh'
+      - '.github/scripts/tests/run_dsp_mlflow_tests.sh'
       - '.github/scripts/python_package_upload/**'
       - Makefile
     types:
@@ -37,7 +38,7 @@ env:
 jobs:
   dspo-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v3
@@ -63,11 +64,60 @@ jobs:
           sh tests.sh --kind
         continue-on-error: true
 
+      - name: Deploy MLflow
+        id: deploy-mlflow
+        uses: opendatahub-io/mlflow-operator/.github/actions/deploy@ec59b7c996ef4d14c448254132e21bd85fd1c28f
+        with:
+          namespace: opendatahub
+          mlflow_image: quay.io/opendatahub/mlflow:odh-stable-490cd77b5b697a8ad0c5a84272983f668b961524
+          mlflow_operator_image: quay.io/opendatahub/mlflow-operator:ec59b7c996ef4d14c448254132e21bd85fd1c28f
+          backend_store: postgres
+          artifact_storage: s3
+          registry_store: postgres
+          s3_access_key: minio
+          s3_secret_key: minio123
+
+      - name: Wait for MLflow readiness
+        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
+        run: |
+          kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running \
+            -n opendatahub --timeout=180s
+          echo "All running pods in opendatahub are Ready"
+          elapsed=0
+          interval=5
+          timeout=300
+          while [ "${elapsed}" -lt "${timeout}" ]; do
+            address_url="$(kubectl get mlflow mlflow -n opendatahub -o jsonpath='{.status.address.url}' 2>/dev/null || true)"
+            if [ -n "${address_url}" ]; then
+              echo "MLflow is ready at ${address_url}"
+              exit 0
+            fi
+            echo "Waiting for MLflow status.address.url (${elapsed}s/${timeout}s)..."
+            sleep "${interval}"
+            elapsed=$((elapsed + interval))
+          done
+          echo "Timed out waiting for MLflow CR status.address.url"
+          kubectl get mlflow mlflow -n opendatahub -o yaml || true
+          exit 1
+
+      - name: Run DSP MLflow tests
+        id: test-mlflow
+        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
+        working-directory: ${{ github.workspace }}/.github/scripts/tests
+        env:
+          CONTAINER_CLI: podman
+          AWS_ACCESS_KEY_ID: minio
+          AWS_SECRET_ACCESS_KEY: minio123
+        run: |
+          bash tests.sh --skip-deploy --mlflow-only
+        continue-on-error: true
+
       - name: Collect events and logs
-        if: steps.test.outcome != 'success'
+        if: steps.test.outcome != 'success' || steps.deploy-mlflow.outcome != 'success' || steps.test-mlflow.outcome != 'success'
         working-directory: ${{ github.workspace }}/.github/scripts/tests
         run: |
           ./collect_logs.sh --dspa-ns test-dspa --dspo-ns opendatahub
           ./collect_logs.sh --dspa-ns dspa-ext --dspo-ns opendatahub
           ./collect_logs.sh --dspa-ns test-k8s-dspa --dspo-ns opendatahub
+          ./collect_logs.sh --dspa-ns test-dspa-mlflow --dspo-ns opendatahub
           exit 1

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -832,17 +832,28 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 				)
 				if p.ResolveMLflowEndpoint == nil {
 					log.Info("ResolveMLflowEndpoint is not configured. Deferring MLflow API server plugin config generation.")
+				} else if p.DSPONamespace == "" {
+					log.V(1).Info("DSPO_NAMESPACE is not set. Deferring MLflow API server plugin config generation.")
 				} else {
-					mlflowEndpoint, err = p.ResolveMLflowEndpoint(ctx, p.Namespace, log)
+					mlflowEndpoint, err = p.ResolveMLflowEndpoint(ctx, p.DSPONamespace, log)
 					if err != nil {
 						log.Error(err, "failed to retrieve MLflow internal endpoint. MLflow API server plugin will not be enabled.")
 					} else {
 						apiServerExternalURL, routeErr := util.GetRouteHostname(ctx, p.APIServerServiceName, p.Namespace, client)
 						if routeErr != nil {
 							log.Info("Unable to retrieve API server route for KFP base URL", "error", routeErr)
-						} else if apiServerExternalURL == "" {
-							log.V(1).Info("APIServer route is not available yet. Deferring MLflow API server plugin config generation.")
-						} else {
+						}
+						if apiServerExternalURL == "" {
+							var svcErr error
+							apiServerExternalURL, svcErr = util.GetServiceHostname(ctx, p.APIServerServiceName, p.Namespace, client)
+							if svcErr != nil {
+								log.Info("Unable to retrieve API server service for KFP base URL", "error", svcErr)
+							}
+							if apiServerExternalURL == "" {
+								log.V(1).Info("APIServer external URL is not available yet. Deferring MLflow API server plugin config generation.")
+							}
+						}
+						if apiServerExternalURL != "" {
 							// Resolve effective CA bundle file path before building plugin config so
 							// APIServer override values are reflected even though global path fields
 							// are updated later in ExtractParams.
@@ -855,7 +866,12 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 								effectiveCABundleFileName = p.APIServer.CABundleFileName
 							}
 							effectiveCABundleFilePath := fmt.Sprintf("%s/%s", effectiveCABundleRootMountPath, effectiveCABundleFileName)
-							pluginCfg, err := BuildMLflowPluginConfigJson(mlflowEndpoint, effectiveCABundleFilePath, *p.MLflow.InjectUserEnvVars, apiServerExternalURL)
+							pluginCfg, err := BuildMLflowPluginConfigJson(
+								mlflowEndpoint,
+								effectiveCABundleFilePath,
+								*p.MLflow.InjectUserEnvVars,
+								apiServerExternalURL,
+							)
 							if err != nil {
 								log.Info("Failed to build MLflow plugin config. MLflow API server plugin will not be enabled.", "error", err)
 							} else {
@@ -1125,7 +1141,12 @@ func validateMLflowEndpointURL(raw string) error {
 	return nil
 }
 
-func BuildMLflowPluginConfigJson(mlflowEndpoint string, caBundlePath string, injectUserEnvVars bool, kfpBaseURL string) (string, error) {
+func BuildMLflowPluginConfigJson(
+	mlflowEndpoint string,
+	caBundlePath string,
+	injectUserEnvVars bool,
+	kfpBaseURL string,
+) (string, error) {
 	settings := MLflowPluginSettings{
 		WorkspacesEnabled:     true,
 		ExperimentDescription: "Created by AI Pipelines.",

--- a/controllers/dspipeline_params_test.go
+++ b/controllers/dspipeline_params_test.go
@@ -27,6 +27,7 @@ import (
 	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/testutil"
 	mlflowv1 "github.com/opendatahub-io/mlflow-operator/api/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -469,6 +470,122 @@ func TestExtractParams_WithoutResourceTTL(t *testing.T) {
 	err := params.ExtractParams(ctx, dspa, client.Client, client.Log)
 	require.NoError(t, err)
 	assert.Empty(t, params.CompiledPipelineSpecPatch)
+}
+
+func TestExtractParams_MLflowEndpointLookupUsesDSPONamespace(t *testing.T) {
+	t.Setenv("DSPO_NAMESPACE", "opendatahub")
+
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	var lookupNamespace string
+	params.ResolveMLflowEndpoint = func(ctx context.Context, ns string, log logr.Logger) (string, error) {
+		lookupNamespace = ns
+		return "https://mlflow.opendatahub.svc.cluster.local/mlflow", nil
+	}
+
+	dspa := testutil.CreateEmptyDSPA()
+	dspa.Namespace = "test-dspa-mlflow"
+	dspa.Spec.APIServer = &dspav1.APIServer{Deploy: true}
+	dspa.Spec.PodToPodTLS = testutil.BoolPtr(false)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-pipeline-testdspa", Namespace: "test-dspa-mlflow"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-pipeline-testdspa", Namespace: "test-dspa-mlflow"},
+		Spec:       routev1.RouteSpec{Host: "dsp-api.example.com"},
+	}
+	require.NoError(t, reconciler.Client.Create(ctx, deploy))
+	require.NoError(t, reconciler.Client.Create(ctx, route))
+
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	require.NoError(t, err)
+	require.Equal(t, "opendatahub", lookupNamespace)
+	require.NotEmpty(t, params.APIServerPluginsJson)
+	require.True(t, params.GrantMlflowWorkloadRBAC)
+}
+
+func TestExtractParams_MLflowPluginConfigUsesServiceWhenRouteUnavailable(t *testing.T) {
+	t.Setenv("DSPO_NAMESPACE", "opendatahub")
+
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	params.ResolveMLflowEndpoint = func(ctx context.Context, ns string, log logr.Logger) (string, error) {
+		return "https://mlflow.opendatahub.svc.cluster.local/mlflow", nil
+	}
+
+	dspa := testutil.CreateEmptyDSPA()
+	dspa.Namespace = "test-dspa-mlflow"
+	dspa.Spec.APIServer = &dspav1.APIServer{Deploy: true}
+	dspa.Spec.PodToPodTLS = testutil.BoolPtr(false)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-pipeline-testdspa", Namespace: "test-dspa-mlflow"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-pipeline-testdspa", Namespace: "test-dspa-mlflow"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8888}},
+		},
+	}
+	require.NoError(t, reconciler.Client.Create(ctx, deploy))
+	require.NoError(t, reconciler.Client.Create(ctx, svc))
+
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	require.NoError(t, err)
+	require.NotEmpty(t, params.APIServerPluginsJson)
+
+	var pluginCfg map[string]any
+	require.NoError(t, json.Unmarshal([]byte(params.APIServerPluginsJson), &pluginCfg))
+	settings, ok := pluginCfg["settings"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "http://ds-pipeline-testdspa.test-dspa-mlflow.svc.cluster.local:8888", settings["kfpBaseURL"])
+}
+
+func TestExtractParams_MLflowEndpointLookupSkippedWhenDSPONamespaceUnset(t *testing.T) {
+	t.Setenv("DSPO_NAMESPACE", "")
+
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	lookupCalled := false
+	params.ResolveMLflowEndpoint = func(ctx context.Context, ns string, log logr.Logger) (string, error) {
+		lookupCalled = true
+		return "https://mlflow.example/mlflow", nil
+	}
+
+	dspa := testutil.CreateEmptyDSPA()
+	dspa.Namespace = "test-dspa-mlflow"
+	dspa.Spec.APIServer = &dspav1.APIServer{Deploy: true}
+	dspa.Spec.PodToPodTLS = testutil.BoolPtr(false)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-pipeline-testdspa", Namespace: "test-dspa-mlflow"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	require.NoError(t, reconciler.Client.Create(ctx, deploy))
+
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	require.NoError(t, err)
+	require.False(t, lookupCalled)
+	require.Empty(t, params.APIServerPluginsJson)
+	require.False(t, params.GrantMlflowWorkloadRBAC)
 }
 
 func testSchemeWithMlflowApps(t *testing.T) *runtime.Scheme {

--- a/tests/resources/dspa-mlflow-lite.yaml
+++ b/tests/resources/dspa-mlflow-lite.yaml
@@ -1,0 +1,97 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: test-dspa-mlflow
+spec:
+  dspVersion: v2
+  podToPodTLS: false
+  mlflow:
+    integrationMode: AUTODETECT
+    injectUserEnvVars: true
+  apiServer:
+    deploy: true
+    enableOauth: false
+    enableSamplePipeline: true
+    caBundleFileMountPath: /kfp/certs
+    caBundleFileName: ca.crt
+    cABundle:
+      configMapName: mlflow-ca-bundle
+      configMapKey: ca-bundle.crt
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100m
+  scheduledWorkflow:
+    deploy: true
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100m
+  persistenceAgent:
+    deploy: true
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100Mi
+  mlmd:
+    deploy: true
+    envoy:
+      image: quay.io/maistra/proxyv2-ubi8:2.5.0
+      deployRoute: false
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100Mi
+    grpc:
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100Mi
+  database:
+    mariaDB:
+      deploy: true
+      image: quay.io/sclorg/mariadb-105-c9s:latest
+      pvcSize: 500Mi
+      resources:
+        limits:
+          cpu: 60m
+          memory: 500Mi
+        requests:
+          cpu: 60m
+          memory: 500Mi
+  workflowController:
+    deploy: true
+    resources:
+      limits:
+        cpu: 20m
+        memory: 500Mi
+      requests:
+        cpu: 20m
+        memory: 100m
+  objectStorage:
+    minio:
+      deploy: true
+      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
+      pvcSize: 500Mi
+      resources:
+        limits:
+          cpu: 20m
+          memory: 500Mi
+        requests:
+          cpu: 20m
+          memory: 100m


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves  [RHOAIENG-63144](https://redhat.atlassian.net/browse/RHOAIENG-63144)

- Adds MLflow integration tests to KinD CI by deploying an MLflow-enabled DSPA and running the MLflow ginkgo specs from the DSP repo (ds-pipelines-tests).
- Reuses the existing MLflow test suite from the DSP repo instead of duplicating pipeline definitions in DSPO.
- When Route lookup fails (e.g., on KinD), the plugin config generator now falls back to the Service hostname instead of deferring


## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLflow end-to-end integration testing infrastructure.

* **Tests**
  * Added dedicated MLflow test scripts and resources for validation.
  * Extended test runner with MLflow-specific test execution paths.
  * Added unit tests for MLflow parameter extraction.

* **Chores**
  * Updated CI workflow to validate MLflow deployments.
  * Enhanced controller parameter handling for MLflow endpoint resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-63144]: https://redhat.atlassian.net/browse/RHOAIENG-63144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ