### PR TITLE
chore(ci): build DSP and Argo images from source during KinD integration tests

### DIFF
--- a/.github/resources/buildkitd.toml
+++ b/.github/resources/buildkitd.toml
@@ -1,0 +1,5 @@
+# BuildKit daemon config for CI - allows pushing to insecure HTTP registries.
+# REGISTRY_ADDRESS is substituted at runtime via envsubst.
+[registry."${REGISTRY_ADDRESS}"]
+  http = true
+  insecure = true

--- a/.github/resources/docker-bake.hcl
+++ b/.github/resources/docker-bake.hcl
@@ -1,0 +1,73 @@
+variable "TAG" {
+  default = "latest"
+}
+
+variable "REGISTRY" {
+  default = "localhost:5000"
+}
+
+variable "KFP_REPO" {
+  default = "."
+}
+
+variable "ARGO_REPO" {
+  default = ""
+}
+
+group "default" {
+  targets = ["api-server", "driver", "launcher", "persistence-agent", "scheduled-workflow", "tests"]
+}
+
+group "argo" {
+  targets = ["argo-workflowcontroller", "argo-argoexec"]
+}
+
+target "argo-workflowcontroller" {
+  context = "${ARGO_REPO}"
+  dockerfile = "Dockerfile"
+  target = "workflow-controller"
+  tags = ["${REGISTRY}/ds-pipelines-argo-workflowcontroller:${TAG}"]
+}
+
+target "argo-argoexec" {
+  context = "${ARGO_REPO}"
+  dockerfile = "Dockerfile"
+  target = "argoexec-nonroot"
+  tags = ["${REGISTRY}/ds-pipelines-argo-argoexec:${TAG}"]
+}
+
+target "api-server" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/Dockerfile"
+  tags = ["${REGISTRY}/ds-pipelines-apiserver:${TAG}"]
+}
+
+target "driver" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/Dockerfile.driver"
+  tags = ["${REGISTRY}/ds-pipelines-driver:${TAG}"]
+}
+
+target "launcher" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/Dockerfile.launcher"
+  tags = ["${REGISTRY}/ds-pipelines-launcher:${TAG}"]
+}
+
+target "persistence-agent" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/Dockerfile.persistenceagent"
+  tags = ["${REGISTRY}/ds-pipelines-persistenceagent:${TAG}"]
+}
+
+target "scheduled-workflow" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/Dockerfile.scheduledworkflow"
+  tags = ["${REGISTRY}/ds-pipelines-scheduledworkflow:${TAG}"]
+}
+
+target "tests" {
+  context = "${KFP_REPO}"
+  dockerfile = "backend/test/images/Dockerfile.test"
+  tags = ["${REGISTRY}/ds-pipelines-tests:${TAG}"]
+}

