### PR TITLE
fix: handle IsServerTimeout in TLS profile resolution

### DIFF
--- a/tls_profile.go
+++ b/tls_profile.go
@@ -32,6 +32,7 @@ func fetchTLSProfile(ctx context.Context, cli client.Client) (*tlsResult, error)
 			l.Info("APIServer resource not found, using Intermediate TLS profile as fallback")
 		case apierrors.IsServiceUnavailable(err),
 			apierrors.IsTimeout(err),
+			apierrors.IsServerTimeout(err),
 			apierrors.IsTooManyRequests(err):
 			l.Info("Transient API error reading TLS profile, using Intermediate TLS profile as fallback", "error", err)
 			// Mark OpenShift config as present so SecurityProfileWatcher still registers.


### PR DESCRIPTION
## Description

`apierrors.IsServerTimeout` (StatusReasonServerTimeout) is a distinct Kubernetes error from `apierrors.IsTimeout` (StatusReasonTimeout). The former fires when the API server itself couldn't complete the request in time, the latter when a gateway/proxy times out.

Without handling `IsServerTimeout`, a server-side API timeout during TLS profile fetch falls to the default error case and prevents startup instead of gracefully falling back to Intermediate defaults.

One-line fix, no behavior change for the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when fetching TLS profiles during server timeouts.
  * Requests now use an intermediate TLS profile fallback instead of failing in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->