### PR TITLE
chore: Add `ALLOWEDSERVICEACCOUNTS` environment variable to apiserver deployment templates for all test cases

### DIFF
--- a/config/internal/apiserver/default/deployment.yaml.tmpl
+++ b/config/internal/apiserver/default/deployment.yaml.tmpl
@@ -121,6 +121,8 @@ spec:
               value: "{{.ObjectStorageConnection.CredentialsSecret.SecretKey}}"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-{{.Name}}"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-{{.Name}}"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "{{.ObjectStorageConnection.Bucket}}"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_0/expected/created/apiserver_deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp0"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp0"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_2/expected/created/apiserver_deployment.yaml
@@ -82,6 +82,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp2"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp2"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_3/expected/created/apiserver_deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "testsecretkey3"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp3"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp3"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "testbucket3"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_4/expected/created/apiserver_deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp4"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp4"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_5/expected/created/apiserver_deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp5"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp5"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_6/expected/created/apiserver_deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp6"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp6"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY

--- a/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
+++ b/controllers/testdata/declarative/case_8/expected/created/apiserver_deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "secretkey"
             - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
               value: "pipeline-runner-testdsp8"
+            - name: ALLOWEDSERVICEACCOUNTS
+              value: "pipeline-runner-testdsp8"
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: "mlpipeline"
             - name: OBJECTSTORECONFIG_ACCESSKEY


### PR DESCRIPTION
Cherry pick of:
- https://github.com/red-hat-data-services/data-science-pipelines-operator/pull/1097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API servers now recognize the pipeline runner service account as an allowed service account.
  * This setting is automatically configured for each Data Science Pipelines instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->