--- a/.github/scripts/build_dsp_images.sh
+++ b/.github/scripts/build_dsp_images.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build DSP images from source and push to the local registry.
+# Requires: GIT_WORKSPACE, REGISTRY_ADDRESS, GITHUB_REPOSITORY_OWNER,
+#           GITHUB_HEAD_REF or GITHUB_REF_NAME, GITHUB_SHA
+
+echo "---------------------------------"
+echo "Building DSP images from source"
+echo "---------------------------------"
+
+dsp_repo_owner="${GITHUB_REPOSITORY_OWNER:-opendatahub-io}"
+dsp_repo="${dsp_repo_owner}/data-science-pipelines"
+dsp_branch="${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-master}}"
+dsp_default_branch="master"
+if [ "$dsp_repo_owner" = "red-hat-data-services" ]; then
+  dsp_default_branch="main"
+fi
+
+tag="${GITHUB_SHA:0:7}"
+if [ -z "$tag" ]; then
+  tag="local"
+fi
+
+dsp_dir="${GIT_WORKSPACE}/_dsp_source"
+rm -rf "$dsp_dir"
+
+echo "Cloning ${dsp_repo} branch ${dsp_branch}..."
+if ! git clone --depth 1 --branch "$dsp_branch" "https://github.com/${dsp_repo}.git" "$dsp_dir" 2>/dev/null; then
+  echo "Branch ${dsp_branch} not found, falling back to ${dsp_default_branch}"
+  git clone --depth 1 --branch "$dsp_default_branch" "https://github.com/${dsp_repo}.git" "$dsp_dir"
+fi
+
+registry="${REGISTRY_ADDRESS}"
+bake_file="${GIT_WORKSPACE}/.github/resources/docker-bake.hcl"
+
+echo "Configuring buildx for insecure registry ${registry}..."
+buildx_config="/tmp/buildkitd-ci.toml"
+REGISTRY_ADDRESS="${registry}" envsubst < "${GIT_WORKSPACE}/.github/resources/buildkitd.toml" > "$buildx_config"
+docker buildx create --name dsp-builder --driver docker-container \
+  --driver-opt network=host --config "$buildx_config" --use 2>/dev/null || \
+  docker buildx use dsp-builder
+
+echo "Building all DSP images in parallel with docker bake..."
+BUILDX_BAKE_ENTITLEMENTS_FS=0 TAG="${tag}" REGISTRY="${registry}" KFP_REPO="${dsp_dir}" \
+  docker buildx bake -f "$bake_file" --push
+
+params_file="${GIT_WORKSPACE}/config/base/params.env"
+
+if grep -q "IMAGES_ARGO_WORKFLOWCONTROLLER" "$params_file"; then
+  argo_repo_owner="${GITHUB_REPOSITORY_OWNER:-opendatahub-io}"
+  argo_repo="${argo_repo_owner}/argo-workflows"
+  argo_branch="${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}"
+  argo_default_branch="main"
+
+  argo_dir="${GIT_WORKSPACE}/_argo_source"
+  rm -rf "$argo_dir"
+
+  echo "Cloning ${argo_repo} branch ${argo_branch}..."
+  if ! git clone --depth 1 --branch "$argo_branch" "https://github.com/${argo_repo}.git" "$argo_dir" 2>/dev/null; then
+    echo "Branch ${argo_branch} not found, falling back to ${argo_default_branch}"
+    git clone --depth 1 --branch "$argo_default_branch" "https://github.com/${argo_repo}.git" "$argo_dir"
+  fi
+
+  echo "Building Argo images in parallel with docker bake..."
+  BUILDX_BAKE_ENTITLEMENTS_FS=0 TAG="${tag}" REGISTRY="${registry}" ARGO_REPO="${argo_dir}" \
+    docker buildx bake -f "$bake_file" argo --push
+
+  sed -i "s|IMAGES_ARGO_WORKFLOWCONTROLLER=.*|IMAGES_ARGO_WORKFLOWCONTROLLER=${registry}/ds-pipelines-argo-workflowcontroller:${tag}|" "$params_file"
+  sed -i "s|IMAGES_ARGO_EXEC=.*|IMAGES_ARGO_EXEC=${registry}/ds-pipelines-argo-argoexec:${tag}|" "$params_file"
+
+  rm -rf "$argo_dir"
+fi
+
+echo "Updating params.env with locally built images..."
+sed -i "s|IMAGES_APISERVER=.*|IMAGES_APISERVER=${registry}/ds-pipelines-apiserver:${tag}|" "$params_file"
+sed -i "s|IMAGES_PERSISTENCEAGENT=.*|IMAGES_PERSISTENCEAGENT=${registry}/ds-pipelines-persistenceagent:${tag}|" "$params_file"
+sed -i "s|IMAGES_SCHEDULEDWORKFLOW=.*|IMAGES_SCHEDULEDWORKFLOW=${registry}/ds-pipelines-scheduledworkflow:${tag}|" "$params_file"
+sed -i "s|IMAGES_DRIVER=.*|IMAGES_DRIVER=${registry}/ds-pipelines-driver:${tag}|" "$params_file"
+sed -i "s|IMAGES_LAUNCHER=.*|IMAGES_LAUNCHER=${registry}/ds-pipelines-launcher:${tag}|" "$params_file"
+
+echo "Updated params.env:"
+grep "^IMAGES_" "$params_file"
+
+echo "DSP_TESTS_IMAGE=${registry}/ds-pipelines-tests:${tag}" >> "$GITHUB_ENV"
+
+rm -rf "$dsp_dir"
+echo "DSP images built and pushed successfully"

