### PR TITLE
fix: TLS profile resilience (transient errors, adherence policy, watcher self-healing)

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -236,6 +238,29 @@ func main() {
 	profile := tlsResult.ProfileSpec
 	hasOpenShiftConfigAPI := tlsResult.HasOpenShiftConfig
 
+	// Fetch the TLS adherence policy (only meaningful on OpenShift clusters with the config API)
+	tlsAdherenceFetched := false
+	var tlsAdherence configv1.TLSAdherencePolicy
+	if hasOpenShiftConfigAPI {
+		var adherenceErr error
+		tlsAdherence, adherenceErr = tlspkg.FetchAPIServerTLSAdherencePolicy(bootstrapCtx, bootstrapClient)
+		if adherenceErr != nil {
+			switch {
+			case apierrors.IsNotFound(adherenceErr), apimeta.IsNoMatchError(adherenceErr):
+				setupLog.Info("APIServer TLS adherence policy unavailable")
+			case apierrors.IsServiceUnavailable(adherenceErr),
+				apierrors.IsTimeout(adherenceErr),
+				apierrors.IsTooManyRequests(adherenceErr):
+				setupLog.Info("Transient error reading TLS adherence policy", "error", adherenceErr)
+			default:
+				setupLog.Error(adherenceErr, "failed to fetch TLS adherence policy")
+				os.Exit(1)
+			}
+		} else {
+			tlsAdherenceFetched = true
+		}
+	}
+
 	mgrOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -367,6 +392,13 @@ func main() {
 				setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
 				cancel()
 			},
+		}
+		if tlsAdherenceFetched {
+			watcher.InitialTLSAdherencePolicy = tlsAdherence
+			watcher.OnAdherencePolicyChange = func(_ context.Context, _, _ configv1.TLSAdherencePolicy) {
+				setupLog.Info("TLS adherence policy changed, initiating graceful shutdown to reload")
+				cancel()
+			}
 		}
 		if err := watcher.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to register TLS security profile watcher")

--- a/main.go
+++ b/main.go
@@ -225,7 +225,9 @@ func main() {
 		setupLog.Error(err, "unable to create bootstrap client for TLS profile")
 		os.Exit(1)
 	}
-	tlsResult, err := fetchTLSProfile(context.Background(), bootstrapClient)
+	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootstrapCancel()
+	tlsResult, err := fetchTLSProfile(bootstrapCtx, bootstrapClient)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS profile, failing startup")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -252,6 +252,7 @@ func main() {
 				apierrors.IsTimeout(adherenceErr),
 				apierrors.IsTooManyRequests(adherenceErr):
 				setupLog.Info("Transient error reading TLS adherence policy", "error", adherenceErr)
+				tlsAdherenceFetched = true // watcher self-heals when the API recovers
 			default:
 				setupLog.Error(adherenceErr, "failed to fetch TLS adherence policy")
 				os.Exit(1)

--- a/tls_profile.go
+++ b/tls_profile.go
@@ -34,6 +34,9 @@ func fetchTLSProfile(ctx context.Context, cli client.Client) (*tlsResult, error)
 			apierrors.IsTimeout(err),
 			apierrors.IsTooManyRequests(err):
 			l.Info("Transient API error reading TLS profile, using Intermediate TLS profile as fallback", "error", err)
+			// Mark OpenShift config as present so SecurityProfileWatcher still registers.
+			// When the API recovers, the watcher will detect the real profile and trigger a restart.
+			result.HasOpenShiftConfig = true
 		default:
 			return nil, fmt.Errorf("failed to fetch TLS profile: %w", err)
 		}

--- a/tls_profile.go
+++ b/tls_profile.go
@@ -30,6 +30,10 @@ func fetchTLSProfile(ctx context.Context, cli client.Client) (*tlsResult, error)
 			l.Info("config.openshift.io API not available (non-OpenShift cluster), using Intermediate TLS profile as fallback")
 		case apierrors.IsNotFound(err):
 			l.Info("APIServer resource not found, using Intermediate TLS profile as fallback")
+		case apierrors.IsServiceUnavailable(err),
+			apierrors.IsTimeout(err),
+			apierrors.IsTooManyRequests(err):
+			l.Info("Transient API error reading TLS profile, using Intermediate TLS profile as fallback", "error", err)
 		default:
 			return nil, fmt.Errorf("failed to fetch TLS profile: %w", err)
 		}


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-49909](https://redhat.atlassian.net/browse/RHOAIENG-49909)

## Description of your changes:
Follow-up to #1063 (TLS profile integration). Three improvements to TLS profile resolution at operator startup:

1. **Transient error handling**: `IsServiceUnavailable`, `IsTimeout`, and `IsTooManyRequests` errors fall back to the Intermediate TLS profile instead of crashing the operator. Prevents startup failures during temporary API server unavailability (e.g., cluster upgrades).

2. **TLSAdherencePolicy support**: Fetches the OCP 5.0 TLS adherence policy from the APIServer CR and wires it into the `SecurityProfileWatcher`. When the adherence policy changes, the operator restarts gracefully to pick up the new configuration.

3. **Watcher self-healing**: On transient errors, the `SecurityProfileWatcher` still registers (both for profile and adherence changes). When the API recovers, the watcher detects the real profile differs from the Intermediate fallback and triggers a graceful restart. No admin intervention needed.

Supersedes #1072 and #1073 (closed due to branch history issues).

## Testing instructions
- Deploy the operator on an OpenShift cluster with TLS profiles configured
- Verify the operator starts successfully under normal conditions
- Verify the operator starts with Intermediate profile fallback when the API server is temporarily unavailable
- Verify the operator self-heals (restarts) when the API server becomes available again

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-49909]: https://redhat.atlassian.net/browse/RHOAIENG-49909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