### PR TITLE
fix: gracefully handle forbidden error in TLS profile fetch

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func main() {
 		tlsAdherence, adherenceErr = tlspkg.FetchAPIServerTLSAdherencePolicy(bootstrapCtx, bootstrapClient)
 		if adherenceErr != nil {
 			switch {
-			case apierrors.IsNotFound(adherenceErr), apimeta.IsNoMatchError(adherenceErr):
+			case apierrors.IsNotFound(adherenceErr), apimeta.IsNoMatchError(adherenceErr), apierrors.IsForbidden(adherenceErr):
 				setupLog.Info("APIServer TLS adherence policy unavailable")
 			case apierrors.IsServiceUnavailable(adherenceErr),
 				apierrors.IsTimeout(adherenceErr),

--- a/tls_profile.go
+++ b/tls_profile.go
@@ -30,6 +30,8 @@ func fetchTLSProfile(ctx context.Context, cli client.Client) (*tlsResult, error)
 			l.Info("config.openshift.io API not available (non-OpenShift cluster), using Intermediate TLS profile as fallback")
 		case apierrors.IsNotFound(err):
 			l.Info("APIServer resource not found, using Intermediate TLS profile as fallback")
+		case apierrors.IsForbidden(err):
+			l.Info("Insufficient RBAC to read APIServer TLS profile, using Intermediate TLS profile as fallback")
 		case apierrors.IsServiceUnavailable(err),
 			apierrors.IsTimeout(err),
 			apierrors.IsTooManyRequests(err):

--- a/tls_profile_test.go
+++ b/tls_profile_test.go
@@ -5,14 +5,19 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestFetchTLSProfile_IntermediateProfile(t *testing.T) {
@@ -116,6 +121,33 @@ func TestFetchTLSProfile_NextProtosAlwaysSet(t *testing.T) {
 	for _, fn := range result.TLSOpts {
 		fn(cfg)
 	}
+	assert.Equal(t, []string{"h2", "http/1.1"}, cfg.NextProtos)
+}
+
+func TestFetchTLSProfile_Forbidden(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, configv1.Install(scheme))
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			return apierrors.NewForbidden(
+				schema.GroupResource{Group: "config.openshift.io", Resource: "apiservers"},
+				"cluster",
+				fmt.Errorf("User \"system:serviceaccount:opendatahub:dspo\" cannot get resource \"apiservers\" in API group \"config.openshift.io\" at the cluster scope"),
+			)
+		},
+	}).Build()
+
+	result, err := fetchTLSProfile(context.Background(), cli)
+	require.NoError(t, err)
+	assert.False(t, result.HasOpenShiftConfig)
+
+	cfg := &tls.Config{}
+	for _, fn := range result.TLSOpts {
+		fn(cfg)
+	}
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	assert.NotEmpty(t, cfg.CipherSuites)
 	assert.Equal(t, []string{"h2", "http/1.1"}, cfg.NextProtos)
 }
 


### PR DESCRIPTION
## Summary

- Handle `IsForbidden` errors gracefully in `fetchTLSProfile` by falling back to the Intermediate TLS profile instead of crashing the operator on startup
- Add the same defense-in-depth handling for the TLS adherence policy fetch in `main.go`
- Add unit test covering the forbidden error scenario using `WithInterceptorFuncs`

## Context

After PR #1063 introduced TLS profile fetching from the OpenShift APIServer resource, the operator crashes on startup when the service account lacks RBAC to read `apiservers` in `config.openshift.io`:

```
failed to fetch TLS profile: failed to get APIServer "/cluster": apiservers.config.openshift.io "cluster" is forbidden
```

PR #1074 added the missing ClusterRole entry, but the code itself had no graceful fallback for "forbidden" errors — it fell to the `default` branch which returned a hard error, causing `os.Exit(1)`. This fix makes the operator resilient regardless of RBAC state.

## Test plan

- [x] New `TestFetchTLSProfile_Forbidden` test passes
- [x] All existing TLS profile tests pass (no regressions)
- [x] Full `make unittest` passes
- [x] `golangci-lint run` clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior when TLS policy information can’t be retrieved, including access-denied and unavailable-resource cases.
  * The app now safely continues with the default Intermediate TLS profile when OpenShift policy data is not accessible.
  * Error handling for policy lookup is more consistent, reducing the chance of unexpected failures while loading TLS settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->