### PR TITLE
fix: set SSL_CERT_DIR on workflow pods so the driver trusts the mounted CA

### DIFF
--- a/config/internal/workflow-controller/configmap.yaml.tmpl
+++ b/config/internal/workflow-controller/configmap.yaml.tmpl
@@ -36,3 +36,13 @@ data:
       secretKeySecret:
         name: "{{.ObjectStorageConnection.CredentialsSecret.SecretName}}"
         key: "{{.ObjectStorageConnection.CredentialsSecret.SecretKey}}"
+{{ if .WorkflowPodSSLCertDir }}
+  # SSL_CERT_DIR so workflow pods trust the CA mounted at /kfp/certs.
+  workflowDefaults: |
+    spec:
+      templateDefaults:
+        container:
+          env:
+            - name: SSL_CERT_DIR
+              value: "{{.WorkflowPodSSLCertDir}}"
+{{ end }}

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -42,6 +42,14 @@ const (
 
 	CustomCABundleRootMountPath = "/dsp-custom-certs"
 
+	// DSPDriverCABundleDir is where the KFP Argo compiler mounts CABUNDLE_CONFIGMAP
+	// onto driver/launcher pods.
+	DSPDriverCABundleDir = "/kfp/certs"
+	// WorkflowPodSSLCertDir is injected into Argo workflow pods via workflowDefaults
+	// so Go's system cert pool includes that compiler-mounted CA. SSL_CERT_DIR
+	// replaces the default directory list, so system CA dirs must be included.
+	WorkflowPodSSLCertDir = DSPDriverCABundleDir + ":/etc/ssl/certs:/etc/pki/tls/certs"
+
 	// GlobalODHCaBundleConfigMapName key and label values  are a contract with
 	// ODH Platform https://github.com/opendatahub-io/architecture-decision-records/pull/28
 	GlobalODHCaBundleConfigMapName = "odh-trusted-ca-bundle"

--- a/controllers/dspipeline_params.go
+++ b/controllers/dspipeline_params.go
@@ -92,6 +92,8 @@ type DSPAParams struct {
 	// for CustomCABundleRootMountPath when
 	// verifying certs
 	CustomSSLCertDir *string
+	// SSL_CERT_DIR for workflow pods when CustomCABundle is set (CA at /kfp/certs).
+	WorkflowPodSSLCertDir string
 	// The CA bundle path found in the pipeline pods
 	PiplinesCABundleMountPath string
 	// Collects all certs from user & global certs
@@ -1062,6 +1064,7 @@ func (p *DSPAParams) ExtractParams(ctx context.Context, dsp *dspa.DataSciencePip
 			// SSL_CERT_DIR accepts a colon separated list of directories
 			sslCertDir := strings.Join(certDirectories, ":")
 			p.CustomSSLCertDir = &sslCertDir
+			p.WorkflowPodSSLCertDir = config.WorkflowPodSSLCertDir
 		}
 
 		if p.APIServer.ArtifactSignedURLExpirySeconds == nil {

--- a/controllers/dspipeline_params_test.go
+++ b/controllers/dspipeline_params_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/testutil"
 	mlflowv1 "github.com/opendatahub-io/mlflow-operator/api/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -641,6 +642,30 @@ func TestBuildMLflowPluginConfigJson_InjectUserEnvVarsTrue(t *testing.T) {
 	var settings map[string]interface{}
 	require.NoError(t, json.Unmarshal(root["settings"], &settings))
 	require.Equal(t, true, settings["injectUserEnvVars"])
+}
+
+func TestExtractParams_WorkflowPodSSLCertDir(t *testing.T) {
+	t.Setenv("SSL_CERT_FILE", "testdata/tls/empty-ca-bundle.crt")
+
+	ctx, params, reconciler := CreateNewTestObjects()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcaname", Namespace: "testnamespace"},
+		Data:       map[string]string{"testcakey": "bundle-contents"},
+	}
+	require.NoError(t, reconciler.Client.Create(ctx, cm))
+
+	dspa := testutil.CreateDSPAWithAPIServerCABundle("testcakey", "testcaname")
+	err := params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log)
+	require.NoError(t, err)
+	require.NotNil(t, params.CustomCABundle)
+	require.Equal(t, config.WorkflowPodSSLCertDir, params.WorkflowPodSSLCertDir)
+	require.Contains(t, params.WorkflowPodSSLCertDir, "/kfp/certs")
+
+	empty := testutil.CreateEmptyDSPA()
+	_, emptyParams, emptyReconciler := CreateNewTestObjects()
+	require.NoError(t, emptyParams.ExtractParams(ctx, empty, emptyReconciler.Client, emptyReconciler.Log))
+	require.Empty(t, emptyParams.WorkflowPodSSLCertDir)
 }
 
 func TestValidateMLflowEndpointURL(t *testing.T) {

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -21,10 +21,15 @@ import (
 	"testing"
 
 	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
+	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/config"
 	"github.com/opendatahub-io/data-science-pipelines-operator/controllers/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestDeployWorkflowController(t *testing.T) {
@@ -83,6 +88,11 @@ func TestDeployWorkflowController(t *testing.T) {
 	assert.True(t, created)
 	assert.Nil(t, err)
 
+	cm := &corev1.ConfigMap{}
+	created, err = reconciler.IsResourceCreated(ctx, cm, expectedWorkflowControllerName, testNamespace)
+	assert.True(t, created)
+	assert.Nil(t, err)
+	assert.Empty(t, cm.Data["workflowDefaults"])
 }
 
 func TestDontDeployWorkflowController(t *testing.T) {
@@ -327,4 +337,64 @@ func TestManagementStateWorkflowControllerInvalidJSONRecovery(t *testing.T) {
 	created, err = reconciler.IsResourceCreated(ctx, deployment, expectedWorkflowControllerName, testNamespace)
 	assert.True(t, created)
 	assert.Nil(t, err)
+}
+
+func TestWorkflowControllerConfigMapInjectsSSLCertDirWhenCABundlePresent(t *testing.T) {
+	testNamespace := "testnamespace"
+	testDSPAName := "testdspa"
+	expectedConfigMapName := "ds-pipeline-workflow-controller-testdspa"
+
+	dspa := &dspav1.DataSciencePipelinesApplication{
+		Spec: dspav1.DSPASpec{
+			PodToPodTLS: testutil.BoolPtr(false),
+			APIServer: &dspav1.APIServer{
+				Deploy: true,
+				CABundle: &dspav1.CABundle{
+					ConfigMapKey:  "testcakey",
+					ConfigMapName: "testcaname",
+				},
+			},
+			WorkflowController: &dspav1.WorkflowController{
+				Deploy: true,
+			},
+			Database: &dspav1.Database{
+				DisableHealthCheck: false,
+				MariaDB: &dspav1.MariaDB{
+					Deploy: true,
+				},
+			},
+			MLMD: &dspav1.MLMD{Deploy: true},
+			ObjectStorage: &dspav1.ObjectStorage{
+				DisableHealthCheck: false,
+				Minio: &dspav1.Minio{
+					Deploy: false,
+					Image:  "someimage",
+				},
+			},
+		},
+	}
+	dspa.Namespace = testNamespace
+	dspa.Name = testDSPAName
+
+	ctx, params, reconciler := CreateNewTestObjects()
+	t.Setenv("SSL_CERT_FILE", "testdata/tls/empty-ca-bundle.crt")
+	require.NoError(t, reconciler.Client.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcaname", Namespace: testNamespace},
+		Data:       map[string]string{"testcakey": "bundle-contents"},
+	}))
+
+	require.NoError(t, params.ExtractParams(ctx, dspa, reconciler.Client, reconciler.Log))
+	require.Equal(t, config.WorkflowPodSSLCertDir, params.WorkflowPodSSLCertDir)
+
+	enabled, err := reconciler.ReconcileWorkflowController(dspa, params)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, reconciler.Get(ctx, types.NamespacedName{
+		Name:      expectedConfigMapName,
+		Namespace: testNamespace,
+	}, cm))
+	require.Contains(t, cm.Data["workflowDefaults"], "SSL_CERT_DIR")
+	require.Contains(t, cm.Data["workflowDefaults"], config.WorkflowPodSSLCertDir)
 }


### PR DESCRIPTION
## Summary
- After DSP stopped putting `tls.caBundlePath` on `KFP_MLFLOW_CONFIG`, the driver uses Go’s system cert pool and never reads the CA DSPO already mounts at `/kfp/certs`. Nested MLflow runs fail-open (pipeline Succeeded, nested count 0).
- When `CustomCABundle` is set, DSPO now sets Argo `workflowDefaults` `SSL_CERT_DIR=/kfp/certs:/etc/ssl/certs:/etc/pki/tls/certs` so the driver trusts that mount. This matches the DSP design (do not copy the API server CA path; configure trust on the driver pod).

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow pods now automatically trust configured custom CA certificates.
  * Added support for injecting the certificate directory into workflow pod defaults through `SSL_CERT_DIR`.
  * Standard system certificate directories remain available alongside the mounted CA bundle.

* **Bug Fixes**
  * Improved secure connectivity for workflow pods when a custom API server CA bundle is configured.

* **Tests**
  * Added coverage for CA bundle configuration and certificate directory injection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->