### PR TITLE
Fix MLflow AUTODETECT not detecting stale/unavailable MLflow when mlflow-operator is down

### DIFF
--- a/controllers/dspipeline_controller.go
+++ b/controllers/dspipeline_controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/dspastatus"
 	mlflowv1 "github.com/opendatahub-io/mlflow-operator/api/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -95,6 +96,8 @@ func (r *DSPAReconciler) removeExpiredMLflowCacheLocked(now time.Time) {
 	}
 }
 
+const mlflowAvailableConditionType = "Available"
+
 func lookupMLflowEndpoint(ctx context.Context, reader client.Reader, namespace string, log logr.Logger) (string, error) {
 	if namespace == "" {
 		return "", fmt.Errorf("namespace must be set for MLflow endpoint lookup")
@@ -112,7 +115,38 @@ func lookupMLflowEndpoint(ctx context.Context, reader client.Reader, namespace s
 	if err := validateMLflowEndpointURL(endpoint); err != nil {
 		return "", fmt.Errorf("MLflow resource has invalid Status.Address.URL: %w", err)
 	}
+
+	// Fast-path: mlflow-operator, if running, already reflects deployment
+	// readiness here.
+	if !meta.IsStatusConditionTrue(mlflowObj.Status.Conditions, mlflowAvailableConditionType) {
+		return "", fmt.Errorf("MLflow resource is not %s", mlflowAvailableConditionType)
+	}
+
+	// Available can be stale if mlflow-operator itself is down, so
+	// cross-check the live Deployment directly.
+	if err := verifyMLflowDeploymentReady(ctx, reader, namespace); err != nil {
+		return "", fmt.Errorf("MLflow endpoint resolved but underlying deployment is not ready: %w", err)
+	}
+
 	return endpoint, nil
+}
+
+// verifyMLflowDeploymentReady checks the MLflow deployment in the namespace.
+func verifyMLflowDeploymentReady(ctx context.Context, reader client.Reader, namespace string) error {
+	deployment := &appsv1.Deployment{}
+	if err := reader.Get(ctx, types.NamespacedName{Name: mlflowCRName, Namespace: namespace}, deployment); err != nil {
+		return fmt.Errorf("failed to get MLflow deployment %s/%s: %w", namespace, mlflowCRName, err)
+	}
+
+	desiredReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+	if desiredReplicas == 0 || deployment.Status.ReadyReplicas < desiredReplicas {
+		return fmt.Errorf("MLflow deployment %s/%s not ready: %d/%d replicas ready",
+			namespace, mlflowCRName, deployment.Status.ReadyReplicas, desiredReplicas)
+	}
+	return nil
 }
 
 func (r *DSPAReconciler) retrieveMLflowEndpointCached(ctx context.Context, namespace string, log logr.Logger) (string, error) {

--- a/controllers/dspipeline_params_test.go
+++ b/controllers/dspipeline_params_test.go
@@ -701,18 +701,43 @@ func TestLookupMLflowEndpoint_MissingURL(t *testing.T) {
 	require.Contains(t, err.Error(), "MLflow resource missing Status.Address.URL")
 }
 
+// mlflowAvailableCondition builds an "Available" condition as mlflow-operator
+// sets it on the MLflow CR.
+func mlflowAvailableCondition(status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:               mlflowAvailableConditionType,
+		Status:             status,
+		Reason:             "Test",
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// readyMlflowDeployment builds a fully-ready Deployment for the MLflow
+// backing workload.
+func readyMlflowDeployment(name, namespace string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: replicas},
+	}
+}
+
 func TestLookupMLflowEndpoint_Success(t *testing.T) {
 	t.Parallel()
 
-	const wantURL = "https://internal-mlflow:5000/mlflow"
+	const wantURL = "https://mlflow.dsp-ns.svc:8443/mlflow"
 	ml := &mlflowv1.MLflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
 		Status: mlflowv1.MLflowStatus{
-			Address: &mlflowv1.MLflowAddressStatus{URL: wantURL},
+			Address:    &mlflowv1.MLflowAddressStatus{URL: wantURL},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionTrue)},
 		},
 	}
 	scheme := testSchemeWithMlflowApps(t)
