### PR TITLE
Add versionName field to PipelineVersion CRD

### DIFF
--- a/config/crd/bases/pipelines.kubeflow.org_pipelineversions.yaml
+++ b/config/crd/bases/pipelines.kubeflow.org_pipelineversions.yaml
@@ -57,6 +57,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              versionName:
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
             required:
             - pipelineSpec
             type: object


### PR DESCRIPTION
## Summary

- Adds the `versionName` field to the PipelineVersion CRD schema (`spec.properties`), matching the upstream KFP definition (optional string, maxLength 253, DNS-label pattern).
- Prepares for the upstream cherry-pick of [kubeflow/pipelines#13552](https://github.com/kubeflow/pipelines/pull/13552), which introduces composite `metadata.name` for PipelineVersion CRs and stores the bare version name in `spec.versionName`.
- Without this field in the CRD, Kubernetes silently prunes `versionName` from stored objects, breaking name-based filtering in K8s Native API tests.
- This change is a no-op for the current DSP code, which does not reference the field.

## Test plan

- [ ] Verify the CRD applies cleanly on a cluster
- [ ] Confirm no existing tests are affected (field is optional and unused by current code)
- [ ] After merging, cherry-pick upstream PR #13552 into DSP and verify K8s Native API tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `versionName` field to pipeline version settings, allowing names to be set directly.
  * Validation now enforces a consistent naming format and length limit for pipeline version names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->