### PR TITLE
fix: exclude .tekton/ from yamllint pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
+        exclude: ^\.tekton/
         types: [file, yaml]
         entry: yamllint --strict -c .yamllint.yaml
 


### PR DESCRIPTION
## Summary

- Exclude `.tekton/` directory from yamllint pre-commit check — these files are managed externally and should not be modified directly

## Test plan

- `pre-commit run yamllint --all-files` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML validation to skip files in the `.tekton/` directory during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->