-	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml).Build()
+	kc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ml, readyMlflowDeployment("mlflow", "dsp-ns", 1)).
+		Build()
 
 	got, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
 	require.NoError(t, err)
@@ -735,6 +760,132 @@ func TestLookupMLflowEndpoint_InvalidURL(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid Status.Address.URL")
 	require.Contains(t, err.Error(), "must be http/https with non-empty host")
+}
+
+func TestLookupMLflowEndpoint_NotAvailable(t *testing.T) {
+	t.Parallel()
+
+	ml := &mlflowv1.MLflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
+		Status: mlflowv1.MLflowStatus{
+			Address:    &mlflowv1.MLflowAddressStatus{URL: "https://mlflow.dsp-ns.svc:8443/mlflow"},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionFalse)},
+		},
+	}
+	scheme := testSchemeWithMlflowApps(t)
+	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml).Build()
+
+	_, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not Available")
+}
+
+func TestLookupMLflowEndpoint_NoConditions(t *testing.T) {
+	t.Parallel()
+
+	// No Conditions at all (never reconciled) must not be treated as Available.
+	ml := &mlflowv1.MLflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
+		Status: mlflowv1.MLflowStatus{
+			Address: &mlflowv1.MLflowAddressStatus{URL: "https://mlflow.dsp-ns.svc:8443/mlflow"},
+		},
+	}
+	scheme := testSchemeWithMlflowApps(t)
+	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml).Build()
+
+	_, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not Available")
+}
+
+// Reproduces mlflow-operator being scaled down while its stale MLflow CR
+// still reports Available=True; the live Deployment check must catch it.
+func TestLookupMLflowEndpoint_StaleAvailableCondition_DeploymentScaledDown(t *testing.T) {
+	t.Parallel()
+
+	ml := &mlflowv1.MLflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
+		Status: mlflowv1.MLflowStatus{
+			Address:    &mlflowv1.MLflowAddressStatus{URL: "https://mlflow.dsp-ns.svc:8443/mlflow"},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionTrue)},
+		},
+	}
+	scheme := testSchemeWithMlflowApps(t)
+	kc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ml, readyMlflowDeployment("mlflow", "dsp-ns", 0)).
+		Build()
+
+	_, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "underlying deployment is not ready")
+}
+
+func TestLookupMLflowEndpoint_StaleAvailableCondition_DeploymentMissing(t *testing.T) {
+	t.Parallel()
+
+	ml := &mlflowv1.MLflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
+		Status: mlflowv1.MLflowStatus{
+			Address:    &mlflowv1.MLflowAddressStatus{URL: "https://mlflow.dsp-ns.svc:8443/mlflow"},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionTrue)},
+		},
+	}
+	scheme := testSchemeWithMlflowApps(t)
+	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml).Build()
+
+	_, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "underlying deployment is not ready")
+}
+
+func TestLookupMLflowEndpoint_DeploymentNotFullyReady(t *testing.T) {
+	t.Parallel()
+
+	ml := &mlflowv1.MLflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlflow", Namespace: "dsp-ns"},
+		Status: mlflowv1.MLflowStatus{
+			Address:    &mlflowv1.MLflowAddressStatus{URL: "https://mlflow.dsp-ns.svc:8443/mlflow"},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionTrue)},
+		},
+	}
+	deploy := readyMlflowDeployment("mlflow", "dsp-ns", 2)
+	deploy.Status.ReadyReplicas = 1 // desired 2, only 1 ready
+	scheme := testSchemeWithMlflowApps(t)
+	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml, deploy).Build()
+
+	_, err := lookupMLflowEndpoint(context.Background(), kc, "dsp-ns", logr.Discard())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "underlying deployment is not ready")
+}
+
+func TestVerifyMLflowDeploymentReady(t *testing.T) {
+	t.Parallel()
+
+	scheme := testSchemeWithMlflowApps(t)
+
+	t.Run("ready", func(t *testing.T) {
+		t.Parallel()
+		kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyMlflowDeployment("mlflow", "dsp-ns", 1)).Build()
+		err := verifyMLflowDeploymentReady(context.Background(), kc, "dsp-ns")
+		require.NoError(t, err)
+	})
+
+	t.Run("deployment not found", func(t *testing.T) {
+		t.Parallel()
+		kc := fake.NewClientBuilder().WithScheme(scheme).Build()
+		err := verifyMLflowDeploymentReady(context.Background(), kc, "dsp-ns")
+		require.Error(t, err)
+		require.True(t, apierrs.IsNotFound(err))
+	})
+
+	t.Run("scaled to zero", func(t *testing.T) {
+		t.Parallel()
+		kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyMlflowDeployment("mlflow", "dsp-ns", 0)).Build()
+		err := verifyMLflowDeploymentReady(context.Background(), kc, "dsp-ns")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not ready")
+	})
 }
 
 func TestIsAPIServerDeploymentReady_NotFound(t *testing.T) {
@@ -818,9 +969,13 @@ func TestIsAPIServerDeploymentReady_WrongDeploymentName_ReturnsFalseNotFoundSema
 func TestLookupMLflowEndpoint_UsesMlflowNamedObject(t *testing.T) {
 	t.Parallel()
 
+	const wantURL = "https://mlflow.dsp-ns.svc:8443/mlflow"
 	wrong := &mlflowv1.MLflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "dsp-ns"},
-		Status:     mlflowv1.MLflowStatus{Address: &mlflowv1.MLflowAddressStatus{URL: "https://x"}},
+		Status: mlflowv1.MLflowStatus{
+			Address:    &mlflowv1.MLflowAddressStatus{URL: wantURL},
+			Conditions: []metav1.Condition{mlflowAvailableCondition(metav1.ConditionTrue)},
+		},
 	}
 	scheme := testSchemeWithMlflowApps(t)
 	kc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wrong).Build()
