### PR TITLE
Update managed pipeline `versionName` logic to use platform version

### DIFF
--- a/controllers/apiserver.go
+++ b/controllers/apiserver.go
@@ -81,6 +81,7 @@ func (r *DSPAReconciler) GenerateSamplePipelineMetadataBlock(pipeline string, pl
 func (r *DSPAReconciler) managedPipelineSampleEntry(pipelineName string, platformVersion string) map[string]string {
 	item, err := r.GenerateSamplePipelineMetadataBlock(pipelineName, platformVersion)
 	if err == nil {
+		item["versionName"] = platformVersion
 		return item
 	}
 	r.Log.Info("Managed pipeline metadata not found in operator config; using minimal sample_config entry",
@@ -90,7 +91,7 @@ func (r *DSPAReconciler) managedPipelineSampleEntry(pipelineName string, platfor
 		"name":               pipelineName,
 		"file":               fmt.Sprintf("/config/managed-pipelines/%s.yaml", pipelineName),
 		"description":        "",
-		"versionName":        fmt.Sprintf("%s - %s", pipelineName, platformVersion),
+		"versionName":        platformVersion,
 		"versionDescription": "",
 	}
 }

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -1233,3 +1233,101 @@ func TestReconcileAPIServer_ConfigHashIdempotent(t *testing.T) {
 	assert.Equal(t, params1.APIServerConfigHash, params2.APIServerConfigHash,
 		"hash should be identical across reconciles with the same input")
 }
+
+func TestManagedPipelineSampleEntry_VersionNameIsPlatformVersionOnly(t *testing.T) {
+	const platformVersion = "rhoai-3.5-ea.2"
+
+	t.Run("minimal_entry", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("DSPO.PlatformVersion", platformVersion)
+		t.Cleanup(func() { viper.Reset() })
+
+		_, _, reconciler := CreateNewTestObjects()
+		dspa := testutil.CreateDSPAWithManagedPipelines("img", []dspav1.ManagedPipeline{{Name: "trainer-ostf"}}, nil)
+		dspa.Spec.APIServer.EnableSamplePipeline = false
+
+		jsonStr, err := reconciler.generateSampleConfigJSON(dspa, config.ResolvedPlatformVersion())
+		require.NoError(t, err)
+
+		var out struct {
+			Pipelines []map[string]string `json:"pipelines"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(jsonStr), &out))
+		require.Len(t, out.Pipelines, 1)
+		assert.Equal(t, platformVersion, out.Pipelines[0]["versionName"],
+			"managed pipeline versionName should be the platform version only")
+	})
+
+	t.Run("config_entry", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("ManagedPipelinesMetadata.foo.Name", "Display Foo")
+		viper.Set("ManagedPipelinesMetadata.foo.Filepath", "/custom/foo.yaml")
+		viper.Set("ManagedPipelinesMetadata.foo.Description", "From config")
+		viper.Set("DSPO.PlatformVersion", platformVersion)
+		t.Cleanup(func() { viper.Reset() })
+
+		_, _, reconciler := CreateNewTestObjects()
+		dspa := testutil.CreateDSPAWithManagedPipelines("img", []dspav1.ManagedPipeline{{Name: "foo"}}, nil)
+		dspa.Spec.APIServer.EnableSamplePipeline = false
+
+		jsonStr, err := reconciler.generateSampleConfigJSON(dspa, config.ResolvedPlatformVersion())
+		require.NoError(t, err)
+
+		var out struct {
+			Pipelines []map[string]string `json:"pipelines"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(jsonStr), &out))
+		require.Len(t, out.Pipelines, 1)
+		assert.Equal(t, platformVersion, out.Pipelines[0]["versionName"],
+			"managed pipeline versionName should be the platform version only, even when config metadata exists")
+	})
+
+	t.Run("iris_sample_unchanged", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("ManagedPipelinesMetadata.iris.Name", "[Demo] iris")
+		viper.Set("ManagedPipelinesMetadata.iris.Filepath", "/samples/iris.yaml")
+		viper.Set("DSPO.PlatformVersion", platformVersion)
+		t.Cleanup(func() { viper.Reset() })
+
+		_, _, reconciler := CreateNewTestObjects()
+		dspa := testutil.CreateEmptyDSPA()
+		dspa.Spec.APIServer = &dspav1.APIServer{Deploy: true, EnableSamplePipeline: true}
+		dspa.Spec.APIServer.ManagedPipelines = nil
+
+		jsonStr, err := reconciler.generateSampleConfigJSON(dspa, config.ResolvedPlatformVersion())
+		require.NoError(t, err)
+
+		var out struct {
+			Pipelines []map[string]string `json:"pipelines"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(jsonStr), &out))
+		require.Len(t, out.Pipelines, 1)
+		assert.Equal(t, "[Demo] iris - "+platformVersion, out.Pipelines[0]["versionName"],
+			"iris sample pipeline versionName should keep the original format")
+	})
+
+	t.Run("mixed_iris_and_managed", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("ManagedPipelinesMetadata.iris.Name", "[Demo] iris")
+		viper.Set("ManagedPipelinesMetadata.iris.Filepath", "/samples/iris.yaml")
+		viper.Set("DSPO.PlatformVersion", platformVersion)
+		t.Cleanup(func() { viper.Reset() })
+
+		_, _, reconciler := CreateNewTestObjects()
+		dspa := testutil.CreateDSPAWithManagedPipelines("img", []dspav1.ManagedPipeline{{Name: "trainer-ostf"}}, nil)
+		dspa.Spec.APIServer.EnableSamplePipeline = true
+
+		jsonStr, err := reconciler.generateSampleConfigJSON(dspa, config.ResolvedPlatformVersion())
+		require.NoError(t, err)
+
+		var out struct {
+			Pipelines []map[string]string `json:"pipelines"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(jsonStr), &out))
+		require.Len(t, out.Pipelines, 2)
+		assert.Equal(t, "[Demo] iris - "+platformVersion, out.Pipelines[0]["versionName"],
+			"iris sample pipeline versionName should keep the original format")
+		assert.Equal(t, platformVersion, out.Pipelines[1]["versionName"],
+			"managed pipeline versionName should be the platform version only")
+	})
+}

--- a/controllers/apiserver_test.go
+++ b/controllers/apiserver_test.go
@@ -1263,6 +1263,7 @@ func TestManagedPipelineSampleEntry_VersionNameIsPlatformVersionOnly(t *testing.
 		viper.Set("ManagedPipelinesMetadata.foo.Name", "Display Foo")
 		viper.Set("ManagedPipelinesMetadata.foo.Filepath", "/custom/foo.yaml")
 		viper.Set("ManagedPipelinesMetadata.foo.Description", "From config")
+		viper.Set("ManagedPipelinesMetadata.foo.VersionName", "Custom Version Label")
 		viper.Set("DSPO.PlatformVersion", platformVersion)
 		t.Cleanup(func() { viper.Reset() })
 


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves https://redhat.atlassian.net/browse/RHOAIENG-70075

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Update managed pipeline versionName logic to use platform version.

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated managed pipeline sample metadata so `versionName` displays only the platform version.
  * Preserved the existing Iris `versionName` format, including when Iris and managed entries appear together.

* **Tests**
  * Added unit coverage to verify the `versionName` formatting across minimal, metadata-driven, Iris, and mixed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->