--- a/.github/workflows/kind-integration-byoargo.yml
+++ b/.github/workflows/kind-integration-byoargo.yml
@@ -18,7 +18,10 @@ on:
       - .github/resources/**
       - .github/actions/**
       - '.github/workflows/kind-integration-byoargo.yml'
+      - '.github/scripts/build_dsp_images.sh'
       - '.github/scripts/tests/tests.sh'
+      - '.github/scripts/tests/collect_logs.sh'
+      - '.github/scripts/tests/deploy_dspa.sh'
       - '.github/scripts/python_package_upload/**'
       - Makefile
     types:

--- a/.github/workflows/kind-integration-byoargo.yml
+++ b/.github/workflows/kind-integration-byoargo.yml
@@ -34,6 +34,9 @@ concurrency:
 env:
   GIT_WORKSPACE: ${{ github.workspace }}
 
+permissions:
+  contents: read
+
 jobs:
   dspo-byoargo-tests:
     runs-on: ubuntu-latest
@@ -50,6 +53,14 @@ jobs:
 
       - name: Setup and start KinD cluster
         uses: ./.github/actions/kind
+
+      - name: Build and push DSP images
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          .github/scripts/build_dsp_images.sh
+        env:
+          REGISTRY_ADDRESS: ${{ env.REGISTRY_ADDRESS }}
 
       - name: Free up disk space
         uses: kubeflow/pipelines/.github/actions/github-disk-cleanup@master

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -18,8 +18,11 @@ on:
       - .github/resources/**
       - .github/actions/**
       - '.github/workflows/kind-integration.yml'
+      - '.github/scripts/build_dsp_images.sh'
       - '.github/scripts/tests/tests.sh'
       - '.github/scripts/tests/run_dsp_mlflow_tests.sh'
+      - '.github/scripts/tests/collect_logs.sh'
+      - '.github/scripts/tests/deploy_dspa.sh'
       - '.github/scripts/python_package_upload/**'
       - Makefile
     types:

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -35,6 +35,9 @@ concurrency:
 env:
   GIT_WORKSPACE: ${{ github.workspace }}
 
+permissions:
+  contents: read
+
 jobs:
   dspo-tests:
     runs-on: ubuntu-latest
@@ -51,6 +54,14 @@ jobs:
 
       - name: Setup and start KinD cluster
         uses: ./.github/actions/kind
+
+      - name: Build and push DSP images
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          .github/scripts/build_dsp_images.sh
+        env:
+          REGISTRY_ADDRESS: ${{ env.REGISTRY_ADDRESS }}
 
       - name: Free up disk space
         uses: kubeflow/pipelines/.github/actions/github-disk-cleanup@master


### PR DESCRIPTION
## Summary

- Add CI infrastructure to build DSP and Argo container images from source during KinD integration tests
- Uses docker buildx bake for parallel image builds, pushing to the local KinD registry
- Avoids reliance on pre-built images from external registries that can expire or drift from the codebase

## Changes

- **New**: `.github/scripts/build_dsp_images.sh` — clones DSP and Argo repos, builds images via docker bake, updates `params.env`
- **New**: `.github/resources/docker-bake.hcl` — multi-target build config for all DSP and Argo components
- **New**: `.github/resources/buildkitd.toml` — BuildKit config for insecure local registry
- **Modified**: `.github/workflows/kind-integration.yml` — added "Build and push DSP images" step
- **Modified**: `.github/workflows/kind-integration-byoargo.yml` — same

## Test plan

- [ ] `dspo-tests` (KinD integration) pass with locally built images
- [ ] `dspo-byoargo-tests` (external Argo) pass with locally built images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated building and publishing of DSP container images for KinD integration environments.
  * Added configurable image tags, registries, and repository sources.
  * Added support for optionally building and publishing Argo component images.
  * Added unified builds for DSP services, Argo components, and test images.
  * Added local registry configuration for integration test deployments.
  * Integration workflows now build, configure, and use the appropriate images automatically.
  * Workflows now run when image-building or deployment support scripts change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->