@@ -830,8 +985,11 @@ func TestLookupMLflowEndpoint_UsesMlflowNamedObject(t *testing.T) {
 
 	ml := wrong.DeepCopy()
 	ml.Name = "mlflow"
-	kcWith := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ml).Build()
+	kcWith := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ml, readyMlflowDeployment("mlflow", "dsp-ns", 1)).
+		Build()
 	got, err := lookupMLflowEndpoint(context.Background(), kcWith, "dsp-ns", logr.Discard())
 	require.NoError(t, err)
-	require.Equal(t, "https://x", got)
+	require.Equal(t, wantURL, got)
 }


### PR DESCRIPTION

## Description of your changes:

When MLflow was previously deployed and then scaled down (along with mlflow-operator itself), DSPO continued to treat MLflow as available and kept the MLflow plugin enabled in the API server config. This caused pipeline run creation to fail with connection errors to a dead MLflow endpoint.
Root cause: `lookupMLflowEndpoint` only checked that `MLflow.Status.Address.URL` was set and syntactically valid. It never checked the `Available` condition or whether the underlying Deployment was actually ready. If `mlflow-operator` itself is also down, its last-reported status (including `Available=True`) is frozen and can no longer be trusted.

## Fix
- Check the MLflow CR's `Available` condition before trusting its reported endpoint.
- Additionally cross-check the live backing `mlflow` Deployment's `ReadyReplicas` directly via the Kubernetes API, so we don't rely solely on `mlflow-operator`'s self-reported status (which goes stale if `mlflow-operator` itself is down).


## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MLflow endpoint validation to confirm the service is marked available and its deployment is fully ready before use.
  * Prevented pipelines from using stale, missing, or incomplete MLflow deployments.
  * Added safeguards for scaled-to-zero deployments and deployments with insufficient ready replicas.
  * Ensured endpoint lookup targets the configured MLflow instance rather than unrelated instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->