### PR TITLE
fix: simplify TLS adherence policy error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,8 +40,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -245,21 +243,9 @@ func main() {
 		var adherenceErr error
 		tlsAdherence, adherenceErr = tlspkg.FetchAPIServerTLSAdherencePolicy(bootstrapCtx, bootstrapClient)
 		if adherenceErr != nil {
-			switch {
-			case apierrors.IsNotFound(adherenceErr), apimeta.IsNoMatchError(adherenceErr):
-				setupLog.Info("APIServer TLS adherence policy unavailable")
-			case apierrors.IsServiceUnavailable(adherenceErr),
-				apierrors.IsTimeout(adherenceErr),
-				apierrors.IsTooManyRequests(adherenceErr):
-				setupLog.Info("Transient error reading TLS adherence policy", "error", adherenceErr)
-				tlsAdherenceFetched = true // watcher self-heals when the API recovers
-			default:
-				setupLog.Error(adherenceErr, "failed to fetch TLS adherence policy")
-				os.Exit(1)
-			}
-		} else {
-			tlsAdherenceFetched = true
+			setupLog.Info("unable to fetch TLS adherence policy, watcher will retry", "error", adherenceErr)
 		}
+		tlsAdherenceFetched = true
 	}
 
 	mgrOpts := ctrl.Options{


### PR DESCRIPTION
## The issue resolved by this Pull Request:
Resolves [RHOAIENG-61066](https://redhat.atlassian.net/browse/RHOAIENG-61066)

## Description of your changes:
Simplify the TLS adherence policy error handling to match the OCP reference pattern from [cluster-machine-approver](https://github.com/openshift/cluster-machine-approver/blob/main/pkg/tls/tls.go#L104-L110):

- Replace switch/os.Exit with simple log+continue
- Log at Info level (not Error) since adherence is expected to be unavailable on pre-5.0 clusters
- Always register the watcher so it self-heals when the API recovers

## Testing instructions
- Deploy on OpenShift with TLS profiles configured
- Verify operator starts normally

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-61066]: https://redhat.atlassian.net/browse/RHOAIENG-61